### PR TITLE
Improve frontend API client resilience

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { apiFetch } from './services/apiClient';
+import { apiFetch, UNAUTHORIZED_EVENT } from './services/apiClient';
 /**
  * @license
  * SPDX-License-Identifier: Apache-2.0
@@ -39,13 +39,14 @@ export default function App() {
   };
 
   useEffect(() => {
+    let cancelled = false;
+
     const checkSession = async () => {
       if (!token) return;
 
       try {
-        const res = await apiFetch('/api/auth/me', {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const res = await apiFetch('/api/auth/me');
+        if (cancelled) return;
 
         if (!res.ok) {
           setToken(null);
@@ -55,9 +56,11 @@ export default function App() {
         }
 
         const data = await res.json();
+        if (cancelled) return;
         setCurrentUser(data.user);
         setCurrentView('dashboard');
       } catch {
+        if (cancelled) return;
         setToken(null);
         localStorage.removeItem('fln_token');
         setCurrentView('home');
@@ -65,7 +68,19 @@ export default function App() {
     };
 
     checkSession();
+    return () => {
+      cancelled = true;
+    };
   }, [token]);
+
+  // Centralized session-expiry handling: apiFetch dispatches this event on any
+  // 401 response (from any component), so a mid-session expired/invalid token
+  // logs the user out once here instead of every call site handling it itself.
+  useEffect(() => {
+    const onUnauthorized = () => handleLogout();
+    window.addEventListener(UNAUTHORIZED_EVENT, onUnauthorized);
+    return () => window.removeEventListener(UNAUTHORIZED_EVENT, onUnauthorized);
+  }, []);
 
   const handleLoginSuccess = (newToken: string, user: User) => {
     setToken(newToken);

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -15,7 +15,59 @@ export function withBase(path: string): string {
   return `${BASE}${path}`;
 }
 
+const DEFAULT_TIMEOUT_MS = 15000;
+
+// Fired when a request comes back 401 (expired/invalid token), so App.tsx can
+// react centrally (clear the stored token, drop back to the login view)
+// instead of every caller having to notice and handle it individually.
+export const UNAUTHORIZED_EVENT = 'fln:unauthorized';
+
+export interface ApiFetchOptions extends RequestInit {
+  timeoutMs?: number;
+}
+
 // fetch() against a base-relative app path. Drop-in replacement for fetch("/api/...").
-export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
-  return fetch(withBase(path), init);
+// Adds, centrally for every call site:
+// - a default request timeout (aborts + rejects instead of hanging forever)
+// - the stored auth token, if the caller didn't already set an Authorization header
+// - a one-shot 'fln:unauthorized' event on a 401, so session expiry is handled once,
+//   not re-implemented at every call site
+// Callers may still pass their own `signal` (e.g. an AbortController tied to a
+// component's unmount) — it's combined with the internal timeout, so either one
+// aborts the request.
+export function apiFetch(path: string, init: ApiFetchOptions = {}): Promise<Response> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: callerSignal, headers, ...rest } = init;
+
+  const timeoutController = new AbortController();
+  const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
+
+  const signal = timeoutController.signal;
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      timeoutController.abort();
+    } else {
+      callerSignal.addEventListener('abort', () => timeoutController.abort(), { once: true });
+    }
+  }
+
+  const mergedHeaders = new Headers(headers);
+  if (!mergedHeaders.has('Authorization')) {
+    const token = localStorage.getItem('fln_token');
+    if (token) mergedHeaders.set('Authorization', `Bearer ${token}`);
+  }
+
+  return fetch(withBase(path), { ...rest, headers: mergedHeaders, signal })
+    .then(res => {
+      if (res.status === 401) {
+        window.dispatchEvent(new CustomEvent(UNAUTHORIZED_EVENT));
+      }
+      return res;
+    })
+    .catch(err => {
+      if (timeoutController.signal.aborted && !callerSignal?.aborted) {
+        throw new Error(`Request to ${path} timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    })
+    .finally(() => clearTimeout(timer));
 }


### PR DESCRIPTION
## Summary
`apiFetch` (the shared wrapper used by ~60 fetch call sites) had none of: a request timeout, centralized 401/error handling, or a consistent way to attach the auth token. Each caller repeated its own `Authorization` header, and a hung request or a mid-session expired token was handled inconsistently (or not at all) per component.

- `apiFetch` now applies a 15s default timeout via `AbortController` (overridable per call, and combinable with a caller-supplied `signal` for future unmount-cancellation), and auto-attaches the stored `fln_token` as a Bearer header when the caller didn't already set one.
- On any 401 response, `apiFetch` dispatches a `fln:unauthorized` window event once; `App.tsx` listens centrally and logs the user out, instead of every component having to notice and handle session expiry itself.
- Added an unmount guard to `App.tsx`'s session-check effect (the most central fetch in the app) so a slow `/api/auth/me` response can't call `setState` after the component has unmounted.

`apiFetch`'s signature/return type (`Promise<Response>`) is unchanged, so all ~60 existing call sites keep working without modification — this is scoped to the shared client, not a call-site-by-call-site rewrite (that's a much larger, separate effort).

## Test plan
- [x] `npx tsc --noEmit` (both frontend and backend) — 0 errors
- [x] `vite build` — succeeds cleanly
- [x] Behavioral test of the exact `apiFetch` logic (timeout/abort, auto-auth-header, 401-event dispatch) — 6/6 checks pass:
  - auto-attaches `Authorization` from stored token when not set
  - does not override an explicitly-set `Authorization` header
  - dispatches `fln:unauthorized` on 401, not on 200
  - a slow request times out and rejects with a clear timeout message
  - a caller-initiated abort (future unmount-cancellation) is not mislabeled as a timeout