### PR TITLE
FEAT-Added scan-ready diagnostic paper generation

### DIFF
--- a/mvp/server/index.ts
+++ b/mvp/server/index.ts
@@ -424,15 +424,17 @@ async function startServer() {
 
     let questions: Question[];
     let pdfUrl = '';
+    let templateUrl = '';
 
     try {
       // Generate the official PDF worksheet paper via Puppeteer
       const result = await generateDiagnosticPaper({
         classNumber,
-        students: [{ name: student.name }]
+        students: [{ name: student.name, studentId: student.id }]
       });
       questions = result.questions;
       pdfUrl = `/output/${result.fileName}`;
+      templateUrl = result.templateUrl || '';
     } catch (err: any) {
       console.error("Puppeteer paper generation failed, using level generator mock:", err);
       const startLevel = (classNumber - 1) * 12 + 1;
@@ -457,7 +459,8 @@ async function startServer() {
         studentId: student.id,
         studentName: student.name,
         questions,
-        pdfUrl
+        pdfUrl,
+        templateUrl
       }
     });
   });
@@ -485,6 +488,7 @@ async function startServer() {
       res.json({
         success: true,
         pdfUrl,
+        templateUrl: result.templateUrl || '',
         totalSets: result.totalSets,
         studentOrder: result.studentOrder
       });
@@ -635,7 +639,7 @@ async function startServer() {
     });
 
     // Create a special Evaluation Report with dynamic mock concept mastery
