### PR TITLE
Fix stale demo-account emails on the login page

### DIFF
--- a/frontend/src/components/LoginView.tsx
+++ b/frontend/src/components/LoginView.tsx
@@ -28,11 +28,11 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
     { label: 'Rajasthan Admin 🏰', email: 'admin.rj@fln.org', pass: 'Fln@2026' },
     { label: 'Ludhiana Dist 🏢', email: 'district.ldh@fln.org', pass: 'Fln@2026' },
     { label: 'Ambala Dist 🏢', email: 'district.amb@fln.org', pass: 'Fln@2026' },
-    { label: 'Ludhiana Block 🏫', email: 'block.ldh-01@fln.org', pass: 'Fln@2026' },
-    { label: 'Punjab Principal 🎓', email: 'gps-mt-001@fln.org', pass: 'Fln@2026' },
-    { label: 'Haryana Teacher 👩‍🏫', email: 'gps-amb-003.t01@fln.org', pass: 'Fln@2026' },
-    { label: 'Punjab Volunteer 🤝', email: 'vol.rahul@fln.org', pass: 'Fln@2026' },
-    { label: 'Haryana Volunteer 🤝', email: 'vol.hr_vipin@fln.org', pass: 'Fln@2026' }
+    { label: 'Ludhiana Block 🏫', email: 'block.ldh_01@fln.org', pass: 'Fln@2026' },
+    { label: 'Punjab Principal 🎓', email: 'school.pb_ldh_ldh_01_01@fln.org', pass: 'Fln@2026' },
+    { label: 'Haryana Teacher 👩‍🏫', email: 'teacher.hr_amb_amb_01_01.c2@fln.org', pass: 'Fln@2026' },
+    { label: 'Punjab Volunteer 🤝', email: 'vol.pb_ldh_ldh_01_03@fln.org', pass: 'Fln@2026' },
+    { label: 'Haryana Volunteer 🤝', email: 'vol.hr_amb_amb_01_03@fln.org', pass: 'Fln@2026' }
   ];
 
   const handleLogin = async (e?: React.FormEvent, customEmail?: string, customPass?: string) => {


### PR DESCRIPTION
## Summary
Follow-up to #104 (already merged, which didn't include this commit — pushed after that PR was merged).

The one-click demo credentials in `LoginView.tsx` predate the current `seed.ts` and no longer matched its actual email format:
- Block admin used a hyphen instead of an underscore (`block.ldh-01` vs `block.ldh_01`)
- Principal/teacher/volunteer entries used an entirely different, no-longer-seeded pattern (e.g. `gps-mt-001@fln.org` instead of `school.pb_ldh_ldh_01_01@fln.org`)

Clicking any of those five demo buttons produced "Invalid email or password".

## Test plan
- [x] `npm run lint` passes
- [x] All 12 demo-login entries verified directly against a freshly seeded local MongoDB — each resolves to a real account with the expected role

🤖 Generated with [Claude Code](https://claude.com/claude-code)