### PR TITLE
Fix 4 wrong level numbers left inside level content

### DIFF
--- a/FLN Levels Structure/Level 10_ Comparison – Numeral/Level 10_ Comparison – Numeral.md
+++ b/FLN Levels Structure/Level 10_ Comparison – Numeral/Level 10_ Comparison – Numeral.md
@@ -1,4 +1,4 @@
-# Level 11: Comparison – Numeral
+# Level 10: Comparison – Numeral
 
 **Class:** Preschool 3 | **Age Group:** Age 5-6
 

--- a/FLN Levels Structure/Level 13_ Numbers 11–30/13.1.md
+++ b/FLN Levels Structure/Level 13_ Numbers 11–30/13.1.md
@@ -1,4 +1,4 @@
-# Sub-Level 12.1
+# Sub-Level 13.1
 
 ## SECTION A: NUMBERS
 All numbers will be shown and blank space will be provided

--- a/FLN Levels Structure/Level 20_ Skip Counting in 2s_3s/Level 20_ Skip Counting in 2s_3s.md
+++ b/FLN Levels Structure/Level 20_ Skip Counting in 2s_3s/Level 20_ Skip Counting in 2s_3s.md
@@ -44,6 +44,6 @@ Difference between sublevels:
 
 | Level | Difficulty | Support |
 |---|---|---|
-| 19.0 | Standard | No Support on i side of the sheet and frog jump/number line on other side |
-| 19.1 | Easier | Frog jumps,number lines,hints |
-| 19.2 | Remediation | Very small patterns,heavy visual support |
+| 20.0 | Standard | No Support on i side of the sheet and frog jump/number line on other side |
+| 20.1 | Easier | Frog jumps,number lines,hints |
+| 20.2 | Remediation | Very small patterns,heavy visual support |

--- a/FLN Levels Structure/Level 23_  Review Assessment/Level 23_  Review Assessment.md
+++ b/FLN Levels Structure/Level 23_  Review Assessment/Level 23_  Review Assessment.md
@@ -4,11 +4,11 @@
 
 ## Objective
 
-Assess mastery of all concepts learned from Levels 12–2.
+Assess mastery of all concepts learned from Levels 12–22.
 
 ## Description
 
-This level serves as a comprehensive review assessment of all concepts introduced from Levels 12–2.
+This level serves as a comprehensive review assessment of all concepts introduced from Levels 12–22.
 
 ## Learning Outcome
 


### PR DESCRIPTION
Four levels have text that references the wrong level number, consistent with copying the previous level's file as a starting template and not updating every reference:

- Level 10's file header read "# Level 11: Comparison – Numeral"
- Level 13's sub-level 13.1 header read "# Sub-Level 12.1"
- Level 20's difficulty table was labeled 19.0/19.1/19.2 while describing its own 20.0/20.1/20.2 sub-levels
- Level 23's objective/description said "Levels 12–2" (missing a digit) instead of "Levels 12–22"

Checked each file's actual worksheet content against its own level's topic before editing, to rule out these being genuine misplaced content rather than label typos — in all four cases the surrounding content matches its own folder's stated subject, confirming these are text-only fixes.