### PR TITLE
Move GET /api/stats into backend/src/routes/stats.ts

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import * as levelsBackendClient from './levelsBackendClient';
 import { STATES_UTS } from './geoData';
 import { getAuthUser, canAccessStudent, sanitizeUser, JWT_SECRET, JWT_EXPIRES_IN } from './auth';
 import { registerAnnouncementRoutes } from './routes/announcements';
+import { registerStatsRoutes } from './routes/stats';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 import bcrypt from 'bcrypt';
@@ -52,37 +53,7 @@ async function startServer() {
 
   // --- API Endpoints ---
 
-  // Public stats (no auth required — used by landing page)
-  app.get('/api/stats', async (_req, res) => {
-    const db = dbStore.getDb();
-    if (!db) return res.json({ totalStates: 0, totalDistricts: 0, totalSchools: 0, totalStudents: 0, totalAssessments: 0, avgFlnLevel: 0, totalUsers: 0, certifiedCount: 0, certifiedPercent: 0 });
-
-    const [totalSchools, totalStudents, totalUsers, totalAssessments, stateCodes, districtCodes, avgResult, certifiedResult] = await Promise.all([
-      db.collection('schools').countDocuments(),
-      db.collection('students').countDocuments(),
-      db.collection('users').countDocuments(),
-      db.collection('worksheets').countDocuments(),
-      db.collection('schools').distinct('stateCode'),
-      db.collection('schools').distinct('districtCode'),
-      db.collection('students').aggregate([{ $group: { _id: null, avg: { $avg: '$currentLevel' } } }]).toArray(),
-      db.collection('students').aggregate([{ $match: { currentLevel: { $gte: 5 } } }, { $count: 'count' }]).toArray(),
-    ]);
-
-    const certifiedCount = certifiedResult[0]?.count ?? 0;
-    const avgFlnLevel = totalStudents > 0 ? Math.round(avgResult[0]?.avg ?? 0) : 0;
-
-    res.json({
-      totalStates: stateCodes.length,
-      totalDistricts: districtCodes.length,
-      totalSchools,
-      totalStudents,
-      totalAssessments,
-      avgFlnLevel,
-      totalUsers,
-      certifiedCount,
-      certifiedPercent: totalStudents > 0 ? Math.round((certifiedCount / totalStudents) * 100) : 0,
-    });
-  });
+  registerStatsRoutes(app);
 
   // Auth: Login
   app.post('/api/auth/login', authRateLimiter, async (req, res) => {

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import { dbStore } from '../db';
+
+export function registerStatsRoutes(app: express.Express) {
+  // Public stats (no auth required — used by landing page)
+  app.get('/api/stats', async (_req, res) => {
+    const db = dbStore.getDb();
+    if (!db) return res.json({ totalStates: 0, totalDistricts: 0, totalSchools: 0, totalStudents: 0, totalAssessments: 0, avgFlnLevel: 0, totalUsers: 0, certifiedCount: 0, certifiedPercent: 0 });
+
+    const [totalSchools, totalStudents, totalUsers, totalAssessments, stateCodes, districtCodes, avgResult, certifiedResult] = await Promise.all([
+      db.collection('schools').countDocuments(),
+      db.collection('students').countDocuments(),
+      db.collection('users').countDocuments(),
+      db.collection('worksheets').countDocuments(),
+      db.collection('schools').distinct('stateCode'),
+      db.collection('schools').distinct('districtCode'),
+      db.collection('students').aggregate([{ $group: { _id: null, avg: { $avg: '$currentLevel' } } }]).toArray(),
+      db.collection('students').aggregate([{ $match: { currentLevel: { $gte: 5 } } }, { $count: 'count' }]).toArray(),
+    ]);
+
+    const certifiedCount = certifiedResult[0]?.count ?? 0;
+    const avgFlnLevel = totalStudents > 0 ? Math.round(avgResult[0]?.avg ?? 0) : 0;
+
+    res.json({
+      totalStates: stateCodes.length,
+      totalDistricts: districtCodes.length,
+      totalSchools,
+      totalStudents,
+      totalAssessments,
+      avgFlnLevel,
+      totalUsers,
+      certifiedCount,
+      certifiedPercent: totalStudents > 0 ? Math.round((certifiedCount / totalStudents) * 100) : 0,
+    });
+  });
+}


### PR DESCRIPTION
Closes #118.

## Summary
Verbatim extraction of the public `GET /api/stats` route into `backend/src/routes/stats.ts`, following the pattern from PR #117. No logic changes.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Live-verified against a scratch seeded MongoDB (86,400 students, 1,440 schools) — `GET /api/stats` with no auth token returns the same shape and correct real numbers (36 states, 72 districts, 73% certified)
- [x] Scratch DB/server torn down after verification