### PR TITLE
Paginate GET /api/students; skip the fetch on panels that don't need it

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -536,30 +536,47 @@ async function startServer() {
       return masked;
     });
 
+    let scoped: typeof maskedStudents;
     if (user.role === UserRole.SUPERADMIN) {
-      return res.json(students);
-    }
-    if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
-      return res.json(maskedStudents.filter(s => s.schoolId === user.schoolId));
-    }
-    if (user.role === UserRole.VOLUNTEER) {
-      return res.json(maskedStudents.filter(s => user.assignedSchools?.includes(s.schoolId)));
-    }
-    if (user.role === UserRole.ADMIN || user.role === UserRole.DISTRICT_ADMIN || user.role === UserRole.BLOCK_ADMIN) {
+      scoped = students;
+    } else if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
+      scoped = maskedStudents.filter(s => s.schoolId === user.schoolId);
+    } else if (user.role === UserRole.VOLUNTEER) {
+      scoped = maskedStudents.filter(s => user.assignedSchools?.includes(s.schoolId));
+    } else if (user.role === UserRole.ADMIN || user.role === UserRole.DISTRICT_ADMIN || user.role === UserRole.BLOCK_ADMIN) {
       // Geo-scope by the admin's own state/district/block, joined via each student's school.
       const schools = await dbStore.getSchools();
       const schoolById = new Map(schools.map(sc => [sc.id, sc]));
-      const geoFiltered = maskedStudents.filter(s => {
+      scoped = maskedStudents.filter(s => {
         const school = schoolById.get(s.schoolId);
         if (!school) return false;
         if (user.role === UserRole.ADMIN) return school.stateCode === user.stateCode;
         if (user.role === UserRole.DISTRICT_ADMIN) return school.districtCode === user.districtCode;
         return school.blockCode === user.blockCode; // BLOCK_ADMIN
       });
-      return res.json(geoFiltered);
+    } else {
+      scoped = maskedStudents;
     }
 
-    res.json(maskedStudents);
+    // Pagination is opt-in via ?page & ?limit — omitting them returns the full
+    // scoped array exactly as before, so existing callers (aggregate/rollup
+    // panels that need the whole scope) are unaffected. Callers that just need
+    // a page to display (the Student List table) can request one directly
+    // instead of always paying for the full national fetch.
+    const pageParam = req.query.page as string | undefined;
+    const limitParam = req.query.limit as string | undefined;
+    if (pageParam || limitParam) {
+      const page = Math.max(1, parseInt(pageParam || '1', 10) || 1);
+      const limit = Math.max(1, Math.min(500, parseInt(limitParam || '50', 10) || 50));
+      const total = scoped.length;
+      const start = (page - 1) * limit;
+      res.set('X-Total-Count', String(total));
+      res.set('X-Page', String(page));
+      res.set('X-Pages', String(Math.max(1, Math.ceil(total / limit))));
+      return res.json(scoped.slice(start, start + limit));
+    }
+
+    res.json(scoped);
   });
 
   // Add Student

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -12,6 +12,11 @@ interface PanelViewsProps {
   token: string;
 }
 
+// Panels that render without ever reading the `students` variable — skipping
+// the fetch on these avoids an up-to-86,400-record national payload on
+// screens that don't display any student data.
+const STUDENTS_NOT_NEEDED_PANELS = new Set(['users', 'worksheet_templates', 'content', 'system_settings']);
+
 const STUDENTS_FALLBACK: Student[] = [
   { id: 's1', name: 'Amanpreet Singh', age: 8, classGroup: 'Class 2', section: 'A', schoolId: 'gps-mt-001', currentLevel: 12, currentSubLevel: 0, targetLevel: 13, aadharMasked: 'XXXX-XXXX-1234', levelHistory: [{ level: 12, subLevel: 0, date: '2026-03-15', reason: 'Diagnostic' }], streak: 3 },
   { id: 's2', name: 'Jasmine Kaur', age: 7, classGroup: 'Class 2', section: 'A', schoolId: 'gps-mt-001', currentLevel: 8, currentSubLevel: 1, targetLevel: 12, aadharMasked: 'XXXX-XXXX-5678', levelHistory: [{ level: 8, subLevel: 1, date: '2026-02-20', reason: 'Mid-year' }], streak: 1 },
@@ -210,10 +215,20 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
 
   useEffect(() => {
     const headers = { 'Authorization': `Bearer ${token}` };
-    apiFetch('/api/students', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiStudents(d); }).catch(() => {});
     apiFetch('/api/schools', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiSchools(d); }).catch(() => {});
     apiFetch('/api/admin/coordinators', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiUsers(d); }).catch(() => {});
   }, [token]);
+
+  // GET /api/students returns the caller's whole role-scoped list — up to
+  // 86,400 records nationally for Superadmin — so skip it entirely on the
+  // handful of Superadmin-only panels that never read `students` at all
+  // (verified by grepping for the identifier in each branch below).
+  useEffect(() => {
+    if (apiStudents.length > 0) return;
+    if (STUDENTS_NOT_NEEDED_PANELS.has(activePanel)) return;
+    const headers = { 'Authorization': `Bearer ${token}` };
+    apiFetch('/api/students', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiStudents(d); }).catch(() => {});
+  }, [token, activePanel, apiStudents.length]);
 
   const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
   const schools = apiSchools.length > 0 ? apiSchools : SCHOOLS_FALLBACK;


### PR DESCRIPTION
## Summary
Part of the "implement pagination" item from the FLN bug tracker. Investigating surfaced that the naive version of this (paginate the Student List table) wouldn't actually help — see below — so this PR does two related but distinct things instead.

### 1. Opt-in pagination on `GET /api/students`
`?page=`/`?limit=` are optional. Omitting them returns the full role-scoped array exactly as today — **zero breaking change** for every existing consumer (the Teachers/Reports/Districts/Blocks/Analytics panels all need the full scoped list client-side to compute real aggregates, and none of them pass these params). When passed:
- Pagination is applied **after** role-scoping, so e.g. a School role's `?limit=5` paginates within their own ~60 students, not the national 86,400.
- Totals reported via `X-Total-Count`/`X-Page`/`X-Pages` response headers rather than changing the response shape (still always a plain array).
- `limit` clamped to 500.

### 2. Skip the fetch entirely where it isn't needed
Investigated wiring the "Student List" table (`Table.tsx`, the one screen with real pagination UI) to the new params — but that screen is only reachable by Teacher/Volunteer, both already scoped to a single school (tens of students). Not the actual problem, and paginating it server-side would regress its existing client-side search-across-full-list feature.

The real cost: `PanelViews.tsx`'s top-level `useEffect` unconditionally fetched the full role-scoped `/api/students` list **on every mount, regardless of the active panel**. A Superadmin just viewing Users, Worksheet Templates, Content, or System Settings — none of which read `students` at all (verified by grep) — was still pulling all 86,400 student records into memory every time. Split that fetch into its own effect, gated to skip on that verified-unused panel set.

## Test plan
- [x] `npm run lint` (tsc --noEmit) clean
- [x] `npm run build` clean
- [x] Live-verified against a scratch seeded MongoDB (86,400 students):
  - No params → unchanged, full 86,400 for Superadmin
  - `?page=1&limit=20` / `?page=2&limit=20` → 20 each, zero ID overlap, correct `X-Total-Count`/`X-Pages` headers
  - `?limit=99999` → clamped, `X-Pages: 173` (500/page)
  - School role, no params → 60 (own school only, unchanged); `?page=1&limit=5` → `X-Total-Count: 60` (paginated within their own scope, not national)
- [x] Scratch DB/server torn down after verification