### PR TITLE
Wire Teacher Roster panel to real data (GET /api/teachers)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -383,6 +383,42 @@ async function startServer() {
     res.json(schools.filter(s => s.blockCode === blockCode));
   });
 
+  app.get('/api/teachers', async (req, res) => {
+    const user = getAuthUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+    if (![UserRole.SCHOOL, UserRole.BLOCK_ADMIN, UserRole.SUPERADMIN].includes(user.role)) {
+      return res.status(403).json({ error: 'Forbidden.' });
+    }
+
+    const [users, schools, classes, students] = await Promise.all([
+      dbStore.getUsers(),
+      dbStore.getSchools(),
+      dbStore.getClasses(),
+      dbStore.getStudents(),
+    ]);
+    const schoolById = new Map(schools.map(s => [s.id, s]));
+
+    let teachers = users.filter(u => u.role === UserRole.TEACHER);
+    if (user.role === UserRole.SCHOOL) {
+      teachers = teachers.filter(t => t.schoolId === user.schoolId);
+    } else if (user.role === UserRole.BLOCK_ADMIN) {
+      teachers = teachers.filter(t => schoolById.get(t.schoolId || '')?.blockCode === user.blockCode);
+    }
+
+    const enriched = teachers.map(t => {
+      const teacherClasses = classes.filter(c => c.teacherId === t.id);
+      const studentsCount = students.filter(s => s.teacherId === t.id).length;
+      return {
+        ...sanitizeUser(t),
+        classes: teacherClasses.map(c => `${c.className} ${c.section}`),
+        studentsCount,
+        status: t.isBanned ? 'Inactive' : 'Active',
+      };
+    });
+
+    res.json(enriched);
+  });
+
   app.post('/api/teachers', async (req, res) => {
     const user = getAuthUser(req);
     if (!user || !COORDINATOR_ROLES.includes(user.role)) {

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -207,17 +207,22 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
   const [apiStudents, setApiStudents] = useState<Student[]>([]);
   const [apiSchools, setApiSchools] = useState<School[]>([]);
   const [apiUsers, setApiUsers] = useState<any[]>([]);
+  const [apiTeachers, setApiTeachers] = useState<any[]>([]);
 
   useEffect(() => {
     const headers = { 'Authorization': `Bearer ${token}` };
     apiFetch('/api/students', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiStudents(d); }).catch(() => {});
     apiFetch('/api/schools', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiSchools(d); }).catch(() => {});
     apiFetch('/api/admin/coordinators', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiUsers(d); }).catch(() => {});
-  }, [token]);
+    if (currentUser.role === UserRole.SCHOOL || currentUser.role === UserRole.BLOCK_ADMIN) {
+      apiFetch('/api/teachers', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiTeachers(d); }).catch(() => {});
+    }
+  }, [token, currentUser.role]);
 
   const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
   const schools = apiSchools.length > 0 ? apiSchools : SCHOOLS_FALLBACK;
   const usersList = apiUsers.length > 0 ? apiUsers : USERS_FALLBACK;
+  const teachersList = apiTeachers.length > 0 ? apiTeachers : TEACHERS_MOCK;
 
   useEffect(() => {
     if (students.length > 0 && !sel) {
@@ -1325,13 +1330,21 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
   }
 
   // ===================== PRINCIPAL / SCHOOL ADMIN PANELS =====================
-  if (panel === 'teachers' && currentUser.role === UserRole.SCHOOL) {
+  if (panel === 'teachers' && (currentUser.role === UserRole.SCHOOL || currentUser.role === UserRole.BLOCK_ADMIN)) {
+    const isBlockAdmin = currentUser.role === UserRole.BLOCK_ADMIN;
+    const schoolById = new Map<string, School>(schools.map(s => [s.id, s]));
     return (
       <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
-        <PageHeader title="Teacher Roster" desc="Manage teaching staff at your school" icon={<Users className="h-5 w-5" />} />
-        <div className="space-y-3">{TEACHERS_MOCK.filter(t => t.schoolId === currentUser.schoolId).map(t => (
+        <PageHeader title="Teacher Roster" desc={isBlockAdmin ? 'Teaching staff across your block' : 'Manage teaching staff at your school'} icon={<Users className="h-5 w-5" />} />
+        <div className="space-y-3">{teachersList.map((t: any) => (
           <div key={t.id} className="flex justify-between items-center p-3 border border-slate-200 dark:border-slate-700 rounded-lg">
-            <div><div className="font-semibold text-sm">{t.name}</div><div className="text-xs text-slate-400 dark:text-slate-500">{t.email} · {t.classes.join(', ')}</div></div>
+            <div>
+              <div className="font-semibold text-sm">{t.name}</div>
+              <div className="text-xs text-slate-400 dark:text-slate-500">
+                {t.email}{t.classes?.length ? ` · ${t.classes.join(', ')}` : ''}
+                {isBlockAdmin && t.schoolId && ` · ${schoolById.get(t.schoolId)?.name || t.schoolId}`}
+              </div>
+            </div>
             <div className="text-right"><span className={`text-[10px] font-mono font-bold px-2 py-0.5 rounded ${t.status === 'Active' ? 'text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800' : 'text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800'}`}>{t.status}</span><div className="text-xs text-slate-400 dark:text-slate-500 mt-1">{t.studentsCount} students</div></div>
           </div>
         ))}</div>


### PR DESCRIPTION
## Summary
- Adds `GET /api/teachers`, geo-scoped like the existing `/api/students` pattern: School role → own school, Block Admin → own block (via `schools.blockCode` join), Superadmin → all. Other roles get 403, unauthenticated gets 401.
- Enriches each teacher with real `classes` (from `ClassGroup.teacherId`) and `studentsCount` (from `Student.teacherId`) — fields the panel already expected but that don't exist on the raw `User` record.
- Wires `PanelViews.tsx`'s Teacher Roster panel to it, replacing `TEACHERS_MOCK` (kept only as an empty-state fallback, same pattern as `apiSchools`/`apiStudents` in this file).
- **Found + fixed a second blank-page bug along the way**: Block Admin has a "Teachers" nav item (`Layout.tsx`) but the panel only handled `currentUser.role === UserRole.SCHOOL` — Block Admins got a blank page. Now both roles render, with block-scoped teachers labeled by school name.

Part of the ongoing "connect static demo panels" pass.

## Test plan
- [x] `npm run lint` (tsc --noEmit) clean
- [x] `npm run build` clean (frontend + backend)
- [x] Live-verified against a scratch seeded MongoDB (`npx tsx src/seed.ts` + `npx tsx src/index.ts`):
  - School principal login → 3 teachers, all scoped to their own `schoolId`
  - Block Admin login → 30 teachers across exactly 10 schools, all confirmed in their own block (`GNT_01`), zero cross-block leakage
  - District Admin (unauthorized role) → 403
  - No token → 401
  - Superadmin → all 4320 seeded teachers
  - Confirmed `passwordHash` never appears in the response (reuses existing `sanitizeUser`)
- [x] Scratch DB/server torn down after verification