### PR TITLE
Require auth on GET /api/schools

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -394,6 +394,8 @@ async function startServer() {
 
   // Schools
   app.get('/api/schools', async (req, res) => {
+    const user = getAuthUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
     const schools = await dbStore.getSchools();
     res.json(schools);
   });


### PR DESCRIPTION
## Summary
`GET /api/schools` had no auth check at all — unlike every other list endpoint in this app (students, teachers, evaluation reports), an unauthenticated request returned all 1,440 schools nationally. Added the same `getAuthUser` + 401 pattern used everywhere else.

Deliberately did **not** add role-scoping on top — any authenticated role still sees the full list, matching current behavior. Scoping this further (e.g. to an admin's own state/district) would be a separate, bigger decision since several panels already rely on getting the full school list client-side to compute real aggregates.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Live-verified against a scratch seeded MongoDB:
  - No token → 401 (was 200 before)
  - Invalid token → 401
  - Valid token → 200, all 1,440 schools (unchanged)
- [x] Scratch DB/server torn down after verification