### PR TITLE
Fix leftover template placeholder in Level 12's description

### DIFF
--- a/FLN Levels Structure/Level 12_Tens and Ones/Level 12_Tens and Ones.md
+++ b/FLN Levels Structure/Level 12_Tens and Ones/Level 12_Tens and Ones.md
@@ -8,7 +8,7 @@ Develop an understanding of place value by identifying tens and ones in two-digi
 
 ### **Description**
 
-* In this level, students are introduced to the concept of **B** using visual representations such as bundles, blocks, sticks, beads, and objects.   
+* In this level, students are introduced to the concept of **place value** using visual representations such as bundles, blocks, sticks, beads, and objects.   
 * Children learn that a two-digit number is made up of tens and ones and practice identifying, counting, and representing numbers accordingly.   
 * This level acts as a bridge between single-digit numbers and larger numbers, helping students build a strong foundation for understanding numbers from 11 to 30\.
 


### PR DESCRIPTION
The description read "students are introduced to the concept of **B** using visual representations..." — an unfilled template placeholder, not real content. Filled in as "place value": the level's own Objective ("Develop an understanding of place value by identifying tens and ones...") and Topics Covered (which lists "Place Value" and "Tens"/"Ones" as separate items) both point to place value as the concept being introduced in this sentence, before the next bullet narrows to tens and ones specifically.