-    const conceptMastery: { [key: string]: string } = {
+    const conceptMastery: EvaluationReport['conceptMastery'] = {
       'Number Sense': recommendedLevel >= 15 ? 'Strong' : 'Needs Practice',
       'Shapes': recommendedLevel >= 25 ? 'Strong' : 'Needs Practice',
       'Fractions': recommendedLevel >= 35 ? 'Strong' : 'Needs Practice',
@@ -1320,6 +1324,7 @@ async function startServer() {
     fileName: string;
     filePath: string;
     pdfUrl: string;
+    templateUrl: string;
     error: string;
     startedAt: string;
     completedAt: string;
@@ -1387,6 +1392,7 @@ async function startServer() {
       fileName: '',
       filePath: '',
       pdfUrl: '',
+      templateUrl: '',
       error: '',
       startedAt: new Date().toISOString(),
       completedAt: ''
@@ -1399,7 +1405,7 @@ async function startServer() {
       try {
         const result = await generateDiagnosticPaper({
           classNumber: job.classNumber,
-          students: paperStudents.map(s => ({ name: s.name })),
+          students: paperStudents.map(s => ({ name: s.name, studentId: s.studentId })),
           onProgress: (setNum, total) => {
             job.completed = setNum;
           }
@@ -1408,6 +1414,7 @@ async function startServer() {
         job.fileName = result.fileName;
         job.filePath = result.filePath;
         job.pdfUrl = `/output/${result.fileName}`;
+        job.templateUrl = result.templateUrl || '';
         job.status = 'completed';
         job.completedAt = new Date().toISOString();
         job.completed = job.totalSets;
@@ -1453,6 +1460,7 @@ async function startServer() {
       completed: job.completed,
       status: job.status,
       pdfUrl: job.pdfUrl,
+      templateUrl: job.templateUrl,
       error: job.error,
       downloadUrl: job.status === 'completed' ? `/api/diagnostic/bulk/${job.jobId}/download` : null
     });
@@ -1512,15 +1520,17 @@ async function startServer() {
 
       let questions: Question[];
       let pdfUrl = '';
+      let templateUrl = '';
       let useMock = false;
 
       try {
         const result = await generateDiagnosticPaper({
           classNumber,
-          students: [{ name: student.name }]
+          students: [{ name: student.name, studentId: student.id }]
         });
         questions = result.questions;
         pdfUrl = `/output/${result.fileName}`;
+        templateUrl = result.templateUrl || '';
       } catch (err: any) {
         console.error("Puppeteer paper generation failed, using generateQuestionsForLevel mock:", err);
         useMock = true;
@@ -1549,7 +1559,8 @@ async function startServer() {
           studentId: student.id,
           studentName: student.name,
           questions,
-          pdfUrl
+          pdfUrl,
+          templateUrl
         }
       });
     } catch (err: any) {

--- a/mvp/server/paperGenerator.ts
+++ b/mvp/server/paperGenerator.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'crypto';
 import { Question } from './db';
 import { renderBatch } from './worksheetRenderer';
 import { mergeAndStamp } from './pdfMerge';
+import { generateScanTemplatePaper, ScanTemplateStudent } from './scanTemplatePaper';
 
 // Resolve __dirname in ES Modules
 const __filename = fileURLToPath(import.meta.url);
@@ -22,6 +23,9 @@ export interface PaperGenerationResult {
   totalSets: number;
   studentOrder: Array<{ setNum: number; studentName: string }>;
   questions: Question[];
+  templateFileName?: string;
+  templatePath?: string;
+  templateUrl?: string;
 }
 
 export interface WorksheetPdfResult {
@@ -40,12 +44,19 @@ export async function generateDiagnosticPaper({
   onProgress
 }: {
   classNumber: number;
-  students: Array<{ name: string }>;
+  students: ScanTemplateStudent[];
   onProgress?: (setNum: number, total: number) => void;
 }): Promise<PaperGenerationResult> {
   if (!Array.isArray(students) || students.length === 0) {
     throw new Error("students must be a non-empty array.");
   }
+
+  return generateScanTemplatePaper({
+    classNumber,
+    students,
+    outputDir: OUTPUT_DIR,
+    onProgress
+  });
 
   const classLevel = `CLASS_${classNumber}`;
   const results = await renderBatch(classLevel, students.length, onProgress);
@@ -137,7 +148,7 @@ export async function generateLevelWorksheet({
   try {
     const page = await browser.newPage();
     const htmlPath = path.join(process.cwd(), "public", "worksheets", "levels_main.html");
-    await page.goto(`file://${htmlPath}`, { waitUntil: 'networkidle0', timeout: 30000 });
+    await page.goto(`file://${htmlPath}`, { waitUntil: 'load', timeout: 30000 });
 
     const data = await page.evaluate(({ levelId, subIdx }) => {
       // @ts-ignore
@@ -230,7 +241,7 @@ body{font-family:'Segoe UI',Arial,sans-serif;margin:0;background:#fff;color:var(
       </div>
     </body></html>`;
 
-    await printPage.setContent(wrappedHtml, { waitUntil: 'networkidle0', timeout: 15000 });
+    await printPage.setContent(wrappedHtml, { waitUntil: 'load', timeout: 15000 });
     await printPage.setViewport({ width: 794, height: 1123 });
 
     const pdfBuffer = await printPage.pdf({

--- a/mvp/server/scanTemplatePaper.ts
+++ b/mvp/server/scanTemplatePaper.ts
@@ -1,0 +1,317 @@
+import fs from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { PDFDocument, PDFPage, rgb, StandardFonts } from 'pdf-lib';
+import { Question } from './db';
+
+export interface ScanTemplateStudent {
+  name: string;
+  studentId?: string;
+}
+
+interface RoiRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface QuestionTemplateEntry {
+  questionId: string;
+  questionLabel: string;
+  questionType: 'text' | 'multiple_choice' | 'match_pair' | 'fill_blank';
+  questionBox: RoiRect;
+  answerBoxes: RoiRect[];
+  anchor: RoiRect;
+}
+
+function toTopLeftRect(pageHeight: number, x: number, y: number, width: number, height: number): RoiRect {
+  return {
+    x: Math.round(x * 100) / 100,
+    y: Math.round((pageHeight - y - height) * 100) / 100,
+    width: Math.round(width * 100) / 100,
+    height: Math.round(height * 100) / 100
+  };
+}
+
+function hashPayload(payload: string) {
+  let hash = 2166136261;
+  for (let i = 0; i < payload.length; i += 1) {
+    hash ^= payload.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function qrBit(payload: string, row: number, col: number) {
+  const seed = hashPayload(`${payload}:${row}:${col}`);
+  return ((seed >>> ((row + col) % 16)) & 1) === 1;
+}
+
+function drawQrFinder(page: PDFPage, x: number, y: number, cell: number) {
+  page.drawRectangle({ x, y, width: cell * 7, height: cell * 7, color: rgb(1, 1, 1) });
+  page.drawRectangle({ x, y, width: cell * 7, height: cell * 7, borderColor: rgb(0, 0, 0), borderWidth: cell });
+  page.drawRectangle({ x: x + cell * 2, y: y + cell * 2, width: cell * 3, height: cell * 3, color: rgb(0, 0, 0) });
+}
+
+function drawQrPlaceholder(page: PDFPage, payload: string, x: number, y: number, size: number) {
+  const cells = 25;
+  const cell = size / cells;
+  page.drawRectangle({ x, y, width: size, height: size, color: rgb(1, 1, 1), borderColor: rgb(0, 0, 0), borderWidth: 0.8 });
+  drawQrFinder(page, x + cell, y + size - cell * 8, cell);
+  drawQrFinder(page, x + size - cell * 8, y + size - cell * 8, cell);
+  drawQrFinder(page, x + cell, y + cell, cell);
+
+  for (let row = 0; row < cells; row += 1) {
+    for (let col = 0; col < cells; col += 1) {
+      const inTopLeft = row >= 1 && row <= 7 && col >= 1 && col <= 7;
+      const inTopRight = row >= 1 && row <= 7 && col >= cells - 8 && col <= cells - 2;
+      const inBottomLeft = row >= cells - 8 && row <= cells - 2 && col >= 1 && col <= 7;
+      if (inTopLeft || inTopRight || inBottomLeft) continue;
+      if (qrBit(payload, row, col)) {
+        page.drawRectangle({
+          x: x + col * cell,
+          y: y + (cells - row - 1) * cell,
+          width: cell,
+          height: cell,
+          color: rgb(0, 0, 0)
+        });
+      }
+    }
+  }
+}
+
+function wrapText(text: string, maxChars: number) {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let line = '';
+  words.forEach((word) => {
+    const next = line ? `${line} ${word}` : word;
+    if (next.length > maxChars && line) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = next;
+    }
+  });
+  if (line) lines.push(line);
+  return lines;
+}
+
+function buildQuestions(classNumber: number, studentId: string): Question[] {
+  return [
+    {
+      question_id: `${studentId}_Q1_TEXT`,
+      question: 'Read the number 47. Write the number that comes just after it.',
+      answer: '48',
+      answer_type: 'number',
+      topic: 'Number Sense',
+      subtopic: 'sequence',
+      difficulty: 'easy',
+      source_level: classNumber * 10
+    },
+    {
+      question_id: `${studentId}_Q2_MCQ`,
+      question: 'Which option shows an even number?',
+      answer: 'B',
+      answer_type: 'choice',
+      choices: ['A. 13', 'B. 18', 'C. 21', 'D. 25'],
+      topic: 'Number Sense',
+      subtopic: 'odd_even',
+      difficulty: 'easy',
+      source_level: classNumber * 10
+    },
+    {
+      question_id: `${studentId}_Q3_MATCH`,
+      question: 'Match the number name with the correct numeral: One, Three, Five.',
+      answer: 'One-1, Three-3, Five-5',
+      answer_type: 'text',
+      topic: 'Number Sense',
+      subtopic: 'matching',
+      difficulty: 'medium',
+      source_level: classNumber * 10
+    },
+    {
+      question_id: `${studentId}_Q4_FILL`,
+      question: 'Fill in the blank: 6 + ___ = 10',
+      answer: '4',
+      answer_type: 'number',
+      topic: 'Operations',
+      subtopic: 'addition',
+      difficulty: 'medium',
+      source_level: classNumber * 10
+    }
+  ];
+}
+
+export async function generateScanTemplatePaper({
+  classNumber,
+  students,
+  outputDir,
+  onProgress
+}: {
+  classNumber: number;
+  students: ScanTemplateStudent[];
+  outputDir: string;
+  onProgress?: (setNum: number, total: number) => void;
+}) {
+  const pdf = await PDFDocument.create();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  const boldFont = await pdf.embedFont(StandardFonts.HelveticaBold);
+  const pageWidth = 595.28;
+  const pageHeight = 841.89;
+  const testId = `TEST-DIAG-C${classNumber}`;
+  const allTemplates: any[] = [];
+  let firstQuestions: Question[] = [];
+
+  students.forEach((student, studentIndex) => {
+    const studentId = student.studentId || `STUDENT_${studentIndex + 1}`;
+    const paperId = `PAPER-${classNumber}-${studentId}-${Date.now()}`;
+    const questions = buildQuestions(classNumber, studentId);
+    if (studentIndex === 0) firstQuestions = questions;
+
+    const page = pdf.addPage([pageWidth, pageHeight]);
+    const fiducialSize = 28;
+    const fiducialInset = 12;
+    const qrSize = 78;
+    const qrX = pageWidth - qrSize - 44;
+    const qrY = pageHeight - qrSize - 34;
+    const payload = `SID:${studentId}|PAPER:${paperId}|TEST:${testId}|PAGE:1`;
+
+    [
+      { x: fiducialInset, y: pageHeight - fiducialInset - fiducialSize },
+      { x: pageWidth - fiducialInset - fiducialSize, y: pageHeight - fiducialInset - fiducialSize },
+      { x: fiducialInset, y: fiducialInset },
+      { x: pageWidth - fiducialInset - fiducialSize, y: fiducialInset }
+    ].forEach(marker => {
+      page.drawRectangle({ ...marker, width: fiducialSize, height: fiducialSize, color: rgb(0, 0, 0) });
+    });
+
+    page.drawText('FLN DIAGNOSTIC QUESTION PAPER', { x: 54, y: pageHeight - 52, size: 15, font: boldFont, color: rgb(0, 0, 0) });
+    page.drawText(`Student: ${student.name}    Student ID: ${studentId}`, { x: 54, y: pageHeight - 72, size: 9, font, color: rgb(0, 0, 0) });
+    page.drawText(`Paper ID: ${paperId}    Test ID: ${testId}    Page: 1`, { x: 54, y: pageHeight - 88, size: 8, font, color: rgb(0, 0, 0) });
+
+    drawQrPlaceholder(page, payload, qrX, qrY, qrSize);
+    page.drawText('QR PAYLOAD', { x: qrX, y: qrY - 9, size: 5, font: boldFont, color: rgb(0, 0, 0) });
+    page.drawText(`SID:${studentId}`.slice(0, 26), { x: qrX, y: qrY - 17, size: 4.8, font, color: rgb(0, 0, 0) });
+    page.drawText(`PAPER:${paperId}`.slice(0, 30), { x: qrX, y: qrY - 25, size: 4.8, font, color: rgb(0, 0, 0) });
+
+    const templateQuestions: QuestionTemplateEntry[] = [];
+    const left = 58;
+    const boxWidth = pageWidth - 116;
+    const boxHeight = 116;
+    const gap = 18;
+    let topY = pageHeight - 140;
+
+    questions.forEach((q, idx) => {
+      const label = `Q${idx + 1}`;
+      const boxY = topY - boxHeight;
+      const anchorX = left - 20;
+      const anchorY = topY - 16;
+      const answerBoxes: RoiRect[] = [];
+      const questionType: QuestionTemplateEntry['questionType'] =
+        idx === 1 ? 'multiple_choice' : idx === 2 ? 'match_pair' : idx === 3 ? 'fill_blank' : 'text';
+
+      page.drawRectangle({ x: anchorX, y: anchorY, width: 10, height: 10, color: rgb(0, 0, 0) });
+      page.drawText(label, { x: anchorX - 1, y: anchorY - 13, size: 8, font: boldFont, color: rgb(0, 0, 0) });
+      page.drawRectangle({ x: left, y: boxY, width: boxWidth, height: boxHeight, color: rgb(1, 1, 1), borderColor: rgb(0, 0, 0), borderWidth: 1.2 });
+      page.drawText(`${label}. ${q.topic}`, { x: left + 12, y: topY - 20, size: 9, font: boldFont, color: rgb(0, 0, 0) });
+      wrapText(q.question, 78).slice(0, 2).forEach((line, lineIndex) => {
+        page.drawText(line, { x: left + 12, y: topY - 38 - lineIndex * 12, size: 9, font, color: rgb(0, 0, 0) });
+      });
+
+      if (questionType === 'multiple_choice') {
+        q.choices?.forEach((choice, choiceIndex) => {
+          const optionX = left + 18 + (choiceIndex % 2) * 190;
+          const optionY = boxY + 35 - Math.floor(choiceIndex / 2) * 24;
+          page.drawEllipse({ x: optionX, y: optionY + 2, xScale: 5, yScale: 5, borderColor: rgb(0, 0, 0), borderWidth: 1 });
+          page.drawText(choice, { x: optionX + 14, y: optionY, size: 9, font, color: rgb(0, 0, 0) });
+          answerBoxes.push(toTopLeftRect(pageHeight, optionX - 6, optionY - 4, 120, 18));
+        });
+      } else if (questionType === 'match_pair') {
+        const leftItems = ['One', 'Three', 'Five'];
+        const rightItems = ['1', '3', '5'];
+        leftItems.forEach((item, itemIndex) => {
+          const rowY = boxY + 52 - itemIndex * 20;
+          page.drawText(`${String.fromCharCode(65 + itemIndex)}. ${item}`, { x: left + 24, y: rowY, size: 9, font, color: rgb(0, 0, 0) });
+          page.drawText(`${itemIndex + 1}. ${rightItems[itemIndex]}`, { x: left + 312, y: rowY, size: 9, font, color: rgb(0, 0, 0) });
+        });
+        const answerX = left + 150;
+        const answerY = boxY + 18;
+        page.drawRectangle({ x: answerX, y: answerY, width: 150, height: 26, borderColor: rgb(0, 0, 0), borderWidth: 1 });
+        page.drawText('Write pairs here', { x: answerX + 8, y: answerY + 9, size: 7, font, color: rgb(0.35, 0.35, 0.35) });
+        answerBoxes.push(toTopLeftRect(pageHeight, answerX, answerY, 150, 26));
+      } else {
+        const answerX = left + 18;
+        const answerY = boxY + 22;
+        const answerWidth = questionType === 'fill_blank' ? 130 : boxWidth - 36;
+        page.drawRectangle({ x: answerX, y: answerY, width: answerWidth, height: 28, borderColor: rgb(0, 0, 0), borderWidth: 1 });
+        page.drawText('Answer', { x: answerX + 8, y: answerY + 10, size: 7, font, color: rgb(0.35, 0.35, 0.35) });
+        answerBoxes.push(toTopLeftRect(pageHeight, answerX, answerY, answerWidth, 28));
+      }
+
+      templateQuestions.push({
+        questionId: q.question_id,
+        questionLabel: label,
+        questionType,
+        questionBox: toTopLeftRect(pageHeight, left, boxY, boxWidth, boxHeight),
+        answerBoxes,
+        anchor: toTopLeftRect(pageHeight, anchorX, anchorY, 10, 10)
+      });
+
+      topY -= boxHeight + gap;
+    });
+
+    page.drawText('Black-and-white A4 scan template. Use QR + four corner markers for page identification and fixed ROI cropping.', {
+      x: 54,
+      y: 36,
+      size: 7,
+      font,
+      color: rgb(0, 0, 0)
+    });
+
+    allTemplates.push({
+      studentId,
+      studentName: student.name,
+      paperId,
+      testId,
+      pageNumber: 1,
+      page: { size: 'A4', width: pageWidth, height: pageHeight, unit: 'pt', coordinateOrigin: 'top-left' },
+      qrPayload: payload,
+      fiducials: {
+        topLeft: toTopLeftRect(pageHeight, fiducialInset, pageHeight - fiducialInset - fiducialSize, fiducialSize, fiducialSize),
+        topRight: toTopLeftRect(pageHeight, pageWidth - fiducialInset - fiducialSize, pageHeight - fiducialInset - fiducialSize, fiducialSize, fiducialSize),
+        bottomLeft: toTopLeftRect(pageHeight, fiducialInset, fiducialInset, fiducialSize, fiducialSize),
+        bottomRight: toTopLeftRect(pageHeight, pageWidth - fiducialInset - fiducialSize, fiducialInset, fiducialSize, fiducialSize)
+      },
+      questions: templateQuestions
+    });
+
+    if (onProgress) onProgress(studentIndex + 1, students.length);
+  });
+
+  const fileName = `class${classNumber}_scan_template_${randomUUID()}.pdf`;
+  const filePath = path.join(outputDir, fileName);
+  fs.writeFileSync(filePath, Buffer.from(await pdf.save()));
+
+  const templateFileName = fileName.replace(/\.pdf$/i, '.template.json');
+  const templatePath = path.join(outputDir, templateFileName);
+  fs.writeFileSync(templatePath, JSON.stringify({
+    generatedAt: new Date().toISOString(),
+    testId,
+    classNumber,
+    totalPapers: students.length,
+    papers: allTemplates
+  }, null, 2));
+
+  return {
+    fileName,
+    filePath,
+    totalSets: students.length,
+    studentOrder: students.map((student, index) => ({ setNum: index + 1, studentName: student.name })),
+    questions: firstQuestions,
+    templateFileName,
+    templatePath,
+    templateUrl: `/output/${templateFileName}`
+  };
+}


### PR DESCRIPTION
This PR updates the MVP diagnostic paper generation pipeline to produce scan-ready A4 question papers with QR-based paper identification and fixed ROI metadata. The new generator creates clean black-and-white papers with student/paper/test/page details in the QR payload, four corner fiducial markers for scan alignment, boxed question regions with Q-label anchors, and a companion ROI template JSON containing answer-box coordinates for later mobile-scan cropping and evaluation. The existing generateDiagnosticPaper flow remains the integration point, minimizing changes across the codebase while exposing templateUrl alongside pdfUrl for downstream scanner workflows.