### PR TITLE
Fix missing token prop breaking login for every role

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,19 +111,19 @@ export default function App() {
   };
 
   const renderRoleWorkspace = () => {
-    if (!currentUser) return null;
+    if (!currentUser || !token) return null;
 
     switch (currentUser.role) {
       case 'superadmin':
-        return <SuperadminDashboard user={currentUser} />;
+        return <SuperadminDashboard user={currentUser} token={token} />;
       case 'admin':
-        return <AdminDashboard user={currentUser} />;
+        return <AdminDashboard user={currentUser} token={token} />;
       case 'school':
-        return <SchoolDashboard user={currentUser} />;
+        return <SchoolDashboard user={currentUser} token={token} />;
       case 'teacher':
-        return <TeacherDashboard user={currentUser} />;
+        return <TeacherDashboard user={currentUser} token={token} />;
       case 'volunteer':
-        return <VolunteerDashboard user={currentUser} />;
+        return <VolunteerDashboard user={currentUser} token={token} />;
       default:
         return <div />;
     }


### PR DESCRIPTION
## Summary
Discovered while verifying an unrelated feature: **login was broken for every role**, 100% reproducible. `App.tsx`'s `renderRoleWorkspace()` rendered each dashboard component without its required `token` prop:

```tsx
return <TeacherDashboard user={currentUser} />;  // no token
```

Every role dashboard builds its own `Authorization` header explicitly from that prop rather than relying on `apiFetch`'s automatic localStorage lookup, so the header became the literal string `"Bearer undefined"`. The backend correctly 401s that, which fires the app's global unauthorized handler and force-logs the user out — so every fresh login bounced straight back to the landing page within about a second, for every single role (superadmin, admin, school, teacher, volunteer).

## Root cause
Missing `token={token}` in five call sites in `renderRoleWorkspace()`.

## Fix
Pass `token={token}` through to all five dashboards, and short-circuit the function if `token` is falsy (matches the existing guard already used around `<Layout>` itself).

## Test plan
- [x] `npm run lint` passes
- [x] Reproduced against a live seeded backend before the fix: every login attempt (verified across teacher role) bounced back to the landing page, with network traces showing `/api/classes` and `/api/students` sent `Authorization: Bearer undefined`
- [x] After the fix: same login flow succeeds, dashboard loads with real data (student roster, etc.) and stays logged in through navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)