### PR TITLE
fix: reliable headless-Chrome launch for PDF generation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,9 @@ JWT_EXPIRES_IN=7d
 # Shared password for the seeded demo accounts (stored only as a bcrypt hash).
 # Defaults to the public demo password if unset; set a private value for real deployments.
 SEED_DEMO_PASSWORD=Fln@2026
+
+# PDF generation uses headless Chrome via Puppeteer. Install the browser once with:
+#   npx puppeteer browsers install chrome
+# (plus its system libraries on Linux). Leave CHROME_EXECUTABLE_PATH unset to use
+# that managed browser, or point it at a specific Chrome/Chromium binary.
+# CHROME_EXECUTABLE_PATH=/usr/bin/chromium

--- a/backend/src/browser.ts
+++ b/backend/src/browser.ts
@@ -1,0 +1,27 @@
+import puppeteer, { Browser } from 'puppeteer';
+
+// Single place to launch headless Chrome for PDF generation.
+//
+// By default Puppeteer uses its own managed Chrome (installed with
+// `npx puppeteer browsers install chrome`, in ~/.cache/puppeteer). Set
+// CHROME_EXECUTABLE_PATH to point at a specific Chrome/Chromium binary instead.
+//
+// If the browser can't start (not installed, or missing system libraries), we
+// throw one clear, actionable error instead of a raw Puppeteer stack trace.
+export async function launchBrowser(): Promise<Browser> {
+  const executablePath = process.env.CHROME_EXECUTABLE_PATH || undefined;
+  try {
+    return await puppeteer.launch({
+      headless: true,
+      executablePath,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+  } catch (err: any) {
+    throw new Error(
+      'Failed to launch Chrome for PDF generation. Install the browser with ' +
+        '`npx puppeteer browsers install chrome` (and its system libraries), or set ' +
+        'CHROME_EXECUTABLE_PATH to a valid Chrome binary. Original error: ' +
+        (err?.message || String(err)),
+    );
+  }
+}

--- a/backend/src/paperGenerator.ts
+++ b/backend/src/paperGenerator.ts
@@ -203,14 +203,8 @@ export async function generateLevelWorksheet({
   levelId: number;
   subIdx: number;
 }): Promise<LevelWorksheetResult> {
-  const puppeteer = await import('puppeteer');
-  const CHROME_EXECUTABLE_PATH = process.env.CHROME_EXECUTABLE_PATH || undefined;
-
-  const browser = await puppeteer.default.launch({
-    headless: true,
-    executablePath: CHROME_EXECUTABLE_PATH,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
-  });
+  const { launchBrowser } = await import('./browser');
+  const browser = await launchBrowser();
 
   try {
     const page = await browser.newPage();

--- a/backend/src/worksheetRenderer.ts
+++ b/backend/src/worksheetRenderer.ts
@@ -1,7 +1,5 @@
-import puppeteer from 'puppeteer';
 import { getAdapter, MAX_SETS_PER_PAGE_LOAD } from './classAdapters';
-
-const CHROME_EXECUTABLE_PATH = process.env.CHROME_EXECUTABLE_PATH || undefined;
+import { launchBrowser } from './browser';
 
 export interface RenderedResult {
   index: number;
@@ -34,11 +32,7 @@ export async function renderBatch(
     throw new Error("studentIdentities must contain one entry for every generated worksheet.");
   }
 
-  const browser = await puppeteer.launch({
-    headless: true,
-    executablePath: CHROME_EXECUTABLE_PATH,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
-  });
+  const browser = await launchBrowser();
 
   try {
     const page = await browser.newPage();


### PR DESCRIPTION
## Problem
PDF generation (diagnostic papers via `paperGenerator.ts`, worksheet rendering via `worksheetRenderer.ts`) launched Puppeteer with **no usable Chrome**:
- `CHROME_EXECUTABLE_PATH` was unset, Puppeteer's managed Chrome was never (fully) installed, and there was no system Chrome.
- So `puppeteer.launch()` threw at runtime and **every PDF request 500'd**.
- A plain `npm install` also failed on Puppeteer's browser download (a partial/corrupt cache).

The two files also duplicated the launch config, and a failure surfaced as a raw Puppeteer stack trace.

## Fix (code)
- Add **`backend/src/browser.ts`** — a single `launchBrowser()` helper used by both `paperGenerator.ts` and `worksheetRenderer.ts` (de-duplicates the launch config). It honors `CHROME_EXECUTABLE_PATH` and, on failure, throws **one clear, actionable error** (install via `npx puppeteer browsers install chrome` / system libs / set the env var) instead of a raw stack.
- Document `CHROME_EXECUTABLE_PATH` + the browser-install step in `.env.example`.

## Provisioning (Option A — done on the deploy host)
This half is environment setup, not code:
1. `npx puppeteer browsers install chrome` → installs the version-matched build (`chrome@150.0.7871.24`).
2. Install its Linux system libraries (Ubuntu 24.04 `t64` names): `libnss3 libnspr4 libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 libatspi2.0-0t64 libxshmfence1 fonts-liberation`.

## Verification
- `npm run lint` → **5 → 5** (zero new; pre-existing baseline).
- On the host, the real `launchBrowser()` code path launches **Chrome 150.0.7871.24** and renders a PDF (**8084 bytes**).
- Error path: a bad `CHROME_EXECUTABLE_PATH` produces the actionable *"Failed to launch Chrome for PDF generation. Install the browser with `npx puppeteer browsers install chrome`…"* message.

Addresses the Puppeteer/Chromium gap noted across AUDIT.md / prior notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)