### PR TITLE
fix: require superadmin auth for DB reset; remove unauthenticated GET reset

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
     "start": "node dist/server.cjs",
     "lint": "tsc --noEmit",
     "seed": "tsx src/seed.ts",
-    "seed:geo": "tsx src/utils/seedGeo.ts"
+    "seed:geo": "tsx src/utils/seedGeo.ts",
+    "reseed": "tsx src/reseed.ts"
   },
   "dependencies": {
     "@google/genai": "^2.4.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1604,17 +1604,18 @@ async function startServer() {
   });
 
   // ══════════════════════════════════════════
-  // DATABASE RESET (Development convenience)
+  // DATABASE RESET (Superadmin only)
   // ══════════════════════════════════════════
+  // Wipes every collection and re-seeds. Requires an authenticated superadmin.
+  // Deliberately POST-only: a GET reset was removed because it let any prefetch,
+  // crawler, or <img>/link trigger a full database wipe with no credentials.
   app.post('/api/reset', async (req, res) => {
+    const user = getAuthUser(req);
+    if (!user || user.role !== UserRole.SUPERADMIN) {
+      return res.status(403).json({ error: 'Forbidden. Superadmin only.' });
+    }
     await dbStore.reset();
     res.json({ success: true, message: 'Database reset to fresh seed data.' });
-  });
-
-  // Also accept GET for easy browser-bar reset
-  app.get('/api/reset', async (req, res) => {
-    await dbStore.reset();
-    res.json({ success: true, message: 'Database reset to fresh seed data. Navigate back to / to continue.' });
   });
 
   // ══════════════════════════════════════════

--- a/backend/src/reseed.ts
+++ b/backend/src/reseed.ts
@@ -1,0 +1,24 @@
+// Offline database (re)seed — the bootstrap companion to the now-superadmin-only
+// POST /api/reset.
+//
+// It wipes every collection and re-seeds from getSeedData() (the canonical demo
+// dataset), which includes bcrypt password hashes for the seed accounts. Use this
+// to initialize a fresh deployment, or to recover login on an older database whose
+// users predate the password-hash change — a case the HTTP reset can no longer
+// handle, since it now requires a superadmin who wouldn't yet be able to log in.
+//
+//   cd backend && MONGODB_URI=... npm run reseed
+import 'dotenv/config';
+import { connectDB, dbStore } from './db';
+
+async function main() {
+  await connectDB();
+  await dbStore.reset();
+  console.log('[reseed] Database reset and seeded from getSeedData() (with password hashes).');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[reseed] Failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem (critical)
`POST /api/reset` **and** `GET /api/reset` both wiped and re-seeded the entire database with **no authentication**. Anyone could destroy all data, and the `GET` variant meant a browser prefetch, crawler, or an `<img>`/link could trigger a full wipe with a single request.

## Fix
- `POST /api/reset` now requires an **authenticated superadmin** (same guard pattern as the other superadmin-only endpoints).
- `GET /api/reset` is **removed entirely** — a state-changing wipe must never be reachable via GET.

## Bootstrap companion (`npm run reseed`)
Guarding the endpoint creates a bootstrap gap: a fresh DB (or an older one whose users predate the `passwordHash` change) can no longer seed itself over HTTP, because the reset now needs a superadmin who can't yet log in. So this PR adds an **offline** `npm run reseed` (`backend/src/reseed.ts`) that calls `dbStore.reset()` directly — seeding the canonical demo dataset **including bcrypt password hashes**, so seeded accounts can log in.

> Note: the existing `npm run seed` (`seed.ts`) builds its own user set **without** `passwordHash`, so it does not produce loginable accounts post-auth-hardening. `npm run reseed` is the login-capable seed path. Aligning `seed.ts` is a separate follow-up.

## Files
- `backend/src/index.ts` — superadmin guard on POST, GET route removed.
- `backend/src/reseed.ts` — new offline reseed script.
- `backend/package.json` — `"reseed"` script.

## Verification
Type-check: `npm run lint` → **5 → 5** (zero new; pre-existing baseline).

End-to-end (backend against a throwaway DB seeded via `npm run reseed`):
| Case | Result |
|---|---|
| `GET /api/reset` | ✅ **404** (route removed) |
| `POST /api/reset` no auth | ✅ **403** |
| `POST /api/reset` as teacher | ✅ **403** |
| `POST /api/reset` as superadmin | ✅ **200** |
| DB still seeded after superadmin reset | ✅ 62 users |
| `npm run reseed` (offline) | ✅ seeds 62 users, superadmin has bcrypt hash |

Closes AUDIT.md P0-3 (open `/api/reset`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)