### PR TITLE
fix: base-path-aware API/asset URLs (support /fln subpath without patching)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from './services/apiClient';
 /**
  * @license
  * SPDX-License-Identifier: Apache-2.0
@@ -42,7 +43,7 @@ export default function App() {
       if (!token) return;
 
       try {
-        const res = await fetch('/api/auth/me', {
+        const res = await apiFetch('/api/auth/me', {
           headers: { Authorization: `Bearer ${token}` },
         });
 

--- a/frontend/src/components/BaselineUpload.tsx
+++ b/frontend/src/components/BaselineUpload.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 import React, { useState } from 'react';
 import { ArrowLeft, Upload, FileJson, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react';
 import { Student } from '../types';
@@ -66,7 +67,7 @@ export const BaselineUpload: React.FC<BaselineUploadProps> = ({ student, token, 
     setError('');
     setResult(null);
     try {
-      const res = await fetch(`/api/students/${student.id}/baseline/submit`, {
+      const res = await apiFetch(`/api/students/${student.id}/baseline/submit`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
         body: JSON.stringify({ classNumber, studentName: student.name, answers })

--- a/frontend/src/components/BulkDiagnosticWorkflow.tsx
+++ b/frontend/src/components/BulkDiagnosticWorkflow.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { UserRole } from '../types';
 import { FileText, Download, Clock, AlertCircle, CheckCircle2, XCircle } from 'lucide-react';
@@ -32,7 +33,7 @@ export const BulkDiagnosticWorkflow: React.FC<BulkDiagnosticWorkflowProps> = ({ 
     if (!job || job.status !== 'running') return;
     const interval = setInterval(async () => {
       try {
-        const res = await fetch(`/api/diagnostic/bulk/${job.jobId}/progress`);
+        const res = await apiFetch(`/api/diagnostic/bulk/${job.jobId}/progress`);
         if (res.ok) {
           const data = await res.json();
           setJob(data);
@@ -66,7 +67,7 @@ export const BulkDiagnosticWorkflow: React.FC<BulkDiagnosticWorkflowProps> = ({ 
     setJob(null);
 
     try {
-      const res = await fetch('/api/diagnostic/bulk', {
+      const res = await apiFetch('/api/diagnostic/bulk', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/DiagnosticWorkflow.tsx
+++ b/frontend/src/components/DiagnosticWorkflow.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 import React, { useState } from 'react';
 import { Student, Question, EvaluationReport } from '../types';
 import { SvgLibraryResolver } from './SvgLibraryResolver';
@@ -21,7 +22,7 @@ export const DiagnosticWorkflow: React.FC<DiagnosticWorkflowProps> = ({ student,
     setLoading(true);
     setError('');
     try {
-      const res = await fetch(`/api/students/${student.id}/diagnostic`, {
+      const res = await apiFetch(`/api/students/${student.id}/diagnostic`, {
         method: 'POST',
         headers: { 'Authorization': `Bearer ${token}` }
       });
@@ -53,7 +54,7 @@ export const DiagnosticWorkflow: React.FC<DiagnosticWorkflowProps> = ({ student,
     setLoading(true);
     setError('');
     try {
-      const res = await fetch(`/api/students/${student.id}/diagnostic/submit`, {
+      const res = await apiFetch(`/api/students/${student.id}/diagnostic/submit`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/IcrScanner.tsx
+++ b/frontend/src/components/IcrScanner.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { Student, ClassGroup, Question, EvaluationReport, User } from '../types';
 
@@ -30,8 +31,8 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
     const fetchData = async () => {
       try {
         const [clsRes, stdRes] = await Promise.all([
-          fetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } }),
-          fetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } })
+          apiFetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } }),
+          apiFetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } })
         ]);
         if (clsRes.ok) {
           const clsData = await clsRes.json();
@@ -61,7 +62,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
     setLoading(true);
     setError('');
     try {
-      const res = await fetch(`/api/students/${selectedStudent.id}/diagnostic`, {
+      const res = await apiFetch(`/api/students/${selectedStudent.id}/diagnostic`, {
         method: 'POST',
         headers: { 'Authorization': `Bearer ${token}` }
       });
@@ -131,7 +132,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
     setLoading(true);
     setError('');
     try {
-      const res = await fetch(`/api/students/${selectedStudent.id}/diagnostic/submit`, {
+      const res = await apiFetch(`/api/students/${selectedStudent.id}/diagnostic/submit`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/LandingView.tsx
+++ b/frontend/src/components/LandingView.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 /**
  * @license
  * SPDX-License-Identifier: Apache-2.0
@@ -44,7 +45,7 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
     const interval = 2000;
 
     const fetchStats = () => {
-      fetch('/api/stats')
+      apiFetch('/api/stats')
         .then(r => { if (!r.ok) throw new Error(); return r.json(); })
         .then(d => { setStats(d); setStatsLoading(false); })
         .catch(() => {

--- a/frontend/src/components/LogbookView.tsx
+++ b/frontend/src/components/LogbookView.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { LogEntry, UserRole, User, School } from '../types';
 import { Download, Search, SlidersHorizontal } from 'lucide-react';
@@ -22,7 +23,7 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ token, user }) => {
   // Fetch logbook entries
   const fetchLogs = async () => {
     try {
-      const res = await fetch('/api/logbook', {
+      const res = await apiFetch('/api/logbook', {
         headers: { 'Authorization': `Bearer ${token}` }
       });
       const data = await res.json();
@@ -37,7 +38,7 @@ export const LogbookView: React.FC<LogbookViewProps> = ({ token, user }) => {
   // Fetch school list for geographical lookup
   const fetchSchools = async () => {
     try {
-      const res = await fetch('/api/schools');
+      const res = await apiFetch('/api/schools');
       const data = await res.json();
       if (Array.isArray(data)) {
         setSchools(data);

--- a/frontend/src/components/LoginView.tsx
+++ b/frontend/src/components/LoginView.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 /**
  * @license
  * SPDX-License-Identifier: Apache-2.0
@@ -43,7 +44,7 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
     const loginPass = customPass || password;
 
     try {
-      const res = await fetch('/api/auth/login', {
+      const res = await apiFetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: loginEmail, password: loginPass })

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { User, UserRole, Student, ClassGroup, School, EvaluationReport, LogEntry, Ticket } from '../types';
 import { Users, ShieldAlert, BookOpen, UserCheck, Calendar, ArrowRight, CheckCircle2, XCircle, SlidersHorizontal, Layers, Award, MapPin, School as SchoolIcon, BarChart3, FileText, ClipboardList, Building2, GraduationCap, BookMarked, Globe, Settings, Database, RefreshCw, Search, ChevronDown } from 'lucide-react';
@@ -206,9 +207,9 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
 
   useEffect(() => {
     const headers = { 'Authorization': `Bearer ${token}` };
-    fetch('/api/students', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiStudents(d); }).catch(() => {});
-    fetch('/api/schools', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiSchools(d); }).catch(() => {});
-    fetch('/api/admin/coordinators', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiUsers(d); }).catch(() => {});
+    apiFetch('/api/students', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiStudents(d); }).catch(() => {});
+    apiFetch('/api/schools', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiSchools(d); }).catch(() => {});
+    apiFetch('/api/admin/coordinators', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiUsers(d); }).catch(() => {});
   }, [token]);
 
   const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;

--- a/frontend/src/components/RoleDashboards.tsx
+++ b/frontend/src/components/RoleDashboards.tsx
@@ -1,3 +1,4 @@
+import { apiFetch, withBase } from '../services/apiClient';
 import React, { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { User, UserRole, Student, ClassGroup, School, LogEntry, Ticket } from '../types';
@@ -193,7 +194,7 @@ export const RegionalAnalyticsView: React.FC<{ token: string; user: User }> = ({
     setLoading(true);
     try {
       const q = `stateCode=${stateCode}&districtCode=${districtCode}&blockCode=${blockCode}`;
-      const res = await fetch(`/api/analytics?${q}`, {
+      const res = await apiFetch(`/api/analytics?${q}`, {
         headers: { 'Authorization': `Bearer ${token}` }
       });
       const d = await res.json();
@@ -560,11 +561,11 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
 
   const fetchGlobalData = async () => {
     try {
-      const schRes = await fetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
+      const schRes = await apiFetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
       const schData = await schRes.json();
       if (Array.isArray(schData)) setSchools(schData);
 
-      const statsRes = await fetch('/api/stats');
+      const statsRes = await apiFetch('/api/stats');
       const statsData = await statsRes.json();
       setStats(statsData);
     } catch (err) {
@@ -574,7 +575,7 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
 
   const fetchCoordinators = async () => {
     try {
-      const res = await fetch('/api/admin/coordinators', { headers: { 'Authorization': `Bearer ${token}` } });
+      const res = await apiFetch('/api/admin/coordinators', { headers: { 'Authorization': `Bearer ${token}` } });
       const data = await res.json();
       if (Array.isArray(data)) setCoordinatorsList(data);
     } catch (e) {
@@ -591,7 +592,7 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
     e.preventDefault();
     if (!announcementTitle || !announcementMsg) return;
     try {
-      const res = await fetch('/api/announcements/create', {
+      const res = await apiFetch('/api/announcements/create', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -620,7 +621,7 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
       : undefined;
 
     try {
-      const res = await fetch('/api/admin/create', {
+      const res = await apiFetch('/api/admin/create', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -652,7 +653,7 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
         await fetchCoordinators();
         
         // Refresh school data
-        const schRes = await fetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
+        const schRes = await apiFetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
         const schData = await schRes.json();
         if (Array.isArray(schData)) setSchools(schData);
 
@@ -674,7 +675,7 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
     setLoading(true);
 
     try {
-      const res = await fetch('/api/schools', {
+      const res = await apiFetch('/api/schools', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -698,7 +699,7 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
         setNewSchoolDistrict('');
         setNewSchoolBlock('');
         // Refresh school list
-        const schRes = await fetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
+        const schRes = await apiFetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
         const schData = await schRes.json();
         if (Array.isArray(schData)) setSchools(schData);
         setTimeout(() => setSchoolSuccess(''), 6000);
@@ -758,7 +759,7 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
         <button
           onClick={async () => {
             if (!window.confirm('Reset all database data to fresh seed state? This is irreversible.')) return;
-            await fetch('/api/reset', { method: 'POST' });
+            await apiFetch('/api/reset', { method: 'POST' });
             window.location.reload();
           }}
           className="px-3 py-1.5 text-xs font-mono font-bold rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-300 hover:bg-red-100 dark:hover:bg-red-900 transition-colors"
@@ -1177,15 +1178,15 @@ export const AdminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const schRes = await fetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
+        const schRes = await apiFetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
         const schData = await schRes.json();
         if (Array.isArray(schData)) setSchools(schData);
 
-        const stdRes = await fetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
+        const stdRes = await apiFetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
         const stdData = await stdRes.json();
         if (Array.isArray(stdData)) setStudents(stdData);
 
-        const uRes = await fetch('/api/admin/coordinators', { headers: { 'Authorization': `Bearer ${token}` } });
+        const uRes = await apiFetch('/api/admin/coordinators', { headers: { 'Authorization': `Bearer ${token}` } });
         const uData = await uRes.json();
         if (Array.isArray(uData)) setAllUsers(uData);
       } catch (err) {
@@ -1432,7 +1433,7 @@ export const AdminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
 
                   const handleRestore = async () => {
                     try {
-                      const res = await fetch('/api/admin/restore-school', {
+                      const res = await apiFetch('/api/admin/restore-school', {
                         method: 'POST',
                         headers: {
                           'Content-Type': 'application/json',
@@ -1443,11 +1444,11 @@ export const AdminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
                       if (res.ok) {
                         alert(`School access restored for ${sch.name}.`);
                         // Refresh data
-                        const schRes = await fetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
+                        const schRes = await apiFetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
                         const schData = await schRes.json();
                         if (Array.isArray(schData)) setSchools(schData);
                         
-                        const uRes = await fetch('/api/admin/coordinators', { headers: { 'Authorization': `Bearer ${token}` } });
+                        const uRes = await apiFetch('/api/admin/coordinators', { headers: { 'Authorization': `Bearer ${token}` } });
                         const uData = await uRes.json();
                         if (Array.isArray(uData)) setAllUsers(uData);
                       } else {
@@ -1506,7 +1507,7 @@ export const AdminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
 
                   const handleRevive = async () => {
                     try {
-                      const res = await fetch('/api/admin/revive-teacher', {
+                      const res = await apiFetch('/api/admin/revive-teacher', {
                         method: 'POST',
                         headers: {
                           'Content-Type': 'application/json',
@@ -1517,11 +1518,11 @@ export const AdminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
                       if (res.ok) {
                         alert(`Teacher ${tch.name} revived. Suspension released.`);
                         // Refresh data
-                        const schRes = await fetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
+                        const schRes = await apiFetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
                         const schData = await schRes.json();
                         if (Array.isArray(schData)) setSchools(schData);
                         
-                        const uRes = await fetch('/api/admin/coordinators', { headers: { 'Authorization': `Bearer ${token}` } });
+                        const uRes = await apiFetch('/api/admin/coordinators', { headers: { 'Authorization': `Bearer ${token}` } });
                         const uData = await uRes.json();
                         if (Array.isArray(uData)) setAllUsers(uData);
                       } else {
@@ -1581,11 +1582,11 @@ export const SchoolDashboard: React.FC<DashboardProps> = ({ user, token }) => {
 
   const fetchSchoolData = async () => {
     try {
-      const clsRes = await fetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } });
+      const clsRes = await apiFetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } });
       const clsData = await clsRes.json();
       if (Array.isArray(clsData)) setClasses(clsData);
 
-      const stdRes = await fetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
+      const stdRes = await apiFetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
       const stdData = await stdRes.json();
       if (Array.isArray(stdData)) setStudents(stdData);
     } catch (err) {
@@ -1717,7 +1718,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
     setLevelPdfLoading(true);
     setLevelPdfError('');
     try {
-      const res = await fetch('/api/worksheets/generate-level-pdf', {
+      const res = await apiFetch('/api/worksheets/generate-level-pdf', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1753,7 +1754,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
     setLevelBatchSkipped([]);
     setLevelBatchId(null);
     try {
-      const res = await fetch('/api/worksheets/generate-level-batch', {
+      const res = await apiFetch('/api/worksheets/generate-level-batch', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1783,7 +1784,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
     if (!levelBatchId) return;
     setLevelBatchDownloading(true);
     try {
-      const res = await fetch(`/api/worksheets/download-batch/${levelBatchId}`);
+      const res = await apiFetch(`/api/worksheets/download-batch/${levelBatchId}`);
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         throw new Error(data.error || 'Download failed.');
@@ -1806,14 +1807,14 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
 
   const fetchTeacherData = async () => {
     try {
-      const clsRes = await fetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } });
+      const clsRes = await apiFetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } });
       const clsData = await clsRes.json();
       if (Array.isArray(clsData)) {
         setClasses(clsData);
         if (clsData.length > 0) setActiveClass(clsData[0]);
       }
 
-      const stdRes = await fetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
+      const stdRes = await apiFetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
       const stdData = await stdRes.json();
       if (Array.isArray(stdData)) setStudents(stdData);
     } catch (err) {
@@ -1830,7 +1831,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
     if (!bulkJob || bulkJob.status !== 'running') return;
     const interval = setInterval(async () => {
       try {
-        const res = await fetch(`/api/diagnostic/bulk/${bulkJob.jobId}/progress`);
+        const res = await apiFetch(`/api/diagnostic/bulk/${bulkJob.jobId}/progress`);
         if (res.ok) {
           const data = await res.json();
           setBulkJob(prev => prev ? { ...prev, completed: data.completed, status: data.status, pdfUrl: data.pdfUrl || prev.pdfUrl, downloadUrl: data.downloadUrl || prev.downloadUrl, error: data.error || '' } : prev);
@@ -1865,7 +1866,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
     const finalSection = activeClass ? activeClass.section : sec;
 
     try {
-      const res = await fetch('/api/students', {
+      const res = await apiFetch('/api/students', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -2157,7 +2158,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
                     setBulkError('');
                     setBulkJob(null);
                     try {
-                      const res = await fetch('/api/diagnostic/bulk', {
+                      const res = await apiFetch('/api/diagnostic/bulk', {
                         method: 'POST',
                         headers: {
                           'Content-Type': 'application/json',
@@ -2403,7 +2404,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
                           Print L{s.currentLevel}.{s.currentSubLevel || 0}
                         </button>
                         <a
-                          href={`/worksheets/levels_main.html?level=${s.currentLevel}&sub=${s.currentSubLevel || 0}`}
+                          href={withBase(`/worksheets/levels_main.html?level=${s.currentLevel}&sub=${s.currentSubLevel || 0}`)}
                           target="_blank"
                           rel="noreferrer"
                           className="bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 border border-zinc-200 dark:border-zinc-700 text-zinc-800 dark:text-zinc-200 font-mono text-[9px] font-bold px-2 py-0.5 rounded cursor-pointer transition-all active:scale-95 inline-flex items-center gap-1"
@@ -2500,7 +2501,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
     setLevelPdfLoading(true);
     setLevelPdfError('');
     try {
-      const res = await fetch('/api/worksheets/generate-level-pdf', {
+      const res = await apiFetch('/api/worksheets/generate-level-pdf', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -2523,14 +2524,14 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
 
   const fetchVolunteerData = async () => {
     try {
-      const clsRes = await fetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } });
+      const clsRes = await apiFetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } });
       const clsData = await clsRes.json();
       if (Array.isArray(clsData)) {
         setClasses(clsData);
         if (clsData.length > 0) setActiveClass(clsData[0]);
       }
 
-      const stdRes = await fetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
+      const stdRes = await apiFetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
       const stdData = await stdRes.json();
       if (Array.isArray(stdData)) setStudents(stdData);
     } catch (err) {
@@ -2547,7 +2548,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
     if (!bulkJob || bulkJob.status !== 'running') return;
     const interval = setInterval(async () => {
       try {
-        const res = await fetch(`/api/diagnostic/bulk/${bulkJob.jobId}/progress`);
+        const res = await apiFetch(`/api/diagnostic/bulk/${bulkJob.jobId}/progress`);
         if (res.ok) {
           const data = await res.json();
           setBulkJob(prev => prev ? { ...prev, completed: data.completed, status: data.status, pdfUrl: data.pdfUrl || prev.pdfUrl, downloadUrl: data.downloadUrl || prev.downloadUrl, error: data.error || '' } : prev);
@@ -2582,7 +2583,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
     const finalSection = activeClass ? activeClass.section : sec;
 
     try {
-      const res = await fetch('/api/students', {
+      const res = await apiFetch('/api/students', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -2851,7 +2852,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
                     setBulkError('');
                     setBulkJob(null);
                     try {
-                      const res = await fetch('/api/diagnostic/bulk', {
+                      const res = await apiFetch('/api/diagnostic/bulk', {
                         method: 'POST',
                         headers: {
                           'Content-Type': 'application/json',
@@ -2947,7 +2948,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
                     setLevelBulkLoading(true);
                     setLevelBulkProgress({ total: placed.length, completed: 0, errors: [] });
                     try {
-                      const res = await fetch('/api/worksheets/generate-level-batch', {
+                      const res = await apiFetch('/api/worksheets/generate-level-batch', {
                         method: 'POST',
                         headers: {
                           'Content-Type': 'application/json',
@@ -3066,7 +3067,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
                           Print L{s.currentLevel}.{s.currentSubLevel || 0}
                         </button>
                         <a
-                          href={`/worksheets/levels_main.html?level=${s.currentLevel}&sub=${s.currentSubLevel || 0}`}
+                          href={withBase(`/worksheets/levels_main.html?level=${s.currentLevel}&sub=${s.currentSubLevel || 0}`)}
                           target="_blank"
                           rel="noreferrer"
                           className="bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 border border-zinc-200 dark:border-zinc-700 text-zinc-800 dark:text-zinc-200 font-mono text-[9px] font-bold px-2 py-0.5 rounded cursor-pointer transition-all active:scale-95 inline-flex items-center gap-1"

--- a/frontend/src/components/TicketSubmission.tsx
+++ b/frontend/src/components/TicketSubmission.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { Ticket, UserRole } from '../types';
 
@@ -17,7 +18,7 @@ export const TicketSubmission: React.FC<TicketSubmissionProps> = ({ token, userR
 
   const fetchTickets = async () => {
     try {
-      const res = await fetch('/api/tickets', {
+      const res = await apiFetch('/api/tickets', {
         headers: { 'Authorization': `Bearer ${token}` }
       });
       const data = await res.json();
@@ -44,7 +45,7 @@ export const TicketSubmission: React.FC<TicketSubmissionProps> = ({ token, userR
     setLoading(true);
 
     try {
-      const res = await fetch('/api/tickets/create', {
+      const res = await apiFetch('/api/tickets/create', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -70,7 +71,7 @@ export const TicketSubmission: React.FC<TicketSubmissionProps> = ({ token, userR
 
   const handleResolve = async (ticketId: string, nextStatus: 'Reviewed' | 'Resolved') => {
     try {
-      const res = await fetch(`/api/tickets/${ticketId}/resolve`, {
+      const res = await apiFetch(`/api/tickets/${ticketId}/resolve`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/WorksheetIframeModal.tsx
+++ b/frontend/src/components/WorksheetIframeModal.tsx
@@ -1,3 +1,4 @@
+import { withBase } from '../services/apiClient';
 import React, { useEffect, useRef } from 'react';
 import { X, ExternalLink } from 'lucide-react';
 
@@ -9,12 +10,12 @@ interface WorksheetIframeModalProps {
 }
 
 const CLASS_FILE_MAP: { [key: string]: string } = {
-  'Class 1': '/worksheets/class1.html',
-  'Class 2': '/worksheets/class2.html',
-  'Class 3': '/worksheets/class3.html',
-  'Class 4': '/worksheets/class4.html',
-  'LEVEL_PERSONALIZED': '/worksheets/levels_main.html',
-  'Level Personalized': '/worksheets/levels_main.html',
+  'Class 1': withBase('/worksheets/class1.html'),
+  'Class 2': withBase('/worksheets/class2.html'),
+  'Class 3': withBase('/worksheets/class3.html'),
+  'Class 4': withBase('/worksheets/class4.html'),
+  'LEVEL_PERSONALIZED': withBase('/worksheets/levels_main.html'),
+  'Level Personalized': withBase('/worksheets/levels_main.html'),
 };
 
 export const WorksheetIframeModal: React.FC<WorksheetIframeModalProps> = ({

--- a/frontend/src/components/WorksheetWorkflow.tsx
+++ b/frontend/src/components/WorksheetWorkflow.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { ClassGroup, Worksheet, Student, AnswerSubmission, EvaluationReport } from '../types';
 import { SvgLibraryResolver } from './SvgLibraryResolver';
@@ -29,16 +30,16 @@ export const WorksheetWorkflow: React.FC<WorksheetWorkflowProps> = ({ classGroup
   // Poll/fetch worksheet for this class
   const fetchWorksheets = async () => {
     try {
-      const res = await fetch('/api/classes', {
+      const res = await apiFetch('/api/classes', {
         headers: { 'Authorization': `Bearer ${token}` }
       });
       if (res.ok) {
         // Fetch all generated worksheets
-        const wsRes = await fetch('/api/logbook', { // logbook fetches can reveal ws stats, or list directly
+        const wsRes = await apiFetch('/api/logbook', { // logbook fetches can reveal ws stats, or list directly
           headers: { 'Authorization': `Bearer ${token}` }
         });
         // Simply pull directly from DB log details or find general worksheets
-        const activeWsRes = await fetch('/api/students', { // student lists
+        const activeWsRes = await apiFetch('/api/students', { // student lists
           headers: { 'Authorization': `Bearer ${token}` }
         });
       }
@@ -50,7 +51,7 @@ export const WorksheetWorkflow: React.FC<WorksheetWorkflowProps> = ({ classGroup
     setError('');
     setSuccess('');
     try {
-      const res = await fetch('/api/worksheets/generate', {
+      const res = await apiFetch('/api/worksheets/generate', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -81,7 +82,7 @@ export const WorksheetWorkflow: React.FC<WorksheetWorkflowProps> = ({ classGroup
     setError('');
     setEvaluationResult(null);
     try {
-      const res = await fetch('/api/evaluation/submit', {
+      const res = await apiFetch('/api/evaluation/submit', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -112,7 +113,7 @@ export const WorksheetWorkflow: React.FC<WorksheetWorkflowProps> = ({ classGroup
     setPdfGenerating(true);
     setError('');
     try {
-      const res = await fetch('/api/worksheets/generate-pdf', {
+      const res = await apiFetch('/api/worksheets/generate-pdf', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,10 @@
 import axios from 'axios';
+import { withBase } from './apiClient';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api',
+  // Base-relative by default (base-aware via withBase), so it works in every
+  // deployment. Override with VITE_API_URL if needed.
+  baseURL: import.meta.env.VITE_API_URL || withBase('/api'),
   headers: { 'Content-Type': 'application/json' },
 });
 

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -1,0 +1,21 @@
+// Base-path-aware URL helpers.
+//
+// `import.meta.env.BASE_URL` is Vite's configured base: the domain root in dev
+// and at the root deployment, or the subpath (set via VITE_BASE_PATH) otherwise.
+// Routing every API/asset URL through these helpers means the same source works
+// under any deployment without hardcoding the subpath, and removes the need to
+// string-rewrite built files at deploy time.
+
+// Base with any trailing slash removed (empty string at the root deployment).
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+// Prefix an absolute app path (/api/x, /worksheets/y.html) with the base, e.g.
+// withBase('/api/stats') returns the base-relative /api/stats path.
+export function withBase(path: string): string {
+  return `${BASE}${path}`;
+}
+
+// fetch() against a base-relative app path. Drop-in replacement for fetch("/api/...").
+export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(withBase(path), init);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,11 @@ import {defineConfig} from 'vite';
 
 export default defineConfig(() => {
   return {
+    // Deployment base path. "/" at the domain root (and dev); set VITE_BASE_PATH
+    // (e.g. "/fln/") for a subpath deployment. All API/asset URLs read this via
+    // import.meta.env.BASE_URL (see src/services/apiClient.ts), so no built-file
+    // string rewriting is needed at deploy time.
+    base: process.env.VITE_BASE_PATH || '/',
     plugins: [react(), tailwindcss()],
     resolve: {
       alias: {


### PR DESCRIPTION
## Problem
Every API and asset URL in the frontend was hardcoded root-absolute — 62 `fetch('/api/...')` calls plus worksheet asset paths like `'/worksheets/x.html'`. At the domain root that works, but under the **`/fln` subpath** a page at `tenali.fun/fln/` calling `fetch('/api/x')` resolves to `tenali.fun/api/x` — it **escapes the subpath**. That's why the deploy had to string-rewrite every built file (`apply_fln_subpath.js`) on each release.

## Fix
- Add **`src/services/apiClient.ts`**: `withBase(path)` + `apiFetch(path, init)`, keyed off **`import.meta.env.BASE_URL`** (Vite's base — `/` at root/dev, `/fln/` for the subpath build). Trailing slash handled so there's no `//`.
- Route all **62** `fetch('/api...')` calls through `apiFetch`, and the worksheet iframe/anchor asset URLs through `withBase`.
- Make the axios client (`services/api.ts`, used by `coordinatorService`) base-aware too — its `baseURL` default is now `withBase('/api')` instead of a wrong `http://localhost:5000/api`.
- `vite.config.ts`: `base = process.env.VITE_BASE_PATH || '/'`, so a subpath build just sets `VITE_BASE_PATH=/fln/` — no `--base` flag and **no built-file rewriting** needed.

The same source now works at the root and under any subpath with zero patching.

## Verification (on the Linux deploy platform)
- `tsc --noEmit` (frontend): **0 errors**.
- **Subpath build** (`VITE_BASE_PATH=/fln/`): builds clean; `index.html` → `src="/fln/assets/..."`; the `/fln/` base is baked into the bundle, so `apiFetch('/api/x')` resolves to `/fln/api/x` at runtime.
- **Root build** (default): builds clean; `index.html` → `src="/assets/..."`; no `/fln` in the bundle → `apiFetch('/api/x')` resolves to `/api/x`.

## Deploy follow-up (not in this PR)
Once merged, the `/fln` server deploy can drop the `apply_fln_subpath.js` patch step and instead build with `VITE_BASE_PATH=/fln/` (nginx already strips `/fln` before proxying, so `/fln/api/*` → backend `/api/*`).

Addresses AUDIT.md's subpath-routing / hardcoded-URL notes (final audit item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)