### PR TITLE
Restrict admin data scope by geography

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -435,6 +435,19 @@ async function startServer() {
     if (user.role === UserRole.VOLUNTEER) {
       return res.json(maskedStudents.filter(s => user.assignedSchools?.includes(s.schoolId)));
     }
+    if (user.role === UserRole.ADMIN || user.role === UserRole.DISTRICT_ADMIN || user.role === UserRole.BLOCK_ADMIN) {
+      // Geo-scope by the admin's own state/district/block, joined via each student's school.
+      const schools = await dbStore.getSchools();
+      const schoolById = new Map(schools.map(sc => [sc.id, sc]));
+      const geoFiltered = maskedStudents.filter(s => {
+        const school = schoolById.get(s.schoolId);
+        if (!school) return false;
+        if (user.role === UserRole.ADMIN) return school.stateCode === user.stateCode;
+        if (user.role === UserRole.DISTRICT_ADMIN) return school.districtCode === user.districtCode;
+        return school.blockCode === user.blockCode; // BLOCK_ADMIN
+      });
+      return res.json(geoFiltered);
+    }
 
     res.json(maskedStudents);
   });


### PR DESCRIPTION
## Summary
- `GET /api/students` scoped school/teacher/volunteer roles to their own school(s), but state/district/block admins fell through to an unfiltered `res.json(maskedStudents)` — every admin saw every student nationwide
- Joined each student to its `School` record (which has `stateCode`/`districtCode`/`blockCode`) and filtered: state admins → own state, district admins → own district, block admins → own block
- Superadmin unchanged (unrestricted by design)

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] Seeded a scratch DB (2 states worth of full hierarchy: 36 states → 1440 schools → 86,400 students) and hit `/api/students` as three different admin roles:
  - State admin (`admin.ap@fln.org`) → 2,400 students, all `AP_*` (was 86,400/all states before this fix)
  - District admin (`district.gnt@fln.org`) → 1,200 students, all `AP_GNT_*`
  - Block admin (`block.gnt_01@fln.org`) → 600 students, all `AP_GNT_GNT_01_*`