### PR TITLE
feat: add automated intervention priority classification and dashboard

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,8 @@ import { dbStore, UserRole, User, Student, School, Question, Worksheet, LevelWor
 import { generateAIDiagnostic, evaluateAIDiagnostic, generateAIPersonalizedWorksheet, evaluateAIWorksheet } from './gemini';
 import { generateDiagnosticPaper } from './paperGenerator';
 import { generateQuestionsForLevel } from './levelGenerator';
+import { buildInterventionDashboard } from './interventionEngine';
+
 import * as levelsBackendClient from './levelsBackendClient';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
@@ -1923,7 +1925,46 @@ async function startServer() {
     // District Admin, Admin, Superadmin see all
     res.json(interventions);
   });
+// Intervention Dashboard: auto-flags students who need attention (Low/
+  // Medium/High priority), derived from existing evaluation report history.
+  // Read-only and purely additive — does not touch grading, worksheet
+  // generation, or level progression anywhere else in the app.
+  app.get('/api/interventions/dashboard', async (req, res) => {
+    const user = getAuthUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
+    let students = await dbStore.getStudents();
+    if (user.role === UserRole.TEACHER) {
+      students = students.filter(s => s.teacherId === user.id);
+    } else if (user.role === UserRole.SCHOOL) {
+      students = students.filter(s => s.schoolId === user.schoolId);
+    } else if (user.role === UserRole.VOLUNTEER) {
+      const assignedSchools = user.assignedSchools || [];
+      students = students.filter(s => assignedSchools.includes(s.schoolId));
+    } else if (user.role === UserRole.BLOCK_ADMIN) {
+      const schools = await dbStore.getSchools();
+      const blockSchools = schools.filter(s => s.blockCode === user.blockCode).map(s => s.id);
+      students = students.filter(s => blockSchools.includes(s.schoolId));
+    }
+    // District Admin, Admin, Superadmin see all students.
+
+    const [allReports, allInterventions] = await Promise.all([
+      dbStore.getEvaluationReports(),
+      dbStore.getInterventions()
+    ]);
+
+    let dashboard = buildInterventionDashboard(students, allReports, allInterventions);
+
+    const { priority, classId, concept, status } = req.query;
+    if (priority) dashboard = dashboard.filter(d => d.priority === priority);
+    if (classId) dashboard = dashboard.filter(d => d.className === classId);
+    if (status) dashboard = dashboard.filter(d => d.status === status);
+    if (concept) {
+      dashboard = dashboard.filter(d => d.weakConcepts.includes(concept as string));
+    }
+
+    res.json(dashboard);
+  });
   // Get single intervention
   app.get('/api/interventions/:id', async (req, res) => {
     const user = getAuthUser(req);

--- a/backend/src/interventionEngine.ts
+++ b/backend/src/interventionEngine.ts
@@ -1,0 +1,199 @@
+import { Student, EvaluationReport, Intervention } from './db';
+
+export type InterventionPriority = 'Low' | 'Medium' | 'High';
+export type InterventionTrend = 'improving' | 'flat' | 'declining';
+export type InterventionStatus = 'Pending' | 'In Progress' | 'Completed';
+
+export interface InterventionFlag {
+  studentId: string;
+  studentName: string;
+  classId: string;
+  className: string;
+  section: string;
+  schoolId: string;
+  currentLevel: number;
+  priority: InterventionPriority;
+  priorityScore: number;
+  reasons: string[];
+  weakConcepts: string[];
+  repeatedMistakeConcepts: string[];
+  latestScorePercent: number;
+  averageScorePercent: number;
+  improvementTrend: InterventionTrend;
+  reportsConsidered: number;
+  status: InterventionStatus;
+  interventionId?: string;
+}
+
+const RECENT_WINDOW = 3; // how many recent assessments count toward "repeated" / "trend" signals
+
+/**
+ * Derives an intervention priority flag for a single student from their
+ * existing evaluation report history. Returns null if there isn't enough
+ * data yet, or if nothing about the student's performance is concerning.
+ *
+ * This is pure derived logic over data that already exists (EvaluationReport,
+ * Student.levelHistory) — it does not call any AI service and does not
+ * change grading/level-progression behavior anywhere else in the app.
+ */
+export function classifyStudentIntervention(
+  student: Student,
+  allReportsForStudent: EvaluationReport[]
+): Omit<InterventionFlag, 'status' | 'interventionId'> | null {
+  const reports = [...allReportsForStudent].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+
+  if (reports.length === 0) return null;
+
+  const recent = reports.slice(-RECENT_WINDOW);
+  const latest = reports[reports.length - 1];
+
+  const percentOf = (r: EvaluationReport) =>
+    r.totalQuestions > 0 ? (r.score / r.totalQuestions) * 100 : 0;
+
+  const allPercents = reports.map(percentOf);
+  const recentPercents = recent.map(percentOf);
+  const latestPercent = percentOf(latest);
+  const averagePercent = allPercents.reduce((a, b) => a + b, 0) / allPercents.length;
+
+  // Weak / repeated-mistake concepts, drawn from the recent window's
+  // concept mastery so an old, since-resolved gap doesn't stay flagged forever.
+  const needsPracticeCount: { [topic: string]: number } = {};
+  recent.forEach(r => {
+    Object.entries(r.conceptMastery || {}).forEach(([topic, mastery]) => {
+      if (mastery === 'Needs Practice') {
+        needsPracticeCount[topic] = (needsPracticeCount[topic] || 0) + 1;
+      }
+    });
+  });
+  const weakConcepts = Object.keys(needsPracticeCount).sort(
+    (a, b) => needsPracticeCount[b] - needsPracticeCount[a]
+  );
+  const repeatedMistakeConcepts = weakConcepts.filter(t => needsPracticeCount[t] >= 2);
+
+  // Improvement trend across the recent window.
+  let improvementTrend: InterventionTrend = 'flat';
+  if (recentPercents.length >= 2) {
+    const delta = recentPercents[recentPercents.length - 1] - recentPercents[0];
+    if (delta > 10) improvementTrend = 'improving';
+    else if (delta < -10) improvementTrend = 'declining';
+  }
+  const noLevelProgress =
+    recent.length >= 2 &&
+    new Set(recent.map(r => r.recommendedLevel)).size === 1 &&
+    recent[recent.length - 1].recommendedLevel <= student.currentLevel;
+
+  // Score signals into a priority. Weights are intentionally simple/transparent
+  // so teachers (and reviewers) can see exactly why a student was flagged.
+  let points = 0;
+  const reasons: string[] = [];
+
+  if (latestPercent < 40) {
+    points += 3;
+    reasons.push(`Low latest score (${Math.round(latestPercent)}%)`);
+  } else if (latestPercent < 60) {
+    points += 1;
+    reasons.push(`Below-average latest score (${Math.round(latestPercent)}%)`);
+  }
+
+  if (averagePercent < 50) {
+    points += 2;
+    reasons.push(`Low average score across ${reports.length} assessment${reports.length > 1 ? 's' : ''} (${Math.round(averagePercent)}%)`);
+  }
+
+  if (repeatedMistakeConcepts.length > 0) {
+    points += 2;
+    reasons.push(`Repeated mistakes in: ${repeatedMistakeConcepts.join(', ')}`);
+  }
+
+  if (weakConcepts.length >= 3) {
+    points += 1;
+    reasons.push(`Multiple weak concepts (${weakConcepts.length})`);
+  }
+
+  if (improvementTrend === 'declining') {
+    points += 2;
+    reasons.push('Declining performance trend');
+  } else if (noLevelProgress) {
+    points += 1;
+    reasons.push('No level progression over recent assessments');
+  }
+
+  if (points === 0) return null; // nothing concerning — don't flag
+
+  const priority: InterventionPriority = points >= 6 ? 'High' : points >= 3 ? 'Medium' : 'Low';
+
+  return {
+    studentId: student.id,
+    studentName: student.name,
+    classId: student.classGroup,
+    className: student.classGroup,
+    section: student.section,
+    schoolId: student.schoolId,
+    currentLevel: student.currentLevel,
+    priority,
+    priorityScore: points,
+    reasons,
+    weakConcepts,
+    repeatedMistakeConcepts,
+    latestScorePercent: Math.round(latestPercent),
+    averageScorePercent: Math.round(averagePercent),
+    improvementTrend,
+    reportsConsidered: reports.length
+  };
+}
+
+/**
+ * Builds the full intervention dashboard list for a set of students,
+ * merging derived priority flags with existing (manually-logged)
+ * Intervention records so the status column reflects real teacher action:
+ *  - No Intervention record yet          -> "Pending"
+ *  - Most recent record status "active"  -> "In Progress"
+ *  - Most recent record status "completed" or "pending_review" -> "Completed"
+ */
+export function buildInterventionDashboard(
+  students: Student[],
+  allReports: EvaluationReport[],
+  allInterventions: Intervention[]
+): InterventionFlag[] {
+  const reportsByStudent = new Map<string, EvaluationReport[]>();
+  allReports.forEach(r => {
+    const list = reportsByStudent.get(r.studentId) || [];
+    list.push(r);
+    reportsByStudent.set(r.studentId, list);
+  });
+
+  const latestInterventionByStudent = new Map<string, Intervention>();
+  allInterventions.forEach(intv => {
+    const existing = latestInterventionByStudent.get(intv.studentId);
+    if (!existing || new Date(intv.createdAt).getTime() > new Date(existing.createdAt).getTime()) {
+      latestInterventionByStudent.set(intv.studentId, intv);
+    }
+  });
+
+  const flags: InterventionFlag[] = [];
+  for (const student of students) {
+    const base = classifyStudentIntervention(student, reportsByStudent.get(student.id) || []);
+    if (!base) continue;
+
+    const latestIntv = latestInterventionByStudent.get(student.id);
+    let status: InterventionStatus = 'Pending';
+    if (latestIntv) {
+      status = latestIntv.status === 'active' ? 'In Progress' : 'Completed';
+    }
+
+    flags.push({ ...base, status, interventionId: latestIntv?.id });
+  }
+
+  // Highest priority first, then lowest score, so the most urgent cases lead the list.
+  const priorityRank: Record<InterventionPriority, number> = { High: 0, Medium: 1, Low: 2 };
+  flags.sort((a, b) => {
+    if (priorityRank[a.priority] !== priorityRank[b.priority]) {
+      return priorityRank[a.priority] - priorityRank[b.priority];
+    }
+    return a.averageScorePercent - b.averageScorePercent;
+  });
+
+  return flags;
+}


### PR DESCRIPTION
Adds a read-only GET /api/interventions/dashboard endpoint that automatically
   classifies students into Low/Medium/High intervention priority, derived from
   existing evaluation report history (score trends, concept mastery, level
   progression) — no new AI calls, purely additive, doesn't change any existing
   grading/worksheet/level logic. Merges with the existing Intervention records
   to show Pending/In Progress/Completed status per student.

   This is the first piece of a larger Intervention Dashboard feature; the
   frontend panel that consumes this endpoint will follow in a separate PR.