### PR TITLE
fix: use valid Gemini model IDs so AI scoring actually runs

### DIFF
--- a/backend/src/gemini.ts
+++ b/backend/src/gemini.ts
@@ -1,6 +1,13 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { Question } from "./db";
 
+// Valid Gemini model IDs, primary first then fallbacks (used by generateContentWithRetry).
+// Centralized here so the call sites below don't drift; these match the IDs the
+// ai-services Python pipeline uses (ai-services/scripts/_api.py). The previous IDs
+// ("gemini-3.5-flash" / "gemini-3.1-*") do not exist and made every AI call 404.
+const GEMINI_MODELS = ["gemini-2.5-flash", "gemini-2.0-flash"] as const;
+const DEFAULT_GEMINI_MODEL = GEMINI_MODELS[0];
+
 // Helper to get Gemini client or null if key is missing
 let aiClient: GoogleGenAI | null = null;
 
@@ -32,9 +39,8 @@ async function generateContentWithRetry(params: {
   model?: string;
 }): Promise<any> {
   const modelsToTry = [
-    params.model || "gemini-3.5-flash",
-    "gemini-3.1-flash-lite",
-    "gemini-3.1-pro-preview"
+    params.model || DEFAULT_GEMINI_MODEL,
+    ...GEMINI_MODELS.slice(1),
   ];
 
   let lastError: any = null;
@@ -391,7 +397,7 @@ Implement "Weakest-Level Mapping" (SRS §6.2): Assign the student to the lowest 
 Provide a clean narrative feedback summary.`;
 
     const response = await generateContentWithRetry({
-      model: "gemini-3.5-flash",
+      model: DEFAULT_GEMINI_MODEL,
       contents: prompt,
       config: {
         systemInstruction: "You are an automated math scoring system for Foundational Literacy & Numeracy.",
@@ -469,7 +475,7 @@ export async function generateAIPersonalizedWorksheet(
   try {
     const category = topicCategories[Math.floor(Math.random() * topicCategories.length)] || "Number Sense";
     const response = await generateContentWithRetry({
-      model: "gemini-3.5-flash",
+      model: DEFAULT_GEMINI_MODEL,
       contents: `Create exactly 3 math assessment questions for a student named ${studentName} who is currently at Level ${level}.
 The main topic area should be around: ${category}.
 Include at least one easy, one medium, and one hard difficulty question.
@@ -579,7 +585,7 @@ Recommended Level progression rules:
 Generate a narrative report summarizing strengths and learning gaps.`;
 
     const response = await generateContentWithRetry({
-      model: "gemini-3.5-flash",
+      model: DEFAULT_GEMINI_MODEL,
       contents: prompt,
       config: {
         systemInstruction: "You are a professional teacher grading and narrative-writing engine.",


### PR DESCRIPTION
## Problem
`backend/src/gemini.ts` referenced Gemini model IDs that **do not exist**:
`gemini-3.5-flash`, `gemini-3.1-flash-lite`, `gemini-3.1-pro-preview` (hardcoded at 4 sites).

Every call to the Gemini API therefore returned **404 (model not found)** and silently fell through to the deterministic fallback in each AI path. Net effect: **real AI scoring never ran**, even when a valid `GEMINI_API_KEY` was configured — the platform's AI diagnostic/worksheet evaluation was effectively dead.

## Fix
- Replace the invalid IDs with valid ones: **`gemini-2.5-flash`** (primary) and **`gemini-2.0-flash`** (fallback) — the same models the `ai-services` Python pipeline already uses (`ai-services/scripts/_api.py`).
- Centralize them in a single `GEMINI_MODELS` constant so the four call sites can't drift again (addresses AUDIT.md §3.4 / P2-3).

## Scope
- One file changed: `backend/src/gemini.ts` (+12 / −6).
- No behavior change other than the model IDs; retry/backoff/fallback logic untouched.

## Verification
- `npm run lint` (tsc): **5 → 5** type errors — zero new errors introduced; the 5 are pre-existing baseline issues in `db.ts` / `paperGenerator.ts` unrelated to this change.
- `npm run build --workspace=@fln/backend` (esbuild): bundles cleanly (`dist/server.cjs`).

Affected runtime paths: `POST /api/students/:id/diagnostic/submit` (`evaluateAIDiagnostic`) and `POST /api/evaluation/submit` (`evaluateAIWorksheet`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)