### PR TITLE
fix: real password auth with signed JWTs; remove role-synthesis bypass

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,7 @@ MONGODB_URI=mongodb+srv://<username>:<password>@cluster0.xxxxx.mongodb.net/fln_p
 
 JWT_SECRET=your-super-secret-key-change-in-production
 JWT_EXPIRES_IN=7d
+
+# Shared password for the seeded demo accounts (stored only as a bcrypt hash).
+# Defaults to the public demo password if unset; set a private value for real deployments.
+SEED_DEMO_PASSWORD=Fln@2026

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,9 +1,16 @@
 import fs from 'fs/promises';
 import path from 'path';
+import bcrypt from 'bcrypt';
 import { MongoClient, Db } from 'mongodb';
 
 const DB_DIR = path.resolve(process.cwd(), 'data');
 const DB_FILE = path.resolve(DB_DIR, 'db.json');
+
+// Every seeded demo account shares one password, stored ONLY as a bcrypt hash
+// (never as plaintext). Defaults to the well-known demo password shown on the login
+// screen; override with SEED_DEMO_PASSWORD for a private deployment.
+const SEED_DEMO_PASSWORD = process.env.SEED_DEMO_PASSWORD || 'Fln@2026';
+const SEED_DEMO_PASSWORD_HASH = bcrypt.hashSync(SEED_DEMO_PASSWORD, 10);
 
 export let mongoClient: MongoClient | null = null;
 
