### PR TITLE
Fix backend build:backend crash (import.meta.url in CJS output)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "dev:old": "tsx src/index.ts",
     "dev:new": "tsx src/server.ts",
     "dev": "concurrently -n old,new -c yellow,cyan \"npm run dev:old\" \"npm run dev:new\"",
-    "build": "esbuild src/index.ts --bundle --platform=node --format=cjs --packages=external --sourcemap --outfile=dist/server.cjs",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=cjs --packages=external --sourcemap --outfile=dist/server.cjs --banner:js=\"const __im_url = require('url').pathToFileURL(__filename).href;\" --define:import.meta.url=__im_url",
     "start": "node dist/server.cjs",
     "lint": "tsc --noEmit",
     "seed": "tsx src/seed.ts",


### PR DESCRIPTION
## Summary
- `npm run build:backend` (plain esbuild → CJS) left `import.meta.url` undefined at runtime, which crashes `classAdapters.ts`/`worksheetRenderer.ts`/`paperGenerator.ts` at module init (`fileURLToPath(undefined)`) — the stock build ships a dead server
- This was previously only worked around by a manual build script kept on the deploy server, never fixed upstream
- Baked the same `--banner:js`/`--define:import.meta.url` shim into `backend/package.json`'s `build` script so the default build works out of the box

## Test plan
- [x] `npm run build` (backend) — no more esbuild "import.meta" warning
- [x] `node dist/server.cjs` boots past module init without the `ERR_INVALID_ARG_TYPE`/`fileURLToPath(undefined)` crash (reproduced the crash first on stock build, confirmed fixed after)
- [x] `npx tsc --noEmit` — 0 errors