### PR TITLE
fix: improve dev backend startup reliability

### DIFF
--- a/scripts/dev-backend.js
+++ b/scripts/dev-backend.js
@@ -1,4 +1,5 @@
 const { spawn } = require('child_process');
+const fs = require('fs');
 const net = require('net');
 const path = require('path');
 
@@ -7,6 +8,26 @@ const levelsBackend = path.resolve(root, 'backend', 'fln-backend');
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const spawnOptions = { stdio: 'inherit', shell: process.platform === 'win32' };
 const processes = [];
+const args = new Set(process.argv.slice(2));
+
+const startMain = !args.has('--levels-only');
+const startLevels = !args.has('--main-only');
+const mainPort = readPort('MAIN_API_PORT', 3000);
+const levelsPort = readPort('LEVELS_API_PORT', 4000);
+
+let isShuttingDown = false;
+
+function readPort(envName, fallback) {
+  const raw = process.env[envName];
+  if (!raw) return fallback;
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`Invalid ${envName}="${raw}". Expected an integer between 1 and 65535.`);
+  }
+
+  return parsed;
+}
 
 function isPortInUse(port) {
   return new Promise((resolve, reject) => {
@@ -19,34 +40,69 @@ function isPortInUse(port) {
   });
 }
 
-function stopAll() {
-  for (const child of processes) if (!child.killed) child.kill();
+function hasPackageJson(folderPath) {
+  return fs.existsSync(path.join(folderPath, 'package.json'));
 }
 
-process.on('SIGINT', stopAll);
-process.on('SIGTERM', stopAll);
-function watch(child) {
-  child.on('exit', (code) => {
-  if (code && code !== 0) {
-    stopAll();
-    process.exitCode = code;
+function stopAll(signal = 'SIGTERM') {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
+  for (const child of processes) {
+    if (!child.killed) {
+      child.kill(signal);
+    }
   }
+}
+
+process.on('SIGINT', () => stopAll('SIGINT'));
+process.on('SIGTERM', () => stopAll('SIGTERM'));
+
+function watch(name, child) {
+  child.on('exit', (code) => {
+    if (code && code !== 0) {
+      console.error(`[dev-backend] ${name} exited with code ${code}. Stopping all services.`);
+      stopAll();
+      process.exitCode = code;
+    }
   });
 }
 
+function spawnService(name, commandArgs, cwd) {
+  console.log(`[dev-backend] Starting ${name}...`);
+  const child = spawn(npm, commandArgs, { ...spawnOptions, cwd });
+  processes.push(child);
+  watch(name, child);
+}
+
 async function main() {
-  if (await isPortInUse(3000)) {
-    console.log('Main API already running on port 3000; starting only the levels backend.');
-  } else {
-    processes.push(spawn(npm, ['run', 'dev', '--workspace', '@fln/backend'], { ...spawnOptions, cwd: root }));
+  if (!startMain && !startLevels) {
+    throw new Error('Nothing to start. Remove conflicting flags and try again.');
   }
 
-  if (await isPortInUse(4000)) {
-    console.log('Levels backend already running on port 4000.');
-  } else {
-    processes.push(spawn(npm, ['run', 'dev'], { ...spawnOptions, cwd: levelsBackend }));
+  if (startMain) {
+    if (await isPortInUse(mainPort)) {
+      console.log(`[dev-backend] Main API already running on port ${mainPort}.`);
+    } else {
+      spawnService('main backend', ['run', 'dev', '--workspace', '@fln/backend'], root);
+    }
   }
-  processes.forEach(watch);
+
+  if (startLevels) {
+    if (!hasPackageJson(levelsBackend)) {
+      throw new Error(`Levels backend is missing package.json at ${levelsBackend}`);
+    }
+
+    if (await isPortInUse(levelsPort)) {
+      console.log(`[dev-backend] Levels backend already running on port ${levelsPort}.`);
+    } else {
+      spawnService('levels backend', ['run', 'dev'], levelsBackend);
+    }
+  }
+
+  if (processes.length === 0) {
+    console.log('[dev-backend] No services were started (ports already in use or disabled by flags).');
+  }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

This PR improves the reliability of the local development startup script by adding validation, configurable startup options, and better process management.

## Changes Made

- Added configurable ports using `MAIN_API_PORT` and `LEVELS_API_PORT` environment variables.
- Added support for `--main-only` and `--levels-only` startup flags.
- Added validation to ensure the levels backend contains a valid `package.json` before startup.
- Refactored service startup into a reusable `spawnService()` helper.
- Improved startup logging for better developer experience.
- Added graceful shutdown protection to prevent duplicate termination.
- Improved error reporting when development services fail to start.

## Benefits

- Makes the development workflow more reliable.
- Prevents invalid startup configurations.
- Improves debugging with clearer startup and error messages.
- Allows developers to start only the required backend service.
- Reduces duplicate startup and shutdown logic.

## Testing

- Verified default startup flow.
- Tested custom port configuration using environment variables.
- Tested `--main-only` and `--levels-only` flags.
- Verified validation when the levels backend configuration is invalid.
- Confirmed existing startup behavior remains unchanged.