### PR TITLE
Remove password complexity check from login

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -111,14 +111,6 @@ async function startServer() {
       return res.status(400).json({ error: 'Email and password are required.' });
     }
 
-    // Verify Password Rules (§3.2 A-3)
-    const hasUppercase = /[A-Z]/.test(password);
-    const hasNumber = /[0-9]/.test(password);
-    const hasSpecial = /[!@#$%^&*(),.?":{}|<>]/.test(password);
-    if (password.length < 8 || !hasUppercase || !hasNumber || !hasSpecial) {
-      return res.status(400).json({ error: 'Password does not meet complexity requirements.' });
-    }
-
     // Check if the user is preloaded
     const users = await dbStore.getUsers();
     const user = users.find(u => u.email.toLowerCase() === email.toLowerCase());


### PR DESCRIPTION
## Summary
- Login re-validated password complexity (uppercase/number/special/length) on every request, not just at account creation
- This would lock out existing users retroactively if the complexity policy ever changed
- Removed the check from login; it's already enforced at registration

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Log in with an existing seeded account and confirm it succeeds