### PR TITLE
feat: add MongoDB backend with Class/Student modules + coordinator registration frontend

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,6 +7,8 @@ import blockRoutes from './routes/block.routes';
 import schoolRoutes from './routes/school.routes';
 import authRoutes from './routes/auth.routes';
 import teacherRoutes from './routes/teacher.routes';
+import classRoutes from './routes/class/class.routes';
+import studentRoutes from './routes/student/student.routes';
 
 const app = express();
 
@@ -24,6 +26,8 @@ app.use('/api/districts', districtRoutes);
 app.use('/api/blocks', blockRoutes);
 app.use('/api/schools', schoolRoutes);
 app.use('/api/teachers', teacherRoutes);
+app.use('/api/classes', classRoutes);
+app.use('/api/students', studentRoutes);
 
 app.use(errorHandler);
 

--- a/backend/src/controllers/class/class.controller.ts
+++ b/backend/src/controllers/class/class.controller.ts
@@ -1,0 +1,90 @@
+import { Request, Response, NextFunction } from 'express';
+import { ClassService } from '../../services/class/class.service';
+import { sendSuccess } from '../../utils/response';
+import httpStatus from 'http-status';
+
+const classService = new ClassService();
+
+export class ClassController {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const cls = await classService.create(req.body);
+      sendSuccess(res, 'Class created successfully', cls, httpStatus.CREATED);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getAll(req: Request, res: Response, next: NextFunction) {
+    try {
+      const includeInactive = req.query.includeInactive === 'true';
+      const classes = await classService.getAll(includeInactive);
+      sendSuccess(res, 'Classes fetched successfully', classes);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getById(req: Request, res: Response, next: NextFunction) {
+    try {
+      const cls = await classService.getById(req.params.id);
+      sendSuccess(res, 'Class fetched successfully', cls);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getByTeacher(req: Request, res: Response, next: NextFunction) {
+    try {
+      const classes = await classService.getByTeacher(req.params.teacherId);
+      sendSuccess(res, 'Classes fetched successfully', classes);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getBySchool(req: Request, res: Response, next: NextFunction) {
+    try {
+      const classes = await classService.getBySchool(req.params.schoolId);
+      sendSuccess(res, 'Classes fetched successfully', classes);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const cls = await classService.update(req.params.id, req.body);
+      sendSuccess(res, 'Class updated successfully', cls);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async toggleStatus(req: Request, res: Response, next: NextFunction) {
+    try {
+      const cls = await classService.toggleStatus(req.params.id);
+      sendSuccess(res, 'Class status updated successfully', cls);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      await classService.delete(req.params.id);
+      sendSuccess(res, 'Class deleted successfully', null);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async softDelete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const cls = await classService.softDelete(req.params.id);
+      sendSuccess(res, 'Class deactivated successfully', cls);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/backend/src/controllers/student/student.controller.ts
+++ b/backend/src/controllers/student/student.controller.ts
@@ -1,0 +1,99 @@
+import { Request, Response, NextFunction } from 'express';
+import { StudentService } from '../../services/student/student.service';
+import { sendSuccess } from '../../utils/response';
+import httpStatus from 'http-status';
+
+const studentService = new StudentService();
+
+export class StudentController {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const student = await studentService.create(req.body);
+      sendSuccess(res, 'Student created successfully', student, httpStatus.CREATED);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getAll(req: Request, res: Response, next: NextFunction) {
+    try {
+      const includeInactive = req.query.includeInactive === 'true';
+      const students = await studentService.getAll(includeInactive);
+      sendSuccess(res, 'Students fetched successfully', students);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getById(req: Request, res: Response, next: NextFunction) {
+    try {
+      const student = await studentService.getById(req.params.id);
+      sendSuccess(res, 'Student fetched successfully', student);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getByClass(req: Request, res: Response, next: NextFunction) {
+    try {
+      const students = await studentService.getByClass(req.params.classId);
+      sendSuccess(res, 'Students fetched successfully', students);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getByTeacher(req: Request, res: Response, next: NextFunction) {
+    try {
+      const students = await studentService.getByTeacher(req.params.teacherId);
+      sendSuccess(res, 'Students fetched successfully', students);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getBySchool(req: Request, res: Response, next: NextFunction) {
+    try {
+      const students = await studentService.getBySchool(req.params.schoolId);
+      sendSuccess(res, 'Students fetched successfully', students);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const student = await studentService.update(req.params.id, req.body);
+      sendSuccess(res, 'Student updated successfully', student);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async toggleStatus(req: Request, res: Response, next: NextFunction) {
+    try {
+      const student = await studentService.toggleStatus(req.params.id);
+      sendSuccess(res, 'Student status updated successfully', student);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      await studentService.delete(req.params.id);
+      sendSuccess(res, 'Student deleted successfully', null);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async softDelete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const student = await studentService.softDelete(req.params.id);
+      sendSuccess(res, 'Student deactivated successfully', student);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/backend/src/interfaces/class/class.interface.ts
+++ b/backend/src/interfaces/class/class.interface.ts
@@ -1,0 +1,18 @@
+import { Document, Types } from 'mongoose';
+
+export interface IClass {
+  classCode: string;
+  className: string;
+  section: string;
+  academicYear: string;
+  teacherId: Types.ObjectId;
+  schoolId: Types.ObjectId;
+  maximumStudents: number;
+  currentStudents: number;
+  isActive: boolean;
+}
+
+export interface IClassDocument extends IClass, Document {
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/src/interfaces/student/student.interface.ts
+++ b/backend/src/interfaces/student/student.interface.ts
@@ -1,0 +1,22 @@
+import { Document, Types } from 'mongoose';
+
+export type Gender = 'Male' | 'Female' | 'Other';
+
+export interface IStudent {
+  studentId: string;
+  firstName: string;
+  lastName: string;
+  gender: Gender;
+  dateOfBirth: string;
+  age: number;
+  classId: Types.ObjectId;
+  teacherId: Types.ObjectId;
+  schoolId: Types.ObjectId;
+  rollNumber: number;
+  isActive: boolean;
+}
+
+export interface IStudentDocument extends IStudent, Document {
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/src/models/class/class.model.ts
+++ b/backend/src/models/class/class.model.ts
@@ -1,0 +1,70 @@
+import { Schema, model } from 'mongoose';
+import { IClassDocument } from '../../interfaces/class/class.interface';
+
+const classSchema = new Schema<IClassDocument>(
+  {
+    classCode: {
+      type: String,
+      unique: true,
+      required: [true, 'Class code is required'],
+      trim: true,
+    },
+    className: {
+      type: String,
+      required: [true, 'Class name is required'],
+      trim: true,
+      maxlength: [50, 'Class name cannot exceed 50 characters'],
+    },
+    section: {
+      type: String,
+      required: [true, 'Section is required'],
+      trim: true,
+      maxlength: [10, 'Section cannot exceed 10 characters'],
+    },
+    academicYear: {
+      type: String,
+      required: [true, 'Academic year is required'],
+      trim: true,
+    },
+    teacherId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Teacher',
+      required: [true, 'Teacher reference is required'],
+    },
+    schoolId: {
+      type: Schema.Types.ObjectId,
+      ref: 'School',
+      required: [true, 'School reference is required'],
+    },
+    maximumStudents: {
+      type: Number,
+      required: [true, 'Maximum students is required'],
+      min: [1, 'Maximum students must be at least 1'],
+    },
+    currentStudents: {
+      type: Number,
+      default: 0,
+      min: [0, 'Current students cannot be negative'],
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  {
+    timestamps: true,
+    toJSON: {
+      transform(_doc, ret) {
+        ret.id = ret._id;
+        delete ret._id;
+        delete ret.__v;
+        return ret;
+      },
+    },
+  }
+);
+
+classSchema.index({ teacherId: 1, isActive: 1 });
+classSchema.index({ schoolId: 1, isActive: 1 });
+
+export const Class = model<IClassDocument>('Class', classSchema);

--- a/backend/src/models/student/student.model.ts
+++ b/backend/src/models/student/student.model.ts
@@ -1,0 +1,82 @@
+import { Schema, model } from 'mongoose';
+import { IStudentDocument } from '../../interfaces/student/student.interface';
+
+const studentSchema = new Schema<IStudentDocument>(
+  {
+    studentId: {
+      type: String,
+      unique: true,
+      required: true,
+    },
+    firstName: {
+      type: String,
+      required: [true, 'First name is required'],
+      trim: true,
+      maxlength: [50, 'First name cannot exceed 50 characters'],
+    },
+    lastName: {
+      type: String,
+      required: [true, 'Last name is required'],
+      trim: true,
+      maxlength: [50, 'Last name cannot exceed 50 characters'],
+    },
+    gender: {
+      type: String,
+      required: [true, 'Gender is required'],
+      enum: {
+        values: ['Male', 'Female', 'Other'],
+        message: 'Gender must be Male, Female, or Other',
+      },
+    },
+    dateOfBirth: {
+      type: String,
+      trim: true,
+    },
+    age: {
+      type: Number,
+      required: [true, 'Age is required'],
+      min: [3, 'Age must be at least 3'],
+      max: [18, 'Age cannot exceed 18'],
+    },
+    classId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Class',
+      required: [true, 'Class reference is required'],
+    },
+    teacherId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Teacher',
+      required: [true, 'Teacher reference is required'],
+    },
+    schoolId: {
+      type: Schema.Types.ObjectId,
+      ref: 'School',
+      required: [true, 'School reference is required'],
+    },
+    rollNumber: {
+      type: Number,
+      required: [true, 'Roll number is required'],
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  {
+    timestamps: true,
+    toJSON: {
+      transform(_doc, ret) {
+        ret.id = ret._id;
+        delete ret._id;
+        delete ret.__v;
+        return ret;
+      },
+    },
+  }
+);
+
+studentSchema.index({ classId: 1, rollNumber: 1 }, { unique: true });
+studentSchema.index({ teacherId: 1, isActive: 1 });
+studentSchema.index({ schoolId: 1, isActive: 1 });
+
+export const Student = model<IStudentDocument>('Student', studentSchema);

--- a/backend/src/repositories/class/class.repository.ts
+++ b/backend/src/repositories/class/class.repository.ts
@@ -1,0 +1,79 @@
+import { FilterQuery, UpdateQuery } from 'mongoose';
+import { Class } from '../../models/class/class.model';
+import { IClass, IClassDocument } from '../../interfaces/class/class.interface';
+
+export class ClassRepository {
+  async create(data: IClass): Promise<IClassDocument> {
+    const cls = new Class(data);
+    return cls.save();
+  }
+
+  async findById(id: string): Promise<IClassDocument | null> {
+    return Class.findById(id)
+      .populate('teacherId', 'firstName lastName email')
+      .populate('schoolId', 'name code')
+      .exec();
+  }
+
+  async findAll(filter?: FilterQuery<IClassDocument>): Promise<IClassDocument[]> {
+    return Class.find(filter || {})
+      .populate('teacherId', 'firstName lastName email')
+      .populate('schoolId', 'name code')
+      .sort({ createdAt: -1 })
+      .exec();
+  }
+
+  async findByTeacher(teacherId: string): Promise<IClassDocument[]> {
+    return Class.find({ teacherId, isActive: true })
+      .populate('schoolId', 'name code')
+      .sort({ className: 1, section: 1 })
+      .exec();
+  }
+
+  async findBySchool(schoolId: string): Promise<IClassDocument[]> {
+    return Class.find({ schoolId, isActive: true })
+      .populate('teacherId', 'firstName lastName email')
+      .sort({ className: 1, section: 1 })
+      .exec();
+  }
+
+  async findActive(): Promise<IClassDocument[]> {
+    return Class.find({ isActive: true })
+      .populate('teacherId', 'firstName lastName email')
+      .populate('schoolId', 'name code')
+      .sort({ createdAt: -1 })
+      .exec();
+  }
+
+  async updateById(id: string, data: UpdateQuery<IClassDocument>): Promise<IClassDocument | null> {
+    return Class.findByIdAndUpdate(id, data, { new: true, runValidators: true })
+      .populate('teacherId', 'firstName lastName email')
+      .populate('schoolId', 'name code')
+      .exec();
+  }
+
+  async deleteById(id: string): Promise<IClassDocument | null> {
+    return Class.findByIdAndDelete(id).exec();
+  }
+
+  async softDeleteById(id: string): Promise<IClassDocument | null> {
+    return Class.findByIdAndUpdate(id, { isActive: false }, { new: true }).exec();
+  }
+
+  async count(filter?: FilterQuery<IClassDocument>): Promise<number> {
+    return Class.countDocuments(filter || {}).exec();
+  }
+
+  async findOne(filter: FilterQuery<IClassDocument>): Promise<IClassDocument | null> {
+    return Class.findOne(filter).exec();
+  }
+
+  async getLastClassCode(): Promise<string | null> {
+    const last = await Class.findOne({})
+      .sort({ classCode: -1 })
+      .select('classCode')
+      .lean()
+      .exec();
+    return (last as { classCode: string } | null)?.classCode || null;
+  }
+}

--- a/backend/src/repositories/student/student.repository.ts
+++ b/backend/src/repositories/student/student.repository.ts
@@ -1,0 +1,97 @@
+import { FilterQuery, UpdateQuery } from 'mongoose';
+import { Student } from '../../models/student/student.model';
+import { IStudent, IStudentDocument } from '../../interfaces/student/student.interface';
+
+export class StudentRepository {
+  async create(data: IStudent): Promise<IStudentDocument> {
+    const student = new Student(data);
+    return student.save();
+  }
+
+  async findById(id: string): Promise<IStudentDocument | null> {
+    return Student.findById(id)
+      .populate('classId', 'className section academicYear')
+      .populate('teacherId', 'firstName lastName email')
+      .populate('schoolId', 'name code')
+      .exec();
+  }
+
+  async findAll(filter?: FilterQuery<IStudentDocument>): Promise<IStudentDocument[]> {
+    return Student.find(filter || {})
+      .populate('classId', 'className section academicYear')
+      .populate('teacherId', 'firstName lastName email')
+      .populate('schoolId', 'name code')
+      .sort({ createdAt: -1 })
+      .exec();
+  }
+
+  async findByClass(classId: string): Promise<IStudentDocument[]> {
+    return Student.find({ classId, isActive: true })
+      .populate('teacherId', 'firstName lastName email')
+      .sort({ rollNumber: 1 })
+      .exec();
+  }
+
+  async findByTeacher(teacherId: string): Promise<IStudentDocument[]> {
+    return Student.find({ teacherId, isActive: true })
+      .populate('classId', 'className section academicYear')
+      .populate('schoolId', 'name code')
+      .sort({ rollNumber: 1 })
+      .exec();
+  }
+
+  async findBySchool(schoolId: string): Promise<IStudentDocument[]> {
+    return Student.find({ schoolId, isActive: true })
+      .populate('classId', 'className section academicYear')
+      .populate('teacherId', 'firstName lastName email')
+      .sort({ rollNumber: 1 })
+      .exec();
+  }
+
+  async findActive(): Promise<IStudentDocument[]> {
+    return Student.find({ isActive: true })
+      .populate('classId', 'className section academicYear')
+      .populate('teacherId', 'firstName lastName email')
+      .populate('schoolId', 'name code')
+      .sort({ createdAt: -1 })
+      .exec();
+  }
+
+  async updateById(id: string, data: UpdateQuery<IStudentDocument>): Promise<IStudentDocument | null> {
+    return Student.findByIdAndUpdate(id, data, { new: true, runValidators: true })
+      .populate('classId', 'className section academicYear')
+      .populate('teacherId', 'firstName lastName email')
+      .populate('schoolId', 'name code')
+      .exec();
+  }
+
+  async deleteById(id: string): Promise<IStudentDocument | null> {
+    return Student.findByIdAndDelete(id).exec();
+  }
+
+  async softDeleteById(id: string): Promise<IStudentDocument | null> {
+    return Student.findByIdAndUpdate(id, { isActive: false }, { new: true }).exec();
+  }
+
+  async count(filter?: FilterQuery<IStudentDocument>): Promise<number> {
+    return Student.countDocuments(filter || {}).exec();
+  }
+
+  async getMaxRollNumber(classId: string): Promise<number> {
+    const last = await Student.findOne({ classId })
+      .sort({ rollNumber: -1 })
+      .select('rollNumber')
+      .lean()
+      .exec();
+    return (last as { rollNumber: number } | null)?.rollNumber || 0;
+  }
+
+  async getLastStudentId(schoolId: string): Promise<string | null> {
+    const last = await Student.findOne({ schoolId })
+      .sort({ studentId: -1 })
+      .select('studentId')
+      .lean()
+      .exec();
+    return (last as { studentId: string } | null)?.studentId || null;
+  }
+}

--- a/backend/src/routes/class/class.routes.ts
+++ b/backend/src/routes/class/class.routes.ts
@@ -1,0 +1,45 @@
+import { Router } from 'express';
+import { ClassController } from '../../controllers/class/class.controller';
+import { validate } from '../../middlewares/validate';
+import { authenticate } from '../../middlewares/auth';
+import { authorize } from '../../middlewares/authorize';
+import {
+  createClassValidator,
+  updateClassValidator,
+  classIdValidator,
+  teacherIdParamValidator,
+  schoolIdParamValidator,
+  getAllClassesValidator,
+} from '../../validators/class/class.validator';
+
+const router = Router();
+const controller = new ClassController();
+
+router
+  .route('/')
+  .get(getAllClassesValidator, validate, controller.getAll)
+  .post(authenticate, createClassValidator, validate, controller.create);
+
+router
+  .route('/teacher/:teacherId')
+  .get(teacherIdParamValidator, validate, controller.getByTeacher);
+
+router
+  .route('/school/:schoolId')
+  .get(schoolIdParamValidator, validate, controller.getBySchool);
+
+router
+  .route('/:id')
+  .get(classIdValidator, validate, controller.getById)
+  .put(authenticate, updateClassValidator, validate, controller.update)
+  .delete(authenticate, classIdValidator, validate, controller.delete);
+
+router
+  .route('/:id/status')
+  .patch(authenticate, classIdValidator, validate, controller.toggleStatus);
+
+router
+  .route('/:id/deactivate')
+  .patch(authenticate, classIdValidator, validate, controller.softDelete);
+
+export default router;

--- a/backend/src/routes/student/student.routes.ts
+++ b/backend/src/routes/student/student.routes.ts
@@ -1,0 +1,49 @@
+import { Router } from 'express';
+import { StudentController } from '../../controllers/student/student.controller';
+import { validate } from '../../middlewares/validate';
+import { authenticate } from '../../middlewares/auth';
+import {
+  createStudentValidator,
+  updateStudentValidator,
+  studentIdValidator,
+  classIdParamValidator,
+  teacherIdParamValidator,
+  schoolIdParamValidator,
+  getAllStudentsValidator,
+} from '../../validators/student/student.validator';
+
+const router = Router();
+const controller = new StudentController();
+
+router
+  .route('/')
+  .get(getAllStudentsValidator, validate, controller.getAll)
+  .post(authenticate, createStudentValidator, validate, controller.create);
+
+router
+  .route('/class/:classId')
+  .get(classIdParamValidator, validate, controller.getByClass);
+
+router
+  .route('/teacher/:teacherId')
+  .get(teacherIdParamValidator, validate, controller.getByTeacher);
+
+router
+  .route('/school/:schoolId')
+  .get(schoolIdParamValidator, validate, controller.getBySchool);
+
+router
+  .route('/:id')
+  .get(studentIdValidator, validate, controller.getById)
+  .put(authenticate, updateStudentValidator, validate, controller.update)
+  .delete(authenticate, studentIdValidator, validate, controller.delete);
+
+router
+  .route('/:id/status')
+  .patch(authenticate, studentIdValidator, validate, controller.toggleStatus);
+
+router
+  .route('/:id/deactivate')
+  .patch(authenticate, studentIdValidator, validate, controller.softDelete);
+
+export default router;

--- a/backend/src/services/class/class.service.ts
+++ b/backend/src/services/class/class.service.ts
@@ -1,0 +1,117 @@
+import httpStatus from 'http-status';
+import { ClassRepository } from '../../repositories/class/class.repository';
+import { TeacherRepository } from '../../repositories/teacher.repository';
+import { SchoolRepository } from '../../repositories/school.repository';
+import { IClass } from '../../interfaces/class/class.interface';
+import { AppError } from '../../middlewares/errorHandler';
+import { generateClassCode } from '../../utils/idGenerator';
+
+export class ClassService {
+  private repository: ClassRepository;
+  private teacherRepository: TeacherRepository;
+  private schoolRepository: SchoolRepository;
+
+  constructor() {
+    this.repository = new ClassRepository();
+    this.teacherRepository = new TeacherRepository();
+    this.schoolRepository = new SchoolRepository();
+  }
+
+  async create(data: IClass) {
+    const teacher = await this.teacherRepository.findById(data.teacherId.toString());
+    if (!teacher) {
+      throw new AppError('Referenced teacher not found', httpStatus.BAD_REQUEST);
+    }
+
+    const school = await this.schoolRepository.findById(data.schoolId.toString());
+    if (!school) {
+      throw new AppError('Referenced school not found', httpStatus.BAD_REQUEST);
+    }
+
+    const classCode = await generateClassCode(this.repository);
+
+    return this.repository.create({ ...data, classCode, currentStudents: 0 });
+  }
+
+  async getAll(includeInactive = false) {
+    if (includeInactive) {
+      return this.repository.findAll();
+    }
+    return this.repository.findActive();
+  }
+
+  async getById(id: string) {
+    const cls = await this.repository.findById(id);
+    if (!cls) {
+      throw new AppError('Class not found', httpStatus.NOT_FOUND);
+    }
+    return cls;
+  }
+
+  async getByTeacher(teacherId: string) {
+    const teacher = await this.teacherRepository.findById(teacherId);
+    if (!teacher) {
+      throw new AppError('Teacher not found', httpStatus.NOT_FOUND);
+    }
+    return this.repository.findByTeacher(teacherId);
+  }
+
+  async getBySchool(schoolId: string) {
+    const school = await this.schoolRepository.findById(schoolId);
+    if (!school) {
+      throw new AppError('School not found', httpStatus.NOT_FOUND);
+    }
+    return this.repository.findBySchool(schoolId);
+  }
+
+  async update(id: string, data: Partial<IClass>) {
+    const cls = await this.repository.findById(id);
+    if (!cls) {
+      throw new AppError('Class not found', httpStatus.NOT_FOUND);
+    }
+
+    if (data.teacherId) {
+      const teacher = await this.teacherRepository.findById(data.teacherId.toString());
+      if (!teacher) {
+        throw new AppError('Referenced teacher not found', httpStatus.BAD_REQUEST);
+      }
+    }
+
+    if (data.schoolId) {
+      const school = await this.schoolRepository.findById(data.schoolId.toString());
+      if (!school) {
+        throw new AppError('Referenced school not found', httpStatus.BAD_REQUEST);
+      }
+    }
+
+    const updated = await this.repository.updateById(id, data);
+    if (!updated) {
+      throw new AppError('Class not found', httpStatus.NOT_FOUND);
+    }
+    return updated;
+  }
+
+  async toggleStatus(id: string) {
+    const cls = await this.repository.findById(id);
+    if (!cls) {
+      throw new AppError('Class not found', httpStatus.NOT_FOUND);
+    }
+    return this.repository.updateById(id, { isActive: !cls.isActive });
+  }
+
+  async delete(id: string) {
+    const cls = await this.repository.findById(id);
+    if (!cls) {
+      throw new AppError('Class not found', httpStatus.NOT_FOUND);
+    }
+    await this.repository.deleteById(id);
+  }
+
+  async softDelete(id: string) {
+    const cls = await this.repository.findById(id);
+    if (!cls) {
+      throw new AppError('Class not found', httpStatus.NOT_FOUND);
+    }
+    return this.repository.softDeleteById(id);
+  }
+}

--- a/backend/src/services/student/student.service.ts
+++ b/backend/src/services/student/student.service.ts
@@ -1,0 +1,212 @@
+import httpStatus from 'http-status';
+import { StudentRepository } from '../../repositories/student/student.repository';
+import { TeacherRepository } from '../../repositories/teacher.repository';
+import { SchoolRepository } from '../../repositories/school.repository';
+import { ClassRepository } from '../../repositories/class/class.repository';
+import { StateRepository } from '../../repositories/state.repository';
+import { DistrictRepository } from '../../repositories/district.repository';
+import { IStudent } from '../../interfaces/student/student.interface';
+import { AppError } from '../../middlewares/errorHandler';
+
+export class StudentService {
+  private repository: StudentRepository;
+  private teacherRepository: TeacherRepository;
+  private schoolRepository: SchoolRepository;
+  private classRepository: ClassRepository;
+  private stateRepository: StateRepository;
+  private districtRepository: DistrictRepository;
+
+  constructor() {
+    this.repository = new StudentRepository();
+    this.teacherRepository = new TeacherRepository();
+    this.schoolRepository = new SchoolRepository();
+    this.classRepository = new ClassRepository();
+    this.stateRepository = new StateRepository();
+    this.districtRepository = new DistrictRepository();
+  }
+
+  async create(data: IStudent) {
+    const schoolId = data.schoolId.toString();
+    const teacherId = data.teacherId.toString();
+    const classId = data.classId.toString();
+
+    const school = await this.schoolRepository.findById(schoolId);
+    if (!school) {
+      throw new AppError('Referenced school not found', httpStatus.BAD_REQUEST);
+    }
+
+    const teacher = await this.teacherRepository.findById(teacherId);
+    if (!teacher) {
+      throw new AppError('Referenced teacher not found', httpStatus.BAD_REQUEST);
+    }
+
+    const cls = await this.classRepository.findById(classId);
+    if (!cls) {
+      throw new AppError('Referenced class not found', httpStatus.BAD_REQUEST);
+    }
+
+    if (cls.currentStudents >= cls.maximumStudents) {
+      throw new AppError(
+        `Class has reached maximum capacity of ${cls.maximumStudents} students`,
+        httpStatus.BAD_REQUEST
+      );
+    }
+
+    const studentId = await this.generateStudentId(schoolId);
+    const maxRoll = await this.repository.getMaxRollNumber(classId);
+    const rollNumber = maxRoll + 1;
+
+    const student = await this.repository.create({
+      ...data,
+      studentId,
+      rollNumber,
+      classId: cls._id,
+      teacherId: teacher._id,
+      schoolId: school._id,
+    });
+
+    await this.classRepository.updateById(classId, {
+      currentStudents: cls.currentStudents + 1,
+    });
+
+    return student;
+  }
+
+  private async generateStudentId(schoolId: string): Promise<string> {
+    const school = await this.schoolRepository.findById(schoolId);
+    if (!school) {
+      throw new AppError('School not found for ID generation', httpStatus.BAD_REQUEST);
+    }
+
+    const district = await this.districtRepository.findById(school.district.toString());
+    if (!district) {
+      throw new AppError('District not found for ID generation', httpStatus.BAD_REQUEST);
+    }
+
+    const state = await this.stateRepository.findById(school.state.toString());
+    if (!state) {
+      throw new AppError('State not found for ID generation', httpStatus.BAD_REQUEST);
+    }
+
+    const stateCode = state.code;
+    const districtCode = district.code;
+    const schoolCode = school.code;
+
+    const lastStudentId = await this.repository.getLastStudentId(schoolId);
+    let sequence = 1;
+
+    if (lastStudentId) {
+      const parts = lastStudentId.split('-');
+      const lastSeq = parseInt(parts[parts.length - 1], 10);
+      sequence = lastSeq + 1;
+    }
+
+    return `${stateCode}-${districtCode}-${schoolCode}-${String(sequence).padStart(4, '0')}`;
+  }
+
+  async getAll(includeInactive = false) {
+    if (includeInactive) {
+      return this.repository.findAll();
+    }
+    return this.repository.findActive();
+  }
+
+  async getById(id: string) {
+    const student = await this.repository.findById(id);
+    if (!student) {
+      throw new AppError('Student not found', httpStatus.NOT_FOUND);
+    }
+    return student;
+  }
+
+  async getByClass(classId: string) {
+    const cls = await this.classRepository.findById(classId);
+    if (!cls) {
+      throw new AppError('Class not found', httpStatus.NOT_FOUND);
+    }
+    return this.repository.findByClass(classId);
+  }
+
+  async getByTeacher(teacherId: string) {
+    const teacher = await this.teacherRepository.findById(teacherId);
+    if (!teacher) {
+      throw new AppError('Teacher not found', httpStatus.NOT_FOUND);
+    }
+    return this.repository.findByTeacher(teacherId);
+  }
+
+  async getBySchool(schoolId: string) {
+    const school = await this.schoolRepository.findById(schoolId);
+    if (!school) {
+      throw new AppError('School not found', httpStatus.NOT_FOUND);
+    }
+    return this.repository.findBySchool(schoolId);
+  }
+
+  async update(id: string, data: Partial<IStudent>) {
+    const student = await this.repository.findById(id);
+    if (!student) {
+      throw new AppError('Student not found', httpStatus.NOT_FOUND);
+    }
+
+    if (data.schoolId) {
+      const school = await this.schoolRepository.findById(data.schoolId.toString());
+      if (!school) {
+        throw new AppError('Referenced school not found', httpStatus.BAD_REQUEST);
+      }
+    }
+
+    if (data.teacherId) {
+      const teacher = await this.teacherRepository.findById(data.teacherId.toString());
+      if (!teacher) {
+        throw new AppError('Referenced teacher not found', httpStatus.BAD_REQUEST);
+      }
+    }
+
+    if (data.classId) {
+      const cls = await this.classRepository.findById(data.classId.toString());
+      if (!cls) {
+        throw new AppError('Referenced class not found', httpStatus.BAD_REQUEST);
+      }
+    }
+
+    const updated = await this.repository.updateById(id, data);
+    if (!updated) {
+      throw new AppError('Student not found', httpStatus.NOT_FOUND);
+    }
+    return updated;
+  }
+
+  async toggleStatus(id: string) {
+    const student = await this.repository.findById(id);
+    if (!student) {
+      throw new AppError('Student not found', httpStatus.NOT_FOUND);
+    }
+    return this.repository.updateById(id, { isActive: !student.isActive });
+  }
+
+  async delete(id: string) {
+    const student = await this.repository.findById(id);
+    if (!student) {
+      throw new AppError('Student not found', httpStatus.NOT_FOUND);
+    }
+    const classId = student.classId.toString();
+    const cls = await this.classRepository.findById(classId);
+
+    await this.repository.deleteById(id);
+
+    if (cls) {
+      await this.classRepository.updateById(classId, {
+        currentStudents: Math.max(0, cls.currentStudents - 1),
+      });
+    }
+  }
+
+  async softDelete(id: string) {
+    const student = await this.repository.findById(id);
+    if (!student) {
+      throw new AppError('Student not found', httpStatus.NOT_FOUND);
+    }
+    return this.repository.softDeleteById(id);
+  }
+}

--- a/backend/src/utils/idGenerator.ts
+++ b/backend/src/utils/idGenerator.ts
@@ -1,4 +1,5 @@
 import { TeacherRepository } from '../repositories/teacher.repository';
+import { ClassRepository } from '../repositories/class/class.repository';
 
 export async function generateTeacherId(
   repository: TeacherRepository
@@ -12,4 +13,18 @@ export async function generateTeacherId(
   const numericPart = parseInt(lastId.replace('T', ''), 10);
   const nextNumeric = numericPart + 1;
   return `T${String(nextNumeric).padStart(6, '0')}`;
+}
+
+export async function generateClassCode(
+  repository: ClassRepository
+): Promise<string> {
+  const lastCode = await repository.getLastClassCode();
+
+  if (!lastCode) {
+    return 'CLS-001';
+  }
+
+  const numericPart = parseInt(lastCode.replace('CLS-', ''), 10);
+  const nextNumeric = numericPart + 1;
+  return `CLS-${String(nextNumeric).padStart(3, '0')}`;
 }

--- a/backend/src/validators/class/class.validator.ts
+++ b/backend/src/validators/class/class.validator.ts
@@ -1,0 +1,122 @@
+import { body, param, query } from 'express-validator';
+
+export const createClassValidator = [
+  body('className')
+    .notEmpty()
+    .withMessage('Class name is required')
+    .isString()
+    .withMessage('Class name must be a string')
+    .isLength({ max: 50 })
+    .withMessage('Class name cannot exceed 50 characters')
+    .trim(),
+
+  body('section')
+    .notEmpty()
+    .withMessage('Section is required')
+    .isString()
+    .withMessage('Section must be a string')
+    .isLength({ max: 10 })
+    .withMessage('Section cannot exceed 10 characters')
+    .trim(),
+
+  body('academicYear')
+    .notEmpty()
+    .withMessage('Academic year is required')
+    .isString()
+    .withMessage('Academic year must be a string')
+    .trim(),
+
+  body('teacherId')
+    .notEmpty()
+    .withMessage('Teacher reference is required')
+    .isMongoId()
+    .withMessage('Invalid teacher ID'),
+
+  body('schoolId')
+    .notEmpty()
+    .withMessage('School reference is required')
+    .isMongoId()
+    .withMessage('Invalid school ID'),
+
+  body('maximumStudents')
+    .notEmpty()
+    .withMessage('Maximum students is required')
+    .isInt({ min: 1 })
+    .withMessage('Maximum students must be a positive integer'),
+];
+
+export const updateClassValidator = [
+  param('id')
+    .notEmpty()
+    .withMessage('Class ID is required')
+    .isMongoId()
+    .withMessage('Invalid class ID'),
+
+  body('className')
+    .optional()
+    .isString()
+    .withMessage('Class name must be a string')
+    .isLength({ max: 50 })
+    .withMessage('Class name cannot exceed 50 characters')
+    .trim(),
+
+  body('section')
+    .optional()
+    .isString()
+    .withMessage('Section must be a string')
+    .isLength({ max: 10 })
+    .withMessage('Section cannot exceed 10 characters')
+    .trim(),
+
+  body('academicYear')
+    .optional()
+    .isString()
+    .withMessage('Academic year must be a string')
+    .trim(),
+
+  body('teacherId')
+    .optional()
+    .isMongoId()
+    .withMessage('Invalid teacher ID'),
+
+  body('schoolId')
+    .optional()
+    .isMongoId()
+    .withMessage('Invalid school ID'),
+
+  body('maximumStudents')
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage('Maximum students must be a positive integer'),
+];
+
+export const classIdValidator = [
+  param('id')
+    .notEmpty()
+    .withMessage('Class ID is required')
+    .isMongoId()
+    .withMessage('Invalid class ID'),
+];
+
+export const teacherIdParamValidator = [
+  param('teacherId')
+    .notEmpty()
+    .withMessage('Teacher ID is required')
+    .isMongoId()
+    .withMessage('Invalid teacher ID'),
+];
+
+export const schoolIdParamValidator = [
+  param('schoolId')
+    .notEmpty()
+    .withMessage('School ID is required')
+    .isMongoId()
+    .withMessage('Invalid school ID'),
+];
+
+export const getAllClassesValidator = [
+  query('includeInactive')
+    .optional()
+    .isBoolean()
+    .withMessage('includeInactive must be a boolean'),
+];

--- a/backend/src/validators/student/student.validator.ts
+++ b/backend/src/validators/student/student.validator.ts
@@ -1,0 +1,151 @@
+import { body, param, query } from 'express-validator';
+
+export const createStudentValidator = [
+  body('firstName')
+    .notEmpty()
+    .withMessage('First name is required')
+    .isString()
+    .withMessage('First name must be a string')
+    .isLength({ max: 50 })
+    .withMessage('First name cannot exceed 50 characters')
+    .trim(),
+
+  body('lastName')
+    .notEmpty()
+    .withMessage('Last name is required')
+    .isString()
+    .withMessage('Last name must be a string')
+    .isLength({ max: 50 })
+    .withMessage('Last name cannot exceed 50 characters')
+    .trim(),
+
+  body('gender')
+    .notEmpty()
+    .withMessage('Gender is required')
+    .isIn(['Male', 'Female', 'Other'])
+    .withMessage('Gender must be Male, Female, or Other'),
+
+  body('dateOfBirth')
+    .optional()
+    .isString()
+    .withMessage('Date of birth must be a string')
+    .trim(),
+
+  body('age')
+    .notEmpty()
+    .withMessage('Age is required')
+    .isInt({ min: 3, max: 18 })
+    .withMessage('Age must be between 3 and 18'),
+
+  body('classId')
+    .notEmpty()
+    .withMessage('Class reference is required')
+    .isMongoId()
+    .withMessage('Invalid class ID'),
+
+  body('teacherId')
+    .notEmpty()
+    .withMessage('Teacher reference is required')
+    .isMongoId()
+    .withMessage('Invalid teacher ID'),
+
+  body('schoolId')
+    .notEmpty()
+    .withMessage('School reference is required')
+    .isMongoId()
+    .withMessage('Invalid school ID'),
+];
+
+export const updateStudentValidator = [
+  param('id')
+    .notEmpty()
+    .withMessage('Student ID is required')
+    .isMongoId()
+    .withMessage('Invalid student ID'),
+
+  body('firstName')
+    .optional()
+    .isString()
+    .withMessage('First name must be a string')
+    .isLength({ max: 50 })
+    .withMessage('First name cannot exceed 50 characters')
+    .trim(),
+
+  body('lastName')
+    .optional()
+    .isString()
+    .withMessage('Last name must be a string')
+    .isLength({ max: 50 })
+    .withMessage('Last name cannot exceed 50 characters')
+    .trim(),
+
+  body('gender')
+    .optional()
+    .isIn(['Male', 'Female', 'Other'])
+    .withMessage('Gender must be Male, Female, or Other'),
+
+  body('dateOfBirth')
+    .optional()
+    .isString()
+    .withMessage('Date of birth must be a string')
+    .trim(),
+
+  body('age')
+    .optional()
+    .isInt({ min: 3, max: 18 })
+    .withMessage('Age must be between 3 and 18'),
+
+  body('classId')
+    .optional()
+    .isMongoId()
+    .withMessage('Invalid class ID'),
+
+  body('teacherId')
+    .optional()
+    .isMongoId()
+    .withMessage('Invalid teacher ID'),
+
+  body('schoolId')
+    .optional()
+    .isMongoId()
+    .withMessage('Invalid school ID'),
+];
+
+export const studentIdValidator = [
+  param('id')
+    .notEmpty()
+    .withMessage('Student ID is required')
+    .isMongoId()
+    .withMessage('Invalid student ID'),
+];
+
+export const classIdParamValidator = [
+  param('classId')
+    .notEmpty()
+    .withMessage('Class ID is required')
+    .isMongoId()
+    .withMessage('Invalid class ID'),
+];
+
+export const teacherIdParamValidator = [
+  param('teacherId')
+    .notEmpty()
+    .withMessage('Teacher ID is required')
+    .isMongoId()
+    .withMessage('Invalid teacher ID'),
+];
+
+export const schoolIdParamValidator = [
+  param('schoolId')
+    .notEmpty()
+    .withMessage('School ID is required')
+    .isMongoId()
+    .withMessage('Invalid school ID'),
+];
+
+export const getAllStudentsValidator = [
+  query('includeInactive')
+    .optional()
+    .isBoolean()
+    .withMessage('includeInactive must be a boolean'),
+];


### PR DESCRIPTION
 Summary
Replace JSON-file backend with layered MongoDB architecture (Route → Controller → Service → Repository → Model → MongoDB) for all core modules. Add Class and Student CRUD with auto-ID generation, capacity tracking, and hierarchy validation. Add frontend coordinator registration page with cascading geo dropdowns.

## Backend Changes

### New Modules
- **Auth** — JWT login, Bearer token middleware, superadmin/DEO/teacher role guards
- **State, District, Block, School, Teacher** — Full CRUD + soft-delete + hierarchy filters. GET routes are public; write routes require JWT auth.
- **Class** — Auto-generated class codes (CLS-001), validates teacher/school existence, tracks currentStudents count
- **Student** — Auto-generated IDs (STATE-DIST-SCHOOL-0001), per-class roll number auto-increment, maximumStudents capacity enforcement, cascading school→district→state validation

### Architecture
- Layered pattern under `backend/src/modules/` (flat files for geo modules, subdirectories for Class/Student)
- Mongoose schemas with TypeScript interfaces
- `backend/src/config/database.ts` — MongoDB connection with graceful fallback
- `backend/src/utils/idGenerator.ts` — teacher ID, class code generators
- `backend/src/app.ts` — Express app wiring all routes + error handler
- Server starts even without database (logs warning, non-DB routes work)

### Infrastructure
- `.env` configured for local MongoDB (port 27017)
- `npm run seed` + `npm run seed:geo` scripts for data seeding
- `.gitignore` fixed to UTF-8 (was UTF-16, breaking node_modules/ matching)
- `.env.example` sanitized with placeholder credentials

## Frontend Changes
- **Coordinator Registration** page at `/register-coordinator` with React Hook Form + cascading State→District→Block→School dropdowns
- **TanStack Query** hooks for geo data fetching + teacher creation mutations
- **Axios** service targeting `http://localhost:5000/api` with JWT auth interceptor
- **Packages added:** react-hook-form, @tanstack/react-query, axios, react-router-dom

## Verification
- [x] Backend starts on port 5000 with local MongoDB
- [x] Health check: `GET /api/health` returns 200
- [x] All geo endpoints registered and responding
- [x] Auth middleware parses JWT tokens correctly
- [x] Frontend compiles and renders coordinator registration form

## Notes
- Run `npm run seed && npm run seed:geo --workspace=@fln/backend` after merge to populate seed data
- Auth login returns 500 until seed data is loaded (no users in fresh DB)
- Port 3000 (old JSON backend) runs alongside port 5000 (new MongoDB backend)