### PR TITLE
Remove hardcoded student PII; add real guardian/medical profile feature

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -90,6 +90,21 @@ export interface Student {
   aadharMasked: string; // Mandatory, unique identifier masked (§13.2 R-6)
   levelHistory: { level: number; subLevel?: number; date: string; reason: string }[];
   streak: number;
+  // Extended profile — optional, filled in by the student's own school/teacher.
+  // guardianContact and address are PII and are redacted for roles beyond
+  // superadmin/school/teacher (same treatment as aadharMasked, §13.2 R-6).
+  gender?: 'Male' | 'Female' | 'Other';
+  dob?: string;
+  guardianName?: string;
+  guardianRelation?: string;
+  guardianContact?: string;
+  address?: string;
+  bloodGroup?: string;
+  disabilityStatus?: string;
+  midDayMealBeneficiary?: boolean;
+  busRoute?: string;
+  siblingsInSchool?: string;
+  teacherNotes?: string;
 }
 
 export interface Question {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -655,6 +655,42 @@ async function startServer() {
     res.json({ success: true });
   });
 
+  // Update Student Profile (guardian/medical/logistics fields) — only the
+  // student's own school/teacher, or higher admins, may edit; kept separate
+  // from the level-update PATCH above so neither contract has to change.
+  app.patch('/api/students/:id/profile', async (req, res) => {
+    const user = getAuthUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const students = await dbStore.getStudents();
+    const student = students.find(s => s.id === req.params.id);
+    if (!student) return res.status(404).json({ error: 'Student not found.' });
+    if (!canAccessStudent(user, student)) return res.status(403).json({ error: 'Forbidden.' });
+
+    const {
+      gender, dob, guardianName, guardianRelation, guardianContact, address,
+      bloodGroup, disabilityStatus, midDayMealBeneficiary, busRoute, siblingsInSchool, teacherNotes,
+    } = req.body;
+
+    const updates: Partial<Student> = {};
+    if (gender !== undefined) updates.gender = gender;
+    if (dob !== undefined) updates.dob = dob;
+    if (guardianName !== undefined) updates.guardianName = guardianName;
+    if (guardianRelation !== undefined) updates.guardianRelation = guardianRelation;
+    if (guardianContact !== undefined) updates.guardianContact = guardianContact;
+    if (address !== undefined) updates.address = address;
+    if (bloodGroup !== undefined) updates.bloodGroup = bloodGroup;
+    if (disabilityStatus !== undefined) updates.disabilityStatus = disabilityStatus;
+    if (midDayMealBeneficiary !== undefined) updates.midDayMealBeneficiary = Boolean(midDayMealBeneficiary);
+    if (busRoute !== undefined) updates.busRoute = busRoute;
+    if (siblingsInSchool !== undefined) updates.siblingsInSchool = siblingsInSchool;
+    if (teacherNotes !== undefined) updates.teacherNotes = teacherNotes;
+
+    await dbStore.updateStudent(student.id, updates);
+
+    res.json({ success: true });
+  });
+
   // Run Onboarding AI Diagnostic Test
   app.post('/api/students/:id/diagnostic', async (req, res) => {
     const user = getAuthUser(req);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -567,7 +567,11 @@ async function startServer() {
     const user = getAuthUser(req);
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
-    const { name, age, classGroup, section, schoolId, aadharNumber } = req.body;
+    const {
+      name, age, classGroup, section, schoolId, aadharNumber,
+      gender, dob, guardianName, guardianRelation, guardianContact, address,
+      bloodGroup, disabilityStatus, midDayMealBeneficiary, busRoute, siblingsInSchool,
+    } = req.body;
     if (!name || !age || !classGroup || !section || !schoolId || !aadharNumber) {
       return res.status(400).json({ error: 'Missing required student details.' });
     }
@@ -598,7 +602,18 @@ async function startServer() {
       targetLevel: 2,
       aadharMasked: rawAadhar, // Store raw unmasked Aadhar in DB so Superadmin sees it, others get masked dynamically
       levelHistory: [],
-      streak: 0
+      streak: 0,
+      gender: gender || undefined,
+      dob: dob || undefined,
+      guardianName: guardianName || undefined,
+      guardianRelation: guardianRelation || undefined,
+      guardianContact: guardianContact || undefined,
+      address: address || undefined,
+      bloodGroup: bloodGroup || undefined,
+      disabilityStatus: disabilityStatus || undefined,
+      midDayMealBeneficiary: midDayMealBeneficiary === undefined ? undefined : Boolean(midDayMealBeneficiary),
+      busRoute: busRoute || undefined,
+      siblingsInSchool: siblingsInSchool || undefined,
     };
 
     await dbStore.addStudent(newStudent);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -517,13 +517,23 @@ async function startServer() {
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
     const students = await dbStore.getStudents();
-    
-    // Mask Aadhar for non-Superadmins (§13.2 R-6)
+
+    // Roles with a direct, day-to-day relationship to the child (and superadmin)
+    // see full contact/address PII; aggregate-scope admins and volunteers get it
+    // redacted — they don't need a guardian's phone number to view rollups.
+    const canSeeGuardianPII = (role: UserRole) =>
+      role === UserRole.SUPERADMIN || role === UserRole.SCHOOL || role === UserRole.TEACHER;
+
+    // Mask Aadhar for non-Superadmins (§13.2 R-6); redact guardian contact/address similarly.
     const maskedStudents = students.map(s => {
-      if (user.role !== UserRole.SUPERADMIN) {
-        return { ...s, aadharMasked: 'XXXX-XXXX-' + s.aadharMasked.slice(-4) };
+      const masked = user.role !== UserRole.SUPERADMIN
+        ? { ...s, aadharMasked: 'XXXX-XXXX-' + s.aadharMasked.slice(-4) }
+        : { ...s };
+      if (!canSeeGuardianPII(user.role)) {
+        delete masked.guardianContact;
+        delete masked.address;
       }
-      return s;
+      return masked;
     });
 
     if (user.role === UserRole.SUPERADMIN) {

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -1,7 +1,7 @@
 import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { User, UserRole, Student, ClassGroup, School, EvaluationReport, LogEntry, Ticket } from '../types';
-import { Users, ShieldAlert, BookOpen, UserCheck, Calendar, ArrowRight, CheckCircle2, XCircle, SlidersHorizontal, Layers, Award, MapPin, School as SchoolIcon, BarChart3, FileText, ClipboardList, Building2, GraduationCap, BookMarked, Globe, Settings, Database, RefreshCw, Search, ChevronDown } from 'lucide-react';
+import { Users, ShieldAlert, BookOpen, Calendar, ArrowRight, CheckCircle2, XCircle, SlidersHorizontal, Layers, Award, MapPin, School as SchoolIcon, BarChart3, FileText, ClipboardList, Building2, GraduationCap, BookMarked, Globe, Settings, Database, RefreshCw, Search, ChevronDown } from 'lucide-react';
 import { Table, Column } from './Table';
 import { MetricCard } from './Card';
 import { STATE_NAMES, DISTRICT_NAMES, BLOCK_NAMES } from '../constants';
@@ -379,21 +379,11 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
       x.id.toLowerCase().includes(searchQuery.toLowerCase())
     );
 
-    const EXTENDED_PROFILES: Record<string, any> = {
-      s1: { gender: 'Male', dob: '2018-04-12', guardian: 'Gurpreet Singh', relation: 'Father', contact: '+91-98765-43210', address: 'House #42, Model Town, Ludhiana, PB-141001', enrollmentDate: '2025-04-01', lastMedical: '2026-01-15', bloodGroup: 'B+', disability: 'None', midDayMeal: 'Yes', busRoute: 'Route 7 - Model Town Stop', notes: 'Consistent performer. Shows strong number sense. Encourage peer tutoring.', sibblings: 'Elder sister in Class 5' },
-      s2: { gender: 'Female', dob: '2019-01-25', guardian: 'Harjeet Kaur', relation: 'Mother', contact: '+91-98123-45678', address: 'Village Dhandra, PO Box 23, Ludhiana', enrollmentDate: '2025-07-15', lastMedical: '2026-03-10', bloodGroup: 'O+', disability: 'None', midDayMeal: 'Yes', busRoute: 'Route 12 - Village Dhandra', notes: 'Struggles with pattern recognition. Needs visual learning aids. Regular attendance.', sibblings: 'Younger brother in Class 1' },
-      s3: { gender: 'Male', dob: '2017-08-30', guardian: 'Suresh Kumar', relation: 'Father', contact: '+91-99887-76655', address: '456, Green Avenue, Ludhiana, PB-141002', enrollmentDate: '2025-04-01', lastMedical: '2026-02-20', bloodGroup: 'A+', disability: 'None', midDayMeal: 'Yes', busRoute: 'Route 3 - Green Ave Stop', notes: 'Top performer in class. Ready for advanced multiplication. Consider skipping to Level 41.', sibblings: 'None' },
-      s4: { gender: 'Female', dob: '2018-11-05', guardian: 'Rajesh Sharma', relation: 'Father', contact: '+91-97654-32100', address: 'Flat 12B, Krishna Apartments, Civil Lines, Ludhiana', enrollmentDate: '2026-01-10', lastMedical: '2026-04-05', bloodGroup: 'AB+', disability: 'None', midDayMeal: 'No', busRoute: 'Route 7 - Civil Lines', notes: 'Newly enrolled. Baseline diagnostic pending. Parents report confidence in basic counting.', sibblings: 'Elder brother in Class 5' },
-      s5: { gender: 'Male', dob: '2019-05-18', guardian: 'Mandeep Verma', relation: 'Mother', contact: '+91-95432-10987', address: 'Ward 3, Basti Jodhewal, Ludhiana', enrollmentDate: '2025-07-15', lastMedical: '2025-12-01', bloodGroup: 'B-', disability: 'Mild visual impairment (corrected)', midDayMeal: 'Yes', busRoute: 'Route 7 - Basti Stop', notes: 'Diagnosed with mild myopia, wears glasses. Performing well in number sense.', sibblings: 'Younger sister (not in school yet)' },
-      s6: { gender: 'Female', dob: '2017-12-22', guardian: 'Vikram Gupta', relation: 'Father', contact: '+91-93210-87654', address: 'H.No. 88, Sarabha Nagar, Ludhiana', enrollmentDate: '2025-04-01', lastMedical: '2026-05-15', bloodGroup: 'O-', disability: 'None', midDayMeal: 'Yes', busRoute: 'Route 3 - Sarabha Nagar', notes: 'Exemplary in multiplication. Should be challenged with word problems.', sibblings: 'None' },
-      s7: { gender: 'Female', dob: '2020-03-10', guardian: 'Balwinder Kaur', relation: 'Mother', contact: '+91-98765-01234', address: 'Street 5, Daresi Market Area, Ludhiana', enrollmentDate: '2026-01-10', lastMedical: '2026-02-28', bloodGroup: 'A-', disability: 'None', midDayMeal: 'Yes', busRoute: 'Route 12 - Daresi Stop', notes: 'Youngest in class. Recently enrolled. Shows enthusiasm for tracing activities.', sibblings: 'Two elder siblings in school' },
-    };
-
-    const profile = EXTENDED_PROFILES[s.id] || {};
     const reports = REPORTS_MOCK.filter(r => r.studentId === s.id);
     const studentSchool = schools.find(sch => sch.id === s.schoolId);
     const att = ATTENDANCE_MOCK.find(a => a.student === s.name);
-    const daysSinceEnroll = Math.floor((Date.now() - new Date(profile.enrollmentDate || s.id).getTime()) / 86400000);
+    const enrollmentDate = s.levelHistory[0]?.date;
+    const daysSinceEnroll = enrollmentDate ? Math.floor((Date.now() - new Date(enrollmentDate).getTime()) / 86400000) : null;
     const classStudents = students.filter(st => st.classGroup === s.classGroup);
     const classAvg = Math.round(classStudents.reduce((a, st) => a + st.currentLevel, 0) / Math.max(1, classStudents.length));
     const avgScore = reports.length > 0 ? Math.round(reports.reduce((a, r) => a + (r.score / r.totalQuestions) * 100, 0) / reports.length) : 0;
@@ -429,7 +419,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
                 <span className="text-xs font-mono font-bold px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-700">ID: {s.id}</span>
                 <span className={`text-[10px] font-mono font-bold px-2 py-0.5 rounded ${s.levelHistory.length > 0 ? 'text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800' : 'text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800'}`}>{s.levelHistory.length > 0 ? 'Active' : 'Pending Diagnostic'}</span>
               </div>
-              <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5 truncate"><strong>{studentSchool?.name || 'N/A'}</strong> · {s.classGroup} - {s.section} · Enrolled {daysSinceEnroll} days ago</p>
+              <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5 truncate"><strong>{studentSchool?.name || 'N/A'}</strong> · {s.classGroup} - {s.section}{daysSinceEnroll !== null && ` · Enrolled ${daysSinceEnroll} days ago`}</p>
             </div>
             {/* Searchable student selector */}
             <div className="relative shrink-0">
@@ -528,7 +518,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
               {/* Quick Info */}
               <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-2.5 text-sm">
                 <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-2">Quick Info</h3>
-                {[['Age', `${s.age} yrs`], ['Gender', profile.gender], ['Blood Group', profile.bloodGroup], ['Guardian', profile.guardian], ['Contact', profile.contact], ['Attendance', att ? `${att.present}/${att.total} (${att.percentage}%)` : 'N/A']].map(([l, v]) => (
+                {[['Age', `${s.age} yrs`], ['Class & Section', `${s.classGroup} - ${s.section}`], ['Current Level', `L${s.currentLevel}`], ['Attendance', att ? `${att.present}/${att.total} (${att.percentage}%)` : 'N/A']].map(([l, v]) => (
                   <div key={l as string} className="flex justify-between border-b border-slate-50 dark:border-slate-800 pb-1.5"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100">{v || 'N/A'}</span></div>
                 ))}
               </div>
@@ -635,12 +625,6 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
                     })}
                   </div>
                 ) : <div className="text-center py-6"><p className="text-xs text-slate-400 dark:text-slate-500">No skill data yet.</p></div>}
-              </div>
-
-              {/* Teacher Notes */}
-              <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm">
-                <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-2 flex items-center gap-2"><FileText className="w-3.5 h-3.5" /> Teacher Notes</h3>
-                <div className="text-sm text-slate-700 dark:text-slate-200 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-lg p-4 leading-relaxed">{profile.notes || 'No notes recorded.'}</div>
               </div>
 
               {/* Recommended Focus */}
@@ -801,26 +785,10 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
             <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-3">
               <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider flex items-center gap-2"><Users className="w-3.5 h-3.5" /> Personal Information</h3>
               <div className="space-y-2.5 text-sm">{[
-                ['Full Name', s.name], ['Date of Birth', profile.dob || 'N/A'], ['Age', `${s.age} years`], ['Gender', profile.gender || 'N/A'], ['Blood Group', profile.bloodGroup || 'N/A'], ['Disability Status', profile.disability || 'None'], ['Aadhar Number', s.aadharMasked], ['Enrollment Date', profile.enrollmentDate || 'N/A'], ['Class & Section', `${s.classGroup} - ${s.section}`], ['School', studentSchool?.name || 'N/A'], ['School ID', s.schoolId],
+                ['Full Name', s.name], ['Age', `${s.age} years`], ['Aadhar Number', s.aadharMasked], ['Class & Section', `${s.classGroup} - ${s.section}`], ['School', studentSchool?.name || 'N/A'], ['School ID', s.schoolId], ['Current Level', `L${s.currentLevel}`],
               ].map(([l, v]) => (<div key={l as string} className="flex justify-between border-b border-slate-50 dark:border-slate-800 pb-1.5"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100 text-right max-w-[55%]">{v}</span></div>))}</div>
             </div>
             <div className="space-y-6">
-              <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-3">
-                <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider flex items-center gap-2"><UserCheck className="w-3.5 h-3.5" /> Guardian & Contact</h3>
-                <div className="space-y-2.5 text-sm">{[
-                  ['Guardian Name', profile.guardian || 'N/A'], ['Relation', profile.relation || 'N/A'], ['Contact Number', profile.contact || 'N/A'], ['Residential Address', profile.address || 'N/A'], ['Mid-Day Meal', profile.midDayMeal || 'N/A'], ['Bus Route', profile.busRoute || 'N/A'],
-                ].map(([l, v]) => (<div key={l as string} className="flex justify-between border-b border-slate-50 dark:border-slate-800 pb-1.5"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100 text-right max-w-[55%]">{v}</span></div>))}</div>
-              </div>
-              <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-3">
-                <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider flex items-center gap-2"><FileText className="w-3.5 h-3.5" /> Additional Information</h3>
-                <div className="text-sm space-y-2">{[
-                  ['Siblings in School', profile.sibblings || 'N/A'], ['Last Medical Check-up', profile.lastMedical || 'N/A'], ['Mid-Day Meal Beneficiary', profile.midDayMeal || 'N/A'],
-                ].map(([l, v]) => (<div key={l as string} className="flex justify-between border-b border-slate-50 dark:border-slate-800 pb-1.5"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100">{v}</span></div>))}</div>
-              </div>
-              <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm">
-                <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-2 flex items-center gap-2"><FileText className="w-3.5 h-3.5" /> Teacher Notes</h3>
-                <div className="text-sm text-slate-700 dark:text-slate-200 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-lg p-4 leading-relaxed">{profile.notes || 'No notes recorded.'}</div>
-              </div>
               <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm">
                 <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-3 flex items-center gap-2"><Calendar className="w-3.5 h-3.5" /> Attendance Record</h3>
                 {att ? (

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -193,6 +193,9 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
   const [expandedReportId, setExpandedReportId] = useState<string | null>(null);
   const [sel, setSel] = useState('');
   const [profileTab, setProfileTab] = useState<'overview' | 'academic' | 'personal' | 'activity'>('overview');
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [profileDraft, setProfileDraft] = useState<Partial<Student>>({});
+  const [savingProfile, setSavingProfile] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
   const [activityFilter, setActivityFilter] = useState<'all' | 'assessment' | 'level_change'>('all');
@@ -384,6 +387,51 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
     const att = ATTENDANCE_MOCK.find(a => a.student === s.name);
     const enrollmentDate = s.levelHistory[0]?.date;
     const daysSinceEnroll = enrollmentDate ? Math.floor((Date.now() - new Date(enrollmentDate).getTime()) / 86400000) : null;
+    const canEditProfile = (() => {
+      switch (currentUser.role) {
+        case UserRole.SUPERADMIN:
+        case UserRole.ADMIN:
+        case UserRole.DISTRICT_ADMIN:
+        case UserRole.BLOCK_ADMIN:
+          return true;
+        case UserRole.SCHOOL:
+        case UserRole.TEACHER:
+          return s.schoolId === currentUser.schoolId;
+        case UserRole.VOLUNTEER:
+          return currentUser.assignedSchools?.includes(s.schoolId) ?? false;
+        default:
+          return false;
+      }
+    })();
+    // Mirrors the backend's redaction in GET /api/students — admins/volunteers
+    // never receive guardianContact/address at all, so those fields are
+    // indistinguishable from "not set" unless we check role here too.
+    const canSeeGuardianPII = currentUser.role === UserRole.SUPERADMIN || currentUser.role === UserRole.SCHOOL || currentUser.role === UserRole.TEACHER;
+    const startEditingProfile = () => {
+      setProfileDraft({
+        gender: s.gender, dob: s.dob, guardianName: s.guardianName, guardianRelation: s.guardianRelation,
+        guardianContact: s.guardianContact, address: s.address, bloodGroup: s.bloodGroup,
+        disabilityStatus: s.disabilityStatus, midDayMealBeneficiary: s.midDayMealBeneficiary,
+        busRoute: s.busRoute, siblingsInSchool: s.siblingsInSchool, teacherNotes: s.teacherNotes,
+      });
+      setEditingProfile(true);
+    };
+    const saveProfile = async () => {
+      setSavingProfile(true);
+      try {
+        const res = await apiFetch(`/api/students/${s.id}/profile`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify(profileDraft),
+        });
+        if (res.ok) {
+          setApiStudents(prev => prev.map(st => st.id === s.id ? { ...st, ...profileDraft } : st));
+          setEditingProfile(false);
+        }
+      } finally {
+        setSavingProfile(false);
+      }
+    };
     const classStudents = students.filter(st => st.classGroup === s.classGroup);
     const classAvg = Math.round(classStudents.reduce((a, st) => a + st.currentLevel, 0) / Math.max(1, classStudents.length));
     const avgScore = reports.length > 0 ? Math.round(reports.reduce((a, r) => a + (r.score / r.totalQuestions) * 100, 0) / reports.length) : 0;
@@ -781,32 +829,118 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
 
         {/* ===== PERSONAL TAB ===== */}
         {profileTab === 'personal' && (
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-3">
-              <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider flex items-center gap-2"><Users className="w-3.5 h-3.5" /> Personal Information</h3>
-              <div className="space-y-2.5 text-sm">{[
-                ['Full Name', s.name], ['Age', `${s.age} years`], ['Aadhar Number', s.aadharMasked], ['Class & Section', `${s.classGroup} - ${s.section}`], ['School', studentSchool?.name || 'N/A'], ['School ID', s.schoolId], ['Current Level', `L${s.currentLevel}`],
-              ].map(([l, v]) => (<div key={l as string} className="flex justify-between border-b border-slate-50 dark:border-slate-800 pb-1.5"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100 text-right max-w-[55%]">{v}</span></div>))}</div>
-            </div>
-            <div className="space-y-6">
-              <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm">
-                <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-3 flex items-center gap-2"><Calendar className="w-3.5 h-3.5" /> Attendance Record</h3>
-                {att ? (
-                  <div className="space-y-3">
-                    <div className="flex justify-between items-center">
-                      <span className="text-sm text-slate-500 dark:text-slate-400">Overall Attendance</span>
-                      <span className={`text-lg font-bold ${att.percentage >= 85 ? 'text-emerald-600' : att.percentage >= 75 ? 'text-amber-600' : 'text-red-600'}`}>{att.percentage}%</span>
-                    </div>
-                    <div className="h-3 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden">
-                      <div className={`h-full rounded-full transition-all ${att.percentage >= 85 ? 'bg-emerald-500' : att.percentage >= 75 ? 'bg-amber-500' : 'bg-red-500'}`} style={{ width: `${att.percentage}%` }} />
-                    </div>
-                    <div className="flex justify-between text-xs text-slate-500 dark:text-slate-400">
-                      <span>Present: {att.present} days</span>
-                      <span>Total: {att.total} days</span>
-                      <span>Absent: {att.total - att.present} days</span>
-                    </div>
+          <div className="space-y-6">
+            {canEditProfile && (
+              <div className="flex justify-end">
+                {editingProfile ? (
+                  <div className="flex gap-2">
+                    <button onClick={() => setEditingProfile(false)} disabled={savingProfile} className="text-xs font-semibold px-3 py-1.5 rounded-lg border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800">Cancel</button>
+                    <button onClick={saveProfile} disabled={savingProfile} className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50">{savingProfile ? 'Saving…' : 'Save Changes'}</button>
                   </div>
-                ) : <p className="text-xs text-slate-400 dark:text-slate-500">No attendance data available.</p>}
+                ) : (
+                  <button onClick={startEditingProfile} className="text-xs font-semibold px-3 py-1.5 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700">Edit Profile</button>
+                )}
+              </div>
+            )}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-3">
+                <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider flex items-center gap-2"><Users className="w-3.5 h-3.5" /> Personal Information</h3>
+                <div className="space-y-2.5 text-sm">{[
+                  ['Full Name', s.name], ['Age', `${s.age} years`], ['Aadhar Number', s.aadharMasked], ['Class & Section', `${s.classGroup} - ${s.section}`], ['School', studentSchool?.name || 'N/A'], ['School ID', s.schoolId], ['Current Level', `L${s.currentLevel}`],
+                ].map(([l, v]) => (<div key={l as string} className="flex justify-between border-b border-slate-50 dark:border-slate-800 pb-1.5"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100 text-right max-w-[55%]">{v}</span></div>))}</div>
+                {editingProfile ? (
+                  <div className="space-y-2.5 pt-2 border-t border-slate-100 dark:border-slate-800">
+                    <label className="block text-xs text-slate-500 dark:text-slate-400">Gender
+                      <select value={profileDraft.gender || ''} onChange={e => setProfileDraft(d => ({ ...d, gender: e.target.value as Student['gender'] }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950">
+                        <option value="">Not set</option><option value="Male">Male</option><option value="Female">Female</option><option value="Other">Other</option>
+                      </select>
+                    </label>
+                    <label className="block text-xs text-slate-500 dark:text-slate-400">Date of Birth
+                      <input type="date" value={profileDraft.dob || ''} onChange={e => setProfileDraft(d => ({ ...d, dob: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" />
+                    </label>
+                    <label className="block text-xs text-slate-500 dark:text-slate-400">Blood Group
+                      <input type="text" placeholder="e.g. B+" value={profileDraft.bloodGroup || ''} onChange={e => setProfileDraft(d => ({ ...d, bloodGroup: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" />
+                    </label>
+                    <label className="block text-xs text-slate-500 dark:text-slate-400">Disability Status
+                      <input type="text" placeholder="e.g. None" value={profileDraft.disabilityStatus || ''} onChange={e => setProfileDraft(d => ({ ...d, disabilityStatus: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" />
+                    </label>
+                  </div>
+                ) : (
+                  <div className="space-y-2.5 text-sm pt-2 border-t border-slate-100 dark:border-slate-800">{[
+                    ['Gender', s.gender || 'N/A'], ['Date of Birth', s.dob || 'N/A'], ['Blood Group', s.bloodGroup || 'N/A'], ['Disability Status', s.disabilityStatus || 'None recorded'],
+                  ].map(([l, v]) => (<div key={l as string} className="flex justify-between"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100 text-right max-w-[55%]">{v}</span></div>))}</div>
+                )}
+              </div>
+              <div className="space-y-6">
+                <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-3">
+                  <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider flex items-center gap-2"><Users className="w-3.5 h-3.5" /> Guardian & Contact</h3>
+                  {editingProfile ? (
+                    <div className="space-y-2.5">
+                      <label className="block text-xs text-slate-500 dark:text-slate-400">Guardian Name
+                        <input type="text" value={profileDraft.guardianName || ''} onChange={e => setProfileDraft(d => ({ ...d, guardianName: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" />
+                      </label>
+                      <label className="block text-xs text-slate-500 dark:text-slate-400">Relation
+                        <input type="text" placeholder="e.g. Father, Mother" value={profileDraft.guardianRelation || ''} onChange={e => setProfileDraft(d => ({ ...d, guardianRelation: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" />
+                      </label>
+                      <label className="block text-xs text-slate-500 dark:text-slate-400">Contact Number
+                        <input type="tel" value={profileDraft.guardianContact || ''} onChange={e => setProfileDraft(d => ({ ...d, guardianContact: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" />
+                      </label>
+                      <label className="block text-xs text-slate-500 dark:text-slate-400">Residential Address
+                        <textarea value={profileDraft.address || ''} onChange={e => setProfileDraft(d => ({ ...d, address: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" rows={2} />
+                      </label>
+                    </div>
+                  ) : (
+                    <div className="space-y-2.5 text-sm">{[
+                      ['Guardian Name', s.guardianName || 'N/A'], ['Relation', s.guardianRelation || 'N/A'],
+                      ['Contact Number', s.guardianContact || (canSeeGuardianPII ? 'N/A' : 'Not visible to your role')],
+                      ['Residential Address', s.address || (canSeeGuardianPII ? 'N/A' : 'Not visible to your role')],
+                    ].map(([l, v]) => (<div key={l as string} className="flex justify-between border-b border-slate-50 dark:border-slate-800 pb-1.5"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100 text-right max-w-[55%]">{v}</span></div>))}</div>
+                  )}
+                </div>
+                <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-3">
+                  <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider flex items-center gap-2"><FileText className="w-3.5 h-3.5" /> Logistics & Notes</h3>
+                  {editingProfile ? (
+                    <div className="space-y-2.5">
+                      <label className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                        <input type="checkbox" checked={!!profileDraft.midDayMealBeneficiary} onChange={e => setProfileDraft(d => ({ ...d, midDayMealBeneficiary: e.target.checked }))} /> Mid-Day Meal Beneficiary
+                      </label>
+                      <label className="block text-xs text-slate-500 dark:text-slate-400">Bus Route
+                        <input type="text" value={profileDraft.busRoute || ''} onChange={e => setProfileDraft(d => ({ ...d, busRoute: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" />
+                      </label>
+                      <label className="block text-xs text-slate-500 dark:text-slate-400">Siblings in School
+                        <input type="text" value={profileDraft.siblingsInSchool || ''} onChange={e => setProfileDraft(d => ({ ...d, siblingsInSchool: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" />
+                      </label>
+                      <label className="block text-xs text-slate-500 dark:text-slate-400">Teacher Notes
+                        <textarea value={profileDraft.teacherNotes || ''} onChange={e => setProfileDraft(d => ({ ...d, teacherNotes: e.target.value }))} className="mt-1 w-full text-sm border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1.5 bg-white dark:bg-slate-950" rows={3} />
+                      </label>
+                    </div>
+                  ) : (
+                    <div className="space-y-2.5 text-sm">
+                      {[['Mid-Day Meal', s.midDayMealBeneficiary === undefined ? 'N/A' : s.midDayMealBeneficiary ? 'Yes' : 'No'], ['Bus Route', s.busRoute || 'N/A'], ['Siblings in School', s.siblingsInSchool || 'N/A']]
+                        .map(([l, v]) => (<div key={l as string} className="flex justify-between border-b border-slate-50 dark:border-slate-800 pb-1.5"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100">{v}</span></div>))}
+                      <div className="pt-1"><span className="text-slate-500 dark:text-slate-400 block mb-1">Teacher Notes</span><p className="text-slate-800 dark:text-slate-100 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-lg p-3 leading-relaxed">{s.teacherNotes || 'No notes recorded.'}</p></div>
+                    </div>
+                  )}
+                </div>
+                <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm">
+                  <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-3 flex items-center gap-2"><Calendar className="w-3.5 h-3.5" /> Attendance Record</h3>
+                  {att ? (
+                    <div className="space-y-3">
+                      <div className="flex justify-between items-center">
+                        <span className="text-sm text-slate-500 dark:text-slate-400">Overall Attendance</span>
+                        <span className={`text-lg font-bold ${att.percentage >= 85 ? 'text-emerald-600' : att.percentage >= 75 ? 'text-amber-600' : 'text-red-600'}`}>{att.percentage}%</span>
+                      </div>
+                      <div className="h-3 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden">
+                        <div className={`h-full rounded-full transition-all ${att.percentage >= 85 ? 'bg-emerald-500' : att.percentage >= 75 ? 'bg-amber-500' : 'bg-red-500'}`} style={{ width: `${att.percentage}%` }} />
+                      </div>
+                      <div className="flex justify-between text-xs text-slate-500 dark:text-slate-400">
+                        <span>Present: {att.present} days</span>
+                        <span>Total: {att.total} days</span>
+                        <span>Absent: {att.total - att.present} days</span>
+                      </div>
+                    </div>
+                  ) : <p className="text-xs text-slate-400 dark:text-slate-500">No attendance data available.</p>}
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -55,6 +55,18 @@ export interface Student {
   aadharMasked: string;
   levelHistory: { level: number; subLevel?: number; date: string; reason: string }[];
   streak: number;
+  gender?: 'Male' | 'Female' | 'Other';
+  dob?: string;
+  guardianName?: string;
+  guardianRelation?: string;
+  guardianContact?: string;
+  address?: string;
+  bloodGroup?: string;
+  disabilityStatus?: string;
+  midDayMealBeneficiary?: boolean;
+  busRoute?: string;
+  siblingsInSchool?: string;
+  teacherNotes?: string;
 }
 
 export interface Question {


### PR DESCRIPTION
## Summary
Started as PII cleanup, grew into the real feature per follow-up discussion: the removed data (`EXTENDED_PROFILES`) was fabricated demo text keyed to fake IDs (`s1`-`s7`) that never matched real seeded students — but the underlying need (guardian contact, blood group, disability status, etc.) was real, so this PR adds it properly against the database instead.

### PII removal
- Removed `PanelViews.tsx`'s hardcoded `EXTENDED_PROFILES` object (guardian names, phone numbers, addresses, blood groups, disability notes for 7 fake student ids) and the UI cards built only to display it (AUDIT.md §3.2, flagged P0).
- "Enrolled N days ago" now derives from the real `levelHistory` onboarding date instead of the fake `enrollmentDate` field (which had a broken fallback that parsed the student's own id as a date).

### Real guardian/medical profile feature
- Extended the `Student` model (`backend/src/db.ts`, mirrored in `frontend/src/types.ts`) with optional fields: `gender`, `dob`, `guardianName`, `guardianRelation`, `guardianContact`, `address`, `bloodGroup`, `disabilityStatus`, `midDayMealBeneficiary`, `busRoute`, `siblingsInSchool`, `teacherNotes`.
- `GET /api/students` redacts `guardianContact`/`address` for roles beyond superadmin/school/teacher — same treatment as the existing Aadhar masking (§13.2 R-6). Aggregate-scope admins and volunteers don't need a guardian's phone number to view rollups.
- `POST /api/students` accepts these fields optionally at creation.
- New `PATCH /api/students/:id/profile` endpoint for editing after creation, gated by the existing `canAccessStudent` check (same access rule as the level-update PATCH).
- Personal Details tab in the student profile view: real data display + an "Edit Profile" form for authorized roles (teacher/school on their own school, or higher admins). Guardian contact/address show "Not visible to your role" rather than a misleading "N/A" when the backend redacted them.

## Test plan
- [x] `npm run lint` passes
- [x] **Full end-to-end verification** against a live seeded MongoDB: as a real seeded teacher, opened a real student's Personal Details tab, clicked Edit, filled in guardian name/relation/contact + blood group, saved — confirmed the write persisted in MongoDB directly. Then, as a block admin, confirmed `GET /api/students` correctly omits `guardianContact`/`address` for that same student while still returning `guardianName`/`bloodGroup`.
- [x] Verified the redaction UI copy ("Not visible to your role") renders correctly for a role without PII access.

Note: verifying this uncovered an unrelated, severe pre-existing bug (dashboard login broken for every role) — fixed separately in #107, needed first to actually drive the UI for this PR's testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)