@@ -39,6 +46,7 @@ export interface User {
   email: string;
   name: string;
   role: UserRole;
+  passwordHash?: string; // bcrypt hash; verified at login. Never sent to clients.
   stateCode?: string;
   districtCode?: string;
   blockCode?: string;
@@ -796,6 +804,9 @@ export class DBStore {
       { id: 'u7_knp_vol', email: 'vol.knp@fln.org', name: 'Anita Singh (Volunteer)', role: UserRole.VOLUNTEER, assignedSchools: ['gps-knp-012'] },
       { id: 'u7_ldh2_vol', email: 'vol.ldh2@fln.org', name: 'Gurpreet Kaur (Volunteer)', role: UserRole.VOLUNTEER, assignedSchools: ['gps-pb-ldh2-013'] }
     ];
+
+    // Give every seeded account the shared demo password as a bcrypt hash.
+    users.forEach(u => { u.passwordHash = SEED_DEMO_PASSWORD_HASH; });
 
     const classes: ClassGroup[] = [
       { id: 'c1', schoolId: 'gps-mt-001', className: 'Class 2', section: 'A', teacherId: 'u6' },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,11 +10,26 @@ import { generateQuestionsForLevel } from './levelGenerator';
 import * as levelsBackendClient from './levelsBackendClient';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const ROOT_DIR = path.resolve(__dirname, '..');
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+
+// --- Auth config (signed JWTs) ---
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-insecure-secret-change-me';
+const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
+if (JWT_SECRET === 'dev-insecure-secret-change-me' && process.env.NODE_ENV === 'production') {
+  console.warn('[auth] WARNING: JWT_SECRET is unset in production — set it to a strong random value.');
+}
+
+// Strip fields that must never be sent to clients (e.g. the bcrypt password hash).
+function sanitizeUser(user: User): Omit<User, 'passwordHash'> {
+  const { passwordHash, ...safe } = user;
+  return safe;
+}
 
 async function startServer() {
   // Connect to MongoDB
@@ -30,58 +45,24 @@ async function startServer() {
   app.use('/output', express.static(path.join(ROOT_DIR, 'output')));
   app.use('/worksheets', express.static(path.join(ROOT_DIR, 'public', 'worksheets')));
   // --- Auth Middleware & Helper ---
-  // A simple token-based auth helper. Token is email address for easy stateless authentication.
+  // Verifies the signed JWT issued by /api/auth/login and resolves the current user
+  // from the database. There is deliberately NO role synthesis from the email/prefix:
+  // only real, seeded users with a valid signed token authenticate.
   function getAuthUser(req: express.Request): User | null {
     const authHeader = req.headers.authorization;
     if (!authHeader) return null;
-    const email = authHeader.replace('Bearer ', '').trim();
-    
-    // Find preseeded user in database
-    const found = dbStore.getUserSync(email);
-    if (found) return found;
+    const token = authHeader.replace('Bearer ', '').trim();
+    if (!token) return null;
 
-    // Direct fallback mapping if not pre-seeded but conforms to email format
-    if (email.endsWith('@fln.org')) {
-      const parts = email.split('@')[0];
-      let role = UserRole.TEACHER;
-      let name = 'User';
-      let schoolId = undefined;
-
-      if (email === 'superadmin@fln.org') {
-        role = UserRole.SUPERADMIN;
-        name = 'Jinal Gupta';
-      } else if (email.startsWith('admin.')) {
-        role = UserRole.ADMIN;
-        name = 'State Admin';
-      } else if (email.startsWith('district.')) {
-        role = UserRole.DISTRICT_ADMIN;
-        name = 'District Officer';
-      } else if (email.startsWith('block.')) {
-        role = UserRole.BLOCK_ADMIN;
-        name = 'Block Coordinator';
-      } else if (email.startsWith('vol.')) {
-        role = UserRole.VOLUNTEER;
-        name = 'Volunteer';
-      } else if (parts.includes('.t')) {
-        role = UserRole.TEACHER;
-        name = 'Teacher';
-        schoolId = parts.split('.t')[0];
-      } else {
-        role = UserRole.SCHOOL;
-        name = 'School Principal';
-        schoolId = parts;
-      }
-
-      return {
-        id: 'u_' + Math.random().toString(36).substr(2, 9),
-        email,
-        name,
-        role,
-        schoolId
-      };
+    let payload: { email?: string };
+    try {
+      payload = jwt.verify(token, JWT_SECRET) as { email?: string };
+    } catch {
+      return null; // invalid signature or expired token
     }
+    if (!payload?.email) return null;
 
-    return null;
+    return dbStore.getUserSync(payload.email);
   }
 
   // --- API Endpoints ---
@@ -140,10 +121,23 @@ async function startServer() {
       return res.status(401).json({ error: 'Invalid email or password' });
     }
 
-    // In a real production app we'd hash and compare, here we return JWT-like email token
+    // Verify the submitted password against the stored bcrypt hash.
+    const passwordOk = user.passwordHash
+      ? await bcrypt.compare(password, user.passwordHash)
+      : false;
+    if (!passwordOk) {
+      return res.status(401).json({ error: 'Invalid email or password' });
+    }
+
+    // Issue a signed JWT; it is verified on every subsequent request (see getAuthUser).
+    const token = jwt.sign(
+      { sub: user.id, email: user.email, role: user.role },
+      JWT_SECRET,
+      { expiresIn: JWT_EXPIRES_IN } as jwt.SignOptions
+    );
     return res.json({
-      token: user.email,
-      user
+      token,
+      user: sanitizeUser(user)
     });
   });
 
@@ -153,7 +147,7 @@ async function startServer() {
     if (!user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    return res.json({ user });
+    return res.json({ user: sanitizeUser(user) });
   });
 
   // Announcements
@@ -1514,8 +1508,8 @@ async function startServer() {
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
     const users = await dbStore.getUsers();
-    // Return all users for audit and coordination
-    res.json(users);
+    // Return all users for audit and coordination (without password hashes).
+    res.json(users.map(sanitizeUser));
   });
 
   // Revive Banned Teacher (§6.5)


### PR DESCRIPTION
## Problem (critical)
Authentication was effectively **open**:
- `getAuthUser()` treated the `Bearer` token as a plaintext email and, for any un-seeded `@fln.org` address, **synthesized a role from the email prefix**. So `Authorization: Bearer superadmin@fln.org` granted **superadmin** — no password, no signature. (This is documented in the repo's own `CLAUDE.md`.)
- `POST /api/auth/login` **never verified the password** (only the input's complexity) and returned the **email itself as the token**.

## Fix (backend only)
1. **Passwords** — every seeded account now carries a **bcrypt hash** of a shared password (`SEED_DEMO_PASSWORD` env, default = the public demo password). New `User.passwordHash` field; never sent to clients.
2. **Login** — `POST /api/auth/login` verifies the password with `bcrypt.compare` and issues a **signed JWT** (`jwt.sign` with `JWT_SECRET` / `JWT_EXPIRES_IN`, both already in `.env.example`).
3. **Request auth** — `getAuthUser()` now **verifies the JWT signature** and resolves the user from the DB. The **entire email-prefix role-synthesis fallback is removed** — only real, seeded users authenticate.
4. **No hash leaks** — added `sanitizeUser()`; `passwordHash` is stripped from every user-returning response (`/api/auth/login`, `/api/auth/me`, `/api/admin/coordinators`).

## Files
- `backend/src/db.ts` — `passwordHash` field + bcrypt-hash the seeded users.
- `backend/src/index.ts` — bcrypt verify, JWT sign/verify, remove synthesis, `sanitizeUser`.
- `backend/.env.example` — document `SEED_DEMO_PASSWORD`.

## Verification
Type-check: `npm run lint` → **5 → 5** errors (zero new; the 5 are pre-existing `db.ts`/`paperGenerator.ts` baseline issues).

End-to-end (ran the backend against a throwaway Mongo DB, seeded via `/api/reset`):
| Case | Result |
|---|---|
| Correct login (`Fln@2026`) | ✅ signed JWT returned, correct role, **no passwordHash** |
| Wrong password (meets complexity) | ✅ **401** |
| **Old bypass `Bearer superadmin@fln.org`** | ✅ **401 — dead** |
| Valid JWT → `/api/auth/me` | ✅ 200, no hash |
| Forged/garbage JWT | ✅ **401** |
| `/api/admin/coordinators` (62 users) | ✅ no `passwordHash` in any |

## ⚠️ Deploy note
Existing databases were seeded **before** this change, so their users have **no `passwordHash`** and won't be able to log in until re-seeded. After deploy, re-seed (`POST /api/reset`) or run a one-time backfill setting each user's `passwordHash`. Also set a strong `JWT_SECRET` in the deployment env (a dev fallback is used otherwise, with a warning in production).

Closes the auth items in AUDIT.md §5 / P0-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)