### PR TITLE
Resolve baseline TypeScript errors

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -292,6 +292,7 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   students: 'students',
   questions: 'questions',
   worksheets: 'worksheets',
+  levelWorksheets: 'levelWorksheets',
   answerSubmissions: 'answer_submissions',
   evaluationReports: 'evaluation_reports',
   tickets: 'tickets',

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": [
-      "ES2022"
+      "ES2022",
+      "DOM"
     ],
     "types": [
       "node"


### PR DESCRIPTION
## Summary
- `db.ts`: `COLLECTION_NAMES` was missing the `levelWorksheets` key required by `Record<keyof DatabaseSchema, string>`
- `paperGenerator.ts`: the `page.evaluate()` callbacks run inside a real browser (Puppeteer) context and reference `document`/`HTMLInputElement`, which the Node-only `"ES2022"` lib doesn't declare — added `"DOM"` to `tsconfig.json`'s `lib`

Clears all 5 pre-existing `tsc --noEmit` errors; no new errors introduced.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors (was 5)