### PR TITLE
fix: make Python evaluation pipeline runnable (python3 + correct dir) and injection-safe

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(__dirname, '..');
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 
+// Python evaluation pipeline: interpreter + location (the pipeline lives in ai-services/,
+// a sibling of backend/). Both overridable by env for non-standard deployments.
+const PYTHON_BIN = process.env.PYTHON_BIN || 'python3';
+const AI_SERVICES_DIR = process.env.AI_SERVICES_DIR || path.resolve(ROOT_DIR, '..', 'ai-services');
+
 // --- Auth config (signed JWTs) ---
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-insecure-secret-change-me';
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
@@ -597,7 +602,7 @@ async function startServer() {
 
     // Connect to Python Evaluation Metrics Pipeline
     const dateStr = new Date().toISOString().split('T')[0];
-    const pipelineDir = path.join(ROOT_DIR, 'evaluation_metrics');
+    const pipelineDir = AI_SERVICES_DIR;
     const responseDir = path.join(pipelineDir, 'student_responses', `class_${classNumber}`, 'phrase_1');
     fs.mkdirSync(responseDir, { recursive: true });
 
@@ -631,18 +636,20 @@ async function startServer() {
     let narrative = '';
 
     try {
-      const { execSync } = await import('child_process');
+      const { execFileSync } = await import('child_process');
       console.log(`Running evaluation pipeline for student ${student.id}...`);
-      
-      // Run the comparison, evaluation, and report card generation pipeline
-      execSync(`python run_pipeline.py ${classNumber} phrase_1 ${student.id}`, {
+
+      // Run the comparison, evaluation, and report card generation pipeline.
+      // execFile (no shell) with array args means classNumber/student.id are passed
+      // literally and can never be interpreted as shell syntax.
+      execFileSync(PYTHON_BIN, ['run_pipeline.py', String(classNumber), 'phrase_1', student.id], {
         cwd: pipelineDir,
         env: { ...process.env, PYTHONIOENCODING: 'utf-8' }
       });
 
       // If failed, run the personalized exam pipeline too
       try {
-        execSync(`python personalized_evaluation_pipeline.py ${student.id} ${classNumber} phrase_1`, {
+        execFileSync(PYTHON_BIN, ['personalized_evaluation_pipeline.py', student.id, String(classNumber), 'phrase_1'], {
           cwd: pipelineDir,
           env: { ...process.env, PYTHONIOENCODING: 'utf-8' }
         });


### PR DESCRIPTION
## Problem
The diagnostic-submit handler (`POST /api/students/:id/diagnostic/submit`) invoked the Python evaluation pipeline in a way that **could never succeed** and was **unsafe**:

1. **Wrong interpreter** — it called `python`, which doesn't exist on the deployment host (Ubuntu 24.04 ships `python3`, no bare `python`). Every run threw `python: not found` and silently fell back to Gemini.
2. **Wrong directory** — `cwd` was `path.join(ROOT_DIR, 'evaluation_metrics')` = `backend/evaluation_metrics`, which **does not exist**. The pipeline lives in the sibling **`ai-services/`** (renamed in the restructure; code never updated). So even a correct interpreter would fail on a missing cwd.
3. **Command injection** — `execSync` ran a **shell string** with `classNumber` and `student.id` interpolated in. Not exploitable with today's generated IDs, but any crafted value (import, alternate create path) would be executed by `/bin/sh`.

Either of #1/#2 alone means the real Python pipeline never runs — the whole `ai-services` classify→compare→evaluate→report stage was dead, masked by the Gemini fallback.

## Fix
- Add `PYTHON_BIN` (default `python3`) and `AI_SERVICES_DIR` (default the sibling `ai-services/`), both env-overridable.
- Point the pipeline `cwd` at `AI_SERVICES_DIR`.
- Replace both `execSync` shell strings with **`execFileSync` + array args** (no shell) — `classNumber`/`student.id` are passed literally and cannot be interpreted as shell syntax.

## Not an infra change
`python3` (3.12.3) and the only Python dep (`requests`, per `ai-services/requirements.txt`) are **already present** on the host — nothing to install. (To get *real* pipeline output rather than the Gemini fallback you still need a `GROQ_API_KEY`/`GEMINI_API_KEY` in the pipeline env, but that's a separate runtime secret.)

## Verification
- `npm run lint` → **5 → 5** (zero new; pre-existing baseline).
- On the target host, the exact fixed call
  `execFileSync('python3', ['run_pipeline.py','2','phrase_1','STD_54321'], {cwd: ai-services})`
  **launches python3 inside `ai-services/`** and reaches the script's own logic (it prints `Student response not found: …/student_responses/class_2/phrase_1/STD_54321.json` — expected, since the handler writes that input file before invoking). No `ENOENT` for interpreter or cwd → both #1 and #2 resolved; #3 resolved by construction (no shell).

Addresses AUDIT.md P2-1 (harden the Python integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)