### PR TITLE
feat: add multilingual (English/Hindi) support with real language swi…

### DIFF
--- a/frontend/src/components/LandingView.tsx
+++ b/frontend/src/components/LandingView.tsx
@@ -6,6 +6,8 @@ import { apiFetch } from '../services/apiClient';
 
 import React, { useState, useEffect } from 'react';
 import { Sparkles, Award, Globe, BookOpen, Users, BarChart3, ArrowRight, MapPin } from 'lucide-react';
+import { useLanguage } from '../i18n/LanguageContext';
+import { LanguageSwitcher } from './LanguageSwitcher';
 
 interface LandingViewProps {
   onNavigateToLogin: () => void;
@@ -22,6 +24,7 @@ interface Stats {
 }
 
 export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) => {
+  const { t } = useLanguage();
   const [fontSize, setFontSize] = useState(100);
   const [stats, setStats] = useState<Stats | null>(null);
   const [statsLoading, setStatsLoading] = useState(true);
@@ -62,11 +65,11 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
   }, []);
 
   const statCards = [
-    { label: 'States & Districts', value: stats ? `${stats.totalStates} States / ${stats.totalDistricts} Districts` : null, desc: 'Across India', icon: MapPin, color: 'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-950/40' },
-    { label: 'Registered Schools', value: stats?.totalSchools?.toLocaleString() ?? null, desc: 'Active institutions', icon: BookOpen, color: 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40' },
-    { label: 'Students Tracked', value: stats?.totalStudents?.toLocaleString() ?? null, desc: 'Enrolled learners', icon: Users, color: 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/40' },
-    { label: 'Assessments Conducted', value: stats?.totalAssessments?.toLocaleString() ?? null, desc: 'Worksheets generated', icon: BarChart3, color: 'text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-950/40' },
-    { label: 'National Avg FLN Level', value: stats ? `L${stats.avgFlnLevel}` : null, desc: 'Average student level', icon: Award, color: 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/40' },
+    { label: t('landing.stat.statesDistricts'), value: stats ? `${stats.totalStates} States / ${stats.totalDistricts} Districts` : null, desc: t('landing.stat.statesDistrictsDesc'), icon: MapPin, color: 'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-950/40' },
+    { label: t('landing.stat.registeredSchools'), value: stats?.totalSchools?.toLocaleString() ?? null, desc: t('landing.stat.registeredSchoolsDesc'), icon: BookOpen, color: 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40' },
+    { label: t('landing.stat.studentsTracked'), value: stats?.totalStudents?.toLocaleString() ?? null, desc: t('landing.stat.studentsTrackedDesc'), icon: Users, color: 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/40' },
+    { label: t('landing.stat.assessmentsConducted'), value: stats?.totalAssessments?.toLocaleString() ?? null, desc: t('landing.stat.assessmentsConductedDesc'), icon: BarChart3, color: 'text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-950/40' },
+    { label: t('landing.stat.nationalFlnScore'), value: stats ? `L${stats.avgFlnLevel}` : null, desc: t('landing.stat.nationalFlnScoreDesc'), icon: Award, color: 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/40' },
   ];
 
   return (
@@ -75,9 +78,9 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
       {/* 1. Accessibility / Top strip (neutral branding) */}
       <div className="w-full bg-[#111827] text-gray-300 text-[10px] md:text-xs font-semibold px-6 py-2 flex justify-between items-center border-b border-gray-800">
         <div className="flex items-center gap-3">
-          <span className="font-bold">FLN Portal</span>
+          <span className="font-bold">{t('portal.name')}</span>
           <span className="text-gray-500">|</span>
-          <span className="text-gray-300 hidden sm:inline">Foundational Literacy & Numeracy</span>
+          <span className="text-gray-300 hidden sm:inline">{t('portal.tagline')}</span>
         </div>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-1 text-[10px] md:text-xs font-bold">
@@ -86,16 +89,7 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
             <button onClick={() => adjustFontSize(10)} className="hover:text-white transition px-1.5 py-0.5 rounded border border-gray-700 hover:border-gray-500" title="Increase font size">A+</button>
           </div>
           <span className="text-gray-700 dark:text-gray-400">|</span>
-          <select
-            defaultValue="en"
-            onChange={(e) => {
-              if (e.target.value === 'hi') alert("हिन्दी भाषा में बदलें");
-            }}
-            className="bg-gray-800 text-gray-300 text-[10px] md:text-xs font-bold border border-gray-700 rounded px-2 py-1 outline-none hover:border-gray-500 cursor-pointer"
-          >
-            <option value="en">English</option>
-            <option value="hi">हिन्दी</option>
-          </select>
+          <LanguageSwitcher variant="dark" />
         </div>
       </div>
 
@@ -112,14 +106,14 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
             <div className="border-l-2 border-slate-200 dark:border-slate-700 pl-3">
               <div className="flex flex-wrap items-center gap-2 justify-center md:justify-start">
                 <span className="text-lg font-extrabold tracking-tight text-slate-900 dark:text-white uppercase">
-                  FLN Portal
+                  {t('portal.name')}
                 </span>
                 <span className="rounded-full bg-amber-100 dark:bg-amber-950/40 px-2.5 py-0.5 text-[10px] font-bold text-amber-700 dark:text-amber-400 uppercase tracking-wider">
                   Official Portal
                 </span>
               </div>
               <p className="text-xs text-slate-500 dark:text-slate-400 font-bold uppercase tracking-wide">
-                Foundational Literacy & Numeracy initiative
+                {t('portal.tagline')} initiative
               </p>
             </div>
           </div>
@@ -128,7 +122,7 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
               onClick={onNavigateToLogin}
               className="rounded-lg bg-indigo-700 dark:bg-indigo-800 px-6 py-2.5 text-xs font-extrabold text-white shadow-md dark:shadow-slate-950/50 transition-all duration-150 hover:bg-indigo-600 dark:hover:bg-indigo-700 border border-indigo-300 dark:border-indigo-700 active:scale-[0.98] uppercase tracking-wider"
             >
-              Sign In to Dashboard
+              {t('landing.signIn')}
             </button>
           </div>
         </div>
@@ -143,14 +137,14 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
           
           <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 dark:bg-amber-950/40 px-4 py-1.5 text-xs font-bold text-slate-900 dark:text-white mb-6 border border-amber-200 dark:border-amber-800">
             <span className="h-2 w-2 rounded-full bg-amber-600 dark:bg-amber-500" />
-            <span>Foundational Literacy and Numeracy (FLN) National Assessment Scheme</span>
+            <span>{t('landing.heroBadge')}</span>
           </div>
 
           <h2 className="text-3xl font-extrabold tracking-tight text-slate-900 dark:text-white sm:text-5xl max-w-4xl mx-auto leading-tight">
-            Foundational Literacy and Numeracy (FLN) Assessment & Grader
+            {t('landing.heroTitle')}
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-base text-slate-600 dark:text-slate-300 leading-relaxed">
-            A state-of-the-art adaptive evaluation, diagnostics, and customized diagnostic worksheet pipeline. Empowering district admin teams, school principals, teachers, and field-level volunteers to elevate primary student learning outcomes under NEP guidelines.
+            {t('landing.heroSubtitle')}
           </p>
 
         </div>
@@ -192,18 +186,18 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
           <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
             <div>
               <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white">
-                Our Vision
+                {t('landing.vision.title')}
               </h3>
               <p className="mt-3 text-sm leading-relaxed text-gray-500 dark:text-slate-300">
-                To enable all children of Class 3/4 to read with comprehension and write, perform basic mathematical operations, and acquire foundational math skills by providing them with customized assessments and remedial worksheets.
+                {t('landing.vision.body')}
               </p>
             </div>
             <div>
               <h3 className="text-xl font-bold tracking-tight text-gray-900 dark:text-white">
-                Curriculum Integration
+                {t('landing.curriculum.title')}
               </h3>
               <p className="mt-3 text-sm leading-relaxed text-gray-500 dark:text-slate-300">
-                Our unified model defines 59 cumulative proficiency levels mapped precisely to Class 1, 2, 3, and 4 standards across foundational numeracy strands. Utilizing a specialized evaluation system, we generate diagnostic assessments on demand to pinpoint students' exact gaps.
+                {t('landing.curriculum.body')}
               </p>
             </div>
           </div>

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useRef, useEffect } from 'react';
+import { Languages, Check } from 'lucide-react';
+import { useLanguage } from '../i18n/LanguageContext';
+import { SUPPORTED_LANGUAGES } from '../i18n/translations';
+
+interface LanguageSwitcherProps {
+  /** 'dark' is for placement on the always-dark top strip of the landing page. */
+  variant?: 'auto' | 'dark';
+}
+
+export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant = 'auto' }) => {
+  const { lang, setLang, t } = useLanguage();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const isDark = variant === 'dark';
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-label={t('language.select')}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={`flex items-center gap-1.5 text-[10px] md:text-xs font-bold transition hover:underline ${
+          isDark
+            ? 'text-gray-300 hover:text-white'
+            : 'text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white'
+        }`}
+      >
+        <Languages className="h-3.5 w-3.5" />
+        {SUPPORTED_LANGUAGES.find((l) => l.code === lang)?.nativeLabel}
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute right-0 mt-2 w-36 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-lg dark:shadow-slate-950/50 py-1 z-50"
+        >
+          {SUPPORTED_LANGUAGES.map((option) => (
+            <button
+              key={option.code}
+              role="option"
+              aria-selected={option.code === lang}
+              onClick={() => {
+                setLang(option.code);
+                setOpen(false);
+              }}
+              className="w-full flex items-center justify-between px-3 py-1.5 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 text-left"
+            >
+              <span>{option.nativeLabel}</span>
+              {option.code === lang && <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import {
   LayoutDashboard, BookOpen, UserCheck, Calendar, ShieldCheck, HelpCircle, Settings, Users,
   School, GraduationCap, MapPin, BarChart3, FileText, ClipboardList, ShieldAlert, KeyRound,   Clock
 } from 'lucide-react';
+import { LanguageSwitcher } from './LanguageSwitcher';
 
 interface NavigationItem {
   name: string;
@@ -332,6 +333,10 @@ export const Layout: React.FC<LayoutProps> = ({
 
         {/* Topbar Right Section */}
         <div className="flex items-center gap-4">
+          {/* Language Switcher — dashboard nav labels remain English for now;
+              see i18n/translations.ts for the keys already wired to Landing/Login. */}
+          <LanguageSwitcher />
+
           {/* Database Storage Status (MongoDB Only) */}
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-emerald-200 bg-emerald-50 text-xs font-mono font-bold shrink-0">
             <span className="h-2.5 w-2.5 rounded-full bg-emerald-500 animate-pulse shrink-0" />

--- a/frontend/src/components/LoginView.tsx
+++ b/frontend/src/components/LoginView.tsx
@@ -7,6 +7,8 @@ import { apiFetch } from '../services/apiClient';
 import React, { useState } from 'react';
 import { Eye, EyeOff, AlertCircle, ArrowLeft } from 'lucide-react';
 import { User, UserRole } from '../types';
+import { useLanguage } from '../i18n/LanguageContext';
+import { LanguageSwitcher } from './LanguageSwitcher';
 
 interface LoginViewProps {
   onLoginSuccess: (token: string, user: User) => void;
@@ -14,6 +16,7 @@ interface LoginViewProps {
 }
 
 export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHome }) => {
+  const { t } = useLanguage();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
@@ -68,6 +71,10 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
       {/* Container with neutral double border design */}
       <div className="w-full max-w-lg rounded-xl border-t-8 border-t-indigo-700 dark:border-t-indigo-600 border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-8 shadow-md dark:shadow-slate-950/50 transition-all">
 
+        <div className="flex justify-end mb-2">
+          <LanguageSwitcher />
+        </div>
+
         {/* Branding header */}
         <div className="flex flex-col items-center text-center">
           {/* Authentic Ashoka Pillar Emblem Visual Representation */}
@@ -77,13 +84,13 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
             </svg>
           </div>
           <h2 className="mt-4 text-xl font-extrabold tracking-tight text-slate-900 dark:text-white sm:text-2xl uppercase">
-            FLN Portal Login
+            {t('login.title')}
           </h2>
           <p className="mt-1 text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
-            Foundational Literacy and Numeracy (FLN) assessment scheme
+            {t('login.subtitle')}
           </p>
           <span className="mt-2 inline-block rounded bg-amber-100 dark:bg-amber-950/40 px-3 py-1 text-[10px] font-extrabold text-amber-800 dark:text-amber-400 uppercase tracking-widest border border-amber-200 dark:border-amber-800">
-            AUTHORIZED DEPARTMENTAL SIGN-IN
+            {t('login.badge')}
           </span>
         </div>
 
@@ -93,13 +100,13 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
           {/* User Email or Username input */}
           <div className="space-y-1.5">
             <label className="text-xs font-extrabold text-slate-700 dark:text-slate-300 uppercase tracking-wider block">
-              Official Email Address / SSO Username
+              {t('login.emailLabel')}
             </label>
             <input
               type="email"
               required
               className="w-full rounded-lg border-2 border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-950 px-3.5 py-2.5 text-sm text-slate-950 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:border-indigo-700 dark:focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-700 dark:focus:ring-indigo-500 font-medium"
-              placeholder="enter mail or username"
+              placeholder={t('login.emailPlaceholder')}
               value={email}
               onChange={e => setEmail(e.target.value)}
             />
@@ -108,7 +115,7 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
           {/* User Password input */}
           <div className="space-y-1.5">
             <label className="text-xs font-extrabold text-slate-700 dark:text-slate-300 uppercase tracking-wider block">
-              Official Access Password
+              {t('login.passwordLabel')}
             </label>
             <div className="relative">
               <input
@@ -143,7 +150,7 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
             disabled={loading}
             className="flex w-full items-center justify-center rounded-lg bg-indigo-700 dark:bg-indigo-800 py-3.5 text-xs font-extrabold text-white shadow-md dark:shadow-slate-950/50 transition-all duration-150 hover:bg-indigo-600 dark:hover:bg-indigo-700 border border-indigo-300 dark:border-indigo-700 active:scale-[0.98] disabled:opacity-50 uppercase tracking-widest cursor-pointer font-mono"
           >
-            {loading ? 'Verifying Digital Certificate Signature...' : 'Secure Sign In'}
+            {loading ? t('login.submitting') : t('login.submit')}
           </button>
         </form>
 
@@ -174,7 +181,7 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
           className="mt-6 flex w-full items-center justify-center gap-1.5 text-xs font-extrabold text-indigo-700 dark:text-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-300 hover:underline uppercase tracking-wider"
         >
           <ArrowLeft className="h-3.5 w-3.5" />
-          Back to Public Information Portal
+          {t('login.back')}
         </button>
 
         {/* Legal Disclaimer Tag */}

--- a/frontend/src/i18n/LanguageContext.tsx
+++ b/frontend/src/i18n/LanguageContext.tsx
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { createContext, useContext, useState, useCallback, useMemo, useEffect } from 'react';
+import { translations, LanguageCode, SUPPORTED_LANGUAGES } from './translations';
+
+const STORAGE_KEY = 'fln_language';
+
+interface LanguageContextValue {
+  lang: LanguageCode;
+  setLang: (lang: LanguageCode) => void;
+  t: (key: keyof (typeof translations)['en']) => string;
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+function getInitialLanguage(): LanguageCode {
+  if (typeof window === 'undefined') return 'en';
+  const stored = window.localStorage.getItem(STORAGE_KEY) as LanguageCode | null;
+  if (stored && SUPPORTED_LANGUAGES.some((l) => l.code === stored)) return stored;
+  return 'en';
+}
+
+export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [lang, setLangState] = useState<LanguageCode>(getInitialLanguage);
+
+  useEffect(() => {
+    document.documentElement.lang = lang;
+  }, [lang]);
+
+  const setLang = useCallback((next: LanguageCode) => {
+    setLangState(next);
+    window.localStorage.setItem(STORAGE_KEY, next);
+  }, []);
+
+  const t = useCallback(
+    (key: keyof (typeof translations)['en']) => {
+      return translations[lang][key] ?? translations.en[key] ?? key;
+    },
+    [lang]
+  );
+
+  const value = useMemo(() => ({ lang, setLang, t }), [lang, setLang, t]);
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+};
+
+// Usage: const { t, lang, setLang } = useLanguage();
+export function useLanguage(): LanguageContextValue {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) {
+    throw new Error('useLanguage() must be called within a <LanguageProvider>');
+  }
+  return ctx;
+}

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Central translation dictionary.
+// To add a new language: add an entry to SUPPORTED_LANGUAGES below, then add
+// a matching block here with the same keys as `en`. Components never
+// hardcode user-facing strings — they call t('key') so every language stays
+// in sync from one place.
+
+export type LanguageCode = 'en' | 'hi';
+
+export const SUPPORTED_LANGUAGES: { code: LanguageCode; label: string; nativeLabel: string }[] = [
+  { code: 'en', label: 'English', nativeLabel: 'English' },
+  { code: 'hi', label: 'Hindi', nativeLabel: 'हिन्दी' },
+];
+
+type TranslationKeys =
+  | 'portal.name'
+  | 'portal.tagline'
+  | 'landing.signIn'
+  | 'landing.heroBadge'
+  | 'landing.heroTitle'
+  | 'landing.heroSubtitle'
+  | 'landing.stat.statesDistricts'
+  | 'landing.stat.statesDistrictsDesc'
+  | 'landing.stat.registeredSchools'
+  | 'landing.stat.registeredSchoolsDesc'
+  | 'landing.stat.studentsTracked'
+  | 'landing.stat.studentsTrackedDesc'
+  | 'landing.stat.assessmentsConducted'
+  | 'landing.stat.assessmentsConductedDesc'
+  | 'landing.stat.nationalFlnScore'
+  | 'landing.stat.nationalFlnScoreDesc'
+  | 'landing.vision.title'
+  | 'landing.vision.body'
+  | 'landing.curriculum.title'
+  | 'landing.curriculum.body'
+  | 'login.title'
+  | 'login.subtitle'
+  | 'login.badge'
+  | 'login.emailLabel'
+  | 'login.emailPlaceholder'
+  | 'login.passwordLabel'
+  | 'login.submit'
+  | 'login.submitting'
+  | 'login.back'
+  | 'language.select';
+
+export const translations: Record<LanguageCode, Record<TranslationKeys, string>> = {
+  en: {
+    'portal.name': 'FLN Portal',
+    'portal.tagline': 'Foundational Literacy & Numeracy',
+    'landing.signIn': 'Sign In to Dashboard',
+    'landing.heroBadge': 'Foundational Literacy and Numeracy (FLN) National Assessment Scheme',
+    'landing.heroTitle': 'Foundational Literacy and Numeracy (FLN) Assessment & Grader',
+    'landing.heroSubtitle':
+      'A state-of-the-art adaptive evaluation, diagnostics, and customized diagnostic worksheet pipeline. Empowering district admin teams, school principals, teachers, and field-level volunteers to elevate primary student learning outcomes under NEP guidelines.',
+    'landing.stat.statesDistricts': 'States & Districts',
+    'landing.stat.statesDistrictsDesc': 'Across India',
+    'landing.stat.registeredSchools': 'Registered Schools',
+    'landing.stat.registeredSchoolsDesc': 'Active institutions',
+    'landing.stat.studentsTracked': 'Students Tracked',
+    'landing.stat.studentsTrackedDesc': 'Enrolled learners',
+    'landing.stat.assessmentsConducted': 'Assessments Conducted',
+    'landing.stat.assessmentsConductedDesc': 'Worksheets generated',
+    'landing.stat.nationalFlnScore': 'National Avg FLN Level',
+    'landing.stat.nationalFlnScoreDesc': 'Average student level',
+    'landing.vision.title': 'Our Vision',
+    'landing.vision.body':
+      "To enable all children of Class 3/4 to read with comprehension and write, perform basic mathematical operations, and acquire foundational math skills by providing them with customized assessments and remedial worksheets.",
+    'landing.curriculum.title': 'Curriculum Integration',
+    'landing.curriculum.body':
+      "Our unified model defines 59 cumulative proficiency levels mapped precisely to Class 1, 2, 3, and 4 standards across foundational numeracy strands. Utilizing a specialized evaluation system, we generate diagnostic assessments on demand to pinpoint students' exact gaps.",
+    'login.title': 'FLN Portal Login',
+    'login.subtitle': 'Foundational Literacy and Numeracy (FLN) assessment scheme',
+    'login.badge': 'AUTHORIZED DEPARTMENTAL SIGN-IN',
+    'login.emailLabel': 'Official Email Address / SSO Username',
+    'login.emailPlaceholder': 'enter mail or username',
+    'login.passwordLabel': 'Official Access Password',
+    'login.submit': 'Secure Sign In',
+    'login.submitting': 'Verifying Digital Certificate Signature...',
+    'login.back': 'Back to Public Information Portal',
+    'language.select': 'Language',
+  },
+  hi: {
+    'portal.name': 'एफएलएन पोर्टल',
+    'portal.tagline': 'बुनियादी साक्षरता और संख्यात्मकता',
+    'landing.signIn': 'डैशबोर्ड में साइन इन करें',
+    'landing.heroBadge': 'बुनियादी साक्षरता और संख्यात्मकता (एफएलएन) राष्ट्रीय मूल्यांकन योजना',
+    'landing.heroTitle': 'बुनियादी साक्षरता और संख्यात्मकता (एफएलएन) मूल्यांकन एवं ग्रेडर',
+    'landing.heroSubtitle':
+      'एक अत्याधुनिक अनुकूली मूल्यांकन, निदान और अनुकूलित निदान वर्कशीट प्रणाली। जिला प्रशासन, स्कूल प्राचार्यों, शिक्षकों और क्षेत्रीय स्वयंसेवकों को एनईपी दिशानिर्देशों के तहत प्राथमिक छात्रों के सीखने के परिणामों को बेहतर बनाने हेतु सशक्त बनाना।',
+    'landing.stat.statesDistricts': 'राज्य और जिले',
+    'landing.stat.statesDistrictsDesc': 'पूरे भारत में',
+    'landing.stat.registeredSchools': 'पंजीकृत स्कूल',
+    'landing.stat.registeredSchoolsDesc': 'सक्रिय संस्थान',
+    'landing.stat.studentsTracked': 'ट्रैक किए गए छात्र',
+    'landing.stat.studentsTrackedDesc': 'नामांकित शिक्षार्थी',
+    'landing.stat.assessmentsConducted': 'आयोजित मूल्यांकन',
+    'landing.stat.assessmentsConductedDesc': 'जनरेट की गई वर्कशीट',
+    'landing.stat.nationalFlnScore': 'राष्ट्रीय औसत एफएलएन स्तर',
+    'landing.stat.nationalFlnScoreDesc': 'औसत छात्र स्तर',
+    'landing.vision.title': 'हमारा दृष्टिकोण',
+    'landing.vision.body':
+      'कक्षा 3/4 के सभी बच्चों को समझ के साथ पढ़ने और लिखने, बुनियादी गणितीय संक्रियाएं करने और अनुकूलित मूल्यांकन तथा उपचारात्मक वर्कशीट के माध्यम से बुनियादी गणित कौशल प्राप्त करने में सक्षम बनाना।',
+    'landing.curriculum.title': 'पाठ्यक्रम एकीकरण',
+    'landing.curriculum.body':
+      'हमारा एकीकृत मॉडल कक्षा 1, 2, 3 और 4 के मानकों के अनुरूप बुनियादी संख्यात्मकता क्षेत्रों में 59 संचयी दक्षता स्तर परिभाषित करता है। एक विशेष मूल्यांकन प्रणाली का उपयोग करते हुए, हम छात्रों की सटीक कमियों का पता लगाने के लिए मांग पर निदान मूल्यांकन तैयार करते हैं।',
+    'login.title': 'एफएलएन पोर्टल लॉगिन',
+    'login.subtitle': 'बुनियादी साक्षरता और संख्यात्मकता (एफएलएन) मूल्यांकन योजना',
+    'login.badge': 'अधिकृत विभागीय साइन-इन',
+    'login.emailLabel': 'आधिकारिक ईमेल पता / एसएसओ उपयोगकर्ता नाम',
+    'login.emailPlaceholder': 'मेल या उपयोगकर्ता नाम दर्ज करें',
+    'login.passwordLabel': 'आधिकारिक एक्सेस पासवर्ड',
+    'login.submit': 'सुरक्षित साइन इन',
+    'login.submitting': 'डिजिटल प्रमाणपत्र हस्ताक्षर सत्यापित हो रहा है...',
+    'login.back': 'सार्वजनिक सूचना पोर्टल पर वापस जाएं',
+    'language.select': 'भाषा',
+  },
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {BrowserRouter} from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
+import { LanguageProvider } from './i18n/LanguageContext';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -16,10 +17,12 @@ const queryClient = new QueryClient({
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <LanguageProvider>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </LanguageProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
…tcher

- Add i18n scaffolding: LanguageContext (React context + t() hook, persists choice to localStorage) and a typed translations dictionary (translations.ts) covering portal branding, landing page hero/stats/vision copy, and the full login form.
- Add LanguageSwitcher component: a real dropdown that actually switches language, replacing the decorative English/Hindi <select> on the landing page's top strip that previously just called alert('हिन्दी भाषा में बदलें') and changed nothing.
- Wire the switcher into LandingView, LoginView, and the dashboard Layout topbar (visible on every authenticated page too).
- Fully compatible with the current dark-mode theming — all new UI respects dark: variants already used across the app.
- Adding a new language going forward only requires one entry in SUPPORTED_LANGUAGES plus one dictionary block in translations.ts.

Scope note: dashboard sidebar navigation items (Students, Worksheets, Reports, etc.) are intentionally left in English for this PR to keep the diff reviewable — the i18n plumbing is fully reusable for a follow-up PR to extend coverage there.