### PR TITLE
feat: add gamified, level-aware practice mode for students

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -717,6 +717,51 @@ async function startServer() {
     });
   });
 
+  // Lightweight, non-PDF practice question set for gamified in-class practice.
+  // Unlike /diagnostic, this never touches Puppeteer/PDF generation and never
+  // mutates the official assessment-cycle streak/level fields — it's a fast,
+  // teacher-facilitated activity a student can run between the three fixed
+  // assessment cycles (SRS §1.2), using the same level generator as worksheets
+  // so the difficulty always matches the student's real current placement.
+  app.get('/api/students/:id/practice', async (req, res) => {
+    const user = getAuthUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const students = await dbStore.getStudents();
+    const student = students.find(s => s.id === req.params.id);
+    if (!student) return res.status(404).json({ error: 'Student not found.' });
+    if (!canAccessStudent(user, student)) return res.status(403).json({ error: 'Forbidden.' });
+
+    // Optional ?topic= lets the UI target a specific weak area surfaced in the
+    // "Recommended Focus Areas" panel instead of a generic mixed set.
+    const topicFilter = typeof req.query.topic === 'string' ? req.query.topic : undefined;
+
+    const level = student.currentLevel;
+    const subLevel = student.currentSubLevel ?? 0;
+
+    let questions = generateQuestionsForLevel(level, subLevel);
+    if (topicFilter) {
+      const filtered = questions.filter(q => q.topic === topicFilter);
+      if (filtered.length > 0) questions = filtered;
+    }
+
+    // Re-tag ids per request so replaying the same level never collides with
+    // a prior session's question_id in client-side tracking.
+    questions = questions.map((q, idx) => ({
+      ...q,
+      question_id: `PRACTICE_${student.id}_${level}_${subLevel}_${idx}_${Date.now()}`
+    }));
+
+    res.json({
+      studentId: student.id,
+      studentName: student.name,
+      level,
+      subLevel,
+      streak: student.streak,
+      questions
+    });
+  });
+
   // Generate multi-student PDF worksheet paper (Puppeteer pipeline)
   app.post('/api/paper/generate', async (req, res) => {
     const user = getAuthUser(req);

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -1,10 +1,11 @@
 import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { User, UserRole, Student, ClassGroup, School, EvaluationReport, LogEntry, Ticket } from '../types';
-import { Users, ShieldAlert, BookOpen, Calendar, ArrowRight, CheckCircle2, XCircle, SlidersHorizontal, Layers, Award, MapPin, School as SchoolIcon, BarChart3, FileText, ClipboardList, Building2, GraduationCap, BookMarked, Globe, Settings, Database, RefreshCw, Search, ChevronDown } from 'lucide-react';
+import { Users, ShieldAlert, BookOpen, Calendar, ArrowRight, CheckCircle2, XCircle, SlidersHorizontal, Layers, Award, MapPin, School as SchoolIcon, BarChart3, FileText, ClipboardList, Building2, GraduationCap, BookMarked, Globe, Settings, Database, RefreshCw, Search, ChevronDown, Flame } from 'lucide-react';
 import { Table, Column } from './Table';
 import { MetricCard } from './Card';
 import { STATE_NAMES, DISTRICT_NAMES, BLOCK_NAMES } from '../constants';
+import { PracticeMode } from './PracticeMode';
 
 interface PanelViewsProps {
   activePanel: string;
@@ -171,6 +172,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
   const [apiUsers, setApiUsers] = useState<any[]>([]);
   const [apiReports, setApiReports] = useState<EvaluationReport[]>([]);
   const [apiTeachers, setApiTeachers] = useState<any[]>([]);
+  const [practiceSession, setPracticeSession] = useState<{ studentId: string; studentName: string; topic?: string } | null>(null);
 
   useEffect(() => {
     const headers = { 'Authorization': `Bearer ${token}` };
@@ -695,10 +697,26 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
 
               {/* Recommended Focus */}
               <div className="bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-950 dark:to-indigo-950 border border-blue-200 dark:border-blue-800 rounded-xl p-5 shadow-sm">
-                <h3 className="text-xs font-mono font-bold text-blue-700 dark:text-blue-300 uppercase tracking-wider mb-3 flex items-center gap-2"><Award className="w-3.5 h-3.5" /> Recommended Focus Areas</h3>
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-xs font-mono font-bold text-blue-700 dark:text-blue-300 uppercase tracking-wider flex items-center gap-2"><Award className="w-3.5 h-3.5" /> Recommended Focus Areas</h3>
+                  <button
+                    onClick={() => setPracticeSession({ studentId: s.id, studentName: s.name })}
+                    className="flex items-center gap-1.5 rounded-lg bg-indigo-700 dark:bg-indigo-600 px-3 py-1.5 text-[10px] font-extrabold text-white uppercase tracking-wider hover:bg-indigo-600 dark:hover:bg-indigo-500 transition"
+                  >
+                    <Flame className="w-3.5 h-3.5" /> Start Practice
+                  </button>
+                </div>
                 <div className="space-y-2">
                   {weakAreas.length > 0 ? weakAreas.map(topic => (
-                    <div key={topic} className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200 bg-white/60 dark:bg-slate-800/60 rounded-lg px-3 py-2 border border-blue-100 dark:border-blue-800"><span className="w-2 h-2 rounded-full bg-amber-500 shrink-0" />Additional practice recommended for <strong>{topic}</strong></div>
+                    <div key={topic} className="flex items-center justify-between gap-2 text-sm text-slate-700 dark:text-slate-200 bg-white/60 dark:bg-slate-800/60 rounded-lg px-3 py-2 border border-blue-100 dark:border-blue-800">
+                      <div className="flex items-center gap-2"><span className="w-2 h-2 rounded-full bg-amber-500 shrink-0" />Additional practice recommended for <strong>{topic}</strong></div>
+                      <button
+                        onClick={() => setPracticeSession({ studentId: s.id, studentName: s.name, topic })}
+                        className="text-[10px] font-extrabold text-indigo-600 dark:text-indigo-400 uppercase tracking-wider hover:underline shrink-0"
+                      >
+                        Practice this →
+                      </button>
+                    </div>
                   )) : reports.length > 0 ? <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200 bg-white/60 dark:bg-slate-800/60 rounded-lg px-3 py-2 border border-blue-100 dark:border-blue-800"><span className="w-2 h-2 rounded-full bg-emerald-500 shrink-0" />All skills at expected level — no focus areas needed</div> : <div className="text-sm text-slate-500 dark:text-slate-400">Complete a diagnostic assessment to generate recommendations.</div>}
                   {s.currentLevel < 59 && <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200 bg-white/60 dark:bg-slate-800/60 rounded-lg px-3 py-2 border border-blue-100 dark:border-blue-800"><span className="w-2 h-2 rounded-full bg-emerald-500 shrink-0" />Next milestone: <strong>Level {Math.min(59, s.currentLevel + 1)}</strong></div>}
                 </div>
@@ -990,6 +1008,16 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
               ) : <div className="text-center py-8"><p className="text-xs text-slate-400 dark:text-slate-500">{activityFilter === 'all' ? 'No activity recorded yet.' : `No ${activityFilter === 'assessment' ? 'assessment' : 'level change'} activity found.`}</p></div>}
             </div>
           </div>
+        )}
+
+        {practiceSession && practiceSession.studentId === s.id && (
+          <PracticeMode
+            studentId={practiceSession.studentId}
+            studentName={practiceSession.studentName}
+            topic={practiceSession.topic}
+            token={token}
+            onClose={() => setPracticeSession(null)}
+          />
         )}
       </div>
     );

--- a/frontend/src/components/PracticeMode.tsx
+++ b/frontend/src/components/PracticeMode.tsx
@@ -1,0 +1,318 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { apiFetch } from '../services/apiClient';
+import React, { useEffect, useState } from 'react';
+import { X, Flame, CheckCircle2, XCircle, PartyPopper, Loader2, RotateCcw } from 'lucide-react';
+import { Question } from '../types';
+
+interface PracticeModeProps {
+  studentId: string;
+  studentName: string;
+  token: string;
+  /** Optional weak-area topic (from the Recommended Focus Areas panel) to target the session. */
+  topic?: string;
+  onClose: () => void;
+}
+
+interface PracticeSet {
+  studentId: string;
+  studentName: string;
+  level: number;
+  subLevel: number;
+  streak: number;
+  questions: Question[];
+}
+
+type AnswerState = 'unanswered' | 'correct' | 'incorrect';
+
+// Normalizes text/number answers before comparing so "12", " 12 ", "twelve"-vs-"12"
+// style formatting differences don't register a right answer as wrong.
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export const PracticeMode: React.FC<PracticeModeProps> = ({ studentId, studentName, token, topic, onClose }) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [set, setSet] = useState<PracticeSet | null>(null);
+
+  const [qIndex, setQIndex] = useState(0);
+  const [inputValue, setInputValue] = useState('');
+  const [answerState, setAnswerState] = useState<AnswerState>('unanswered');
+  const [sessionStreak, setSessionStreak] = useState(0);
+  const [bestStreak, setBestStreak] = useState(0);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [finished, setFinished] = useState(false);
+
+  const loadSet = () => {
+    setLoading(true);
+    setError(null);
+    setFinished(false);
+    setQIndex(0);
+    setSessionStreak(0);
+    setCorrectCount(0);
+    setAnswerState('unanswered');
+    setInputValue('');
+
+    const query = topic ? `?topic=${encodeURIComponent(topic)}` : '';
+    apiFetch(`/api/students/${studentId}/practice${query}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error('Failed to load practice set.');
+        return r.json();
+      })
+      .then((data: PracticeSet) => setSet(data))
+      .catch(() => setError('Could not load a practice set right now. Please try again.'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadSet();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [studentId, topic]);
+
+  if (loading) {
+    return (
+      <PracticeOverlay onClose={onClose}>
+        <div className="flex flex-col items-center justify-center py-20 gap-3">
+          <Loader2 className="h-8 w-8 animate-spin text-indigo-600 dark:text-indigo-400" />
+          <p className="text-sm text-slate-500 dark:text-slate-400">Preparing practice questions…</p>
+        </div>
+      </PracticeOverlay>
+    );
+  }
+
+  if (error || !set || set.questions.length === 0) {
+    return (
+      <PracticeOverlay onClose={onClose}>
+        <div className="flex flex-col items-center justify-center py-16 gap-4 text-center px-6">
+          <XCircle className="h-10 w-10 text-red-500" />
+          <p className="text-sm text-slate-600 dark:text-slate-300">{error || 'No practice questions available for this level yet.'}</p>
+          <button
+            onClick={loadSet}
+            className="flex items-center gap-2 rounded-lg bg-indigo-700 px-4 py-2 text-xs font-bold text-white hover:bg-indigo-600"
+          >
+            <RotateCcw className="h-3.5 w-3.5" /> Try again
+          </button>
+        </div>
+      </PracticeOverlay>
+    );
+  }
+
+  const question = set.questions[qIndex];
+  const isLast = qIndex === set.questions.length - 1;
+
+  const checkAnswer = () => {
+    if (answerState !== 'unanswered' || !inputValue) return;
+    const isCorrect = normalize(inputValue) === normalize(question.answer);
+    setAnswerState(isCorrect ? 'correct' : 'incorrect');
+    if (isCorrect) {
+      setCorrectCount((c) => c + 1);
+      setSessionStreak((s) => {
+        const next = s + 1;
+        setBestStreak((b) => Math.max(b, next));
+        return next;
+      });
+    } else {
+      setSessionStreak(0);
+    }
+  };
+
+  const selectChoice = (choice: string) => {
+    if (answerState !== 'unanswered') return;
+    setInputValue(choice);
+    const isCorrect = normalize(choice) === normalize(question.answer);
+    setAnswerState(isCorrect ? 'correct' : 'incorrect');
+    if (isCorrect) {
+      setCorrectCount((c) => c + 1);
+      setSessionStreak((s) => {
+        const next = s + 1;
+        setBestStreak((b) => Math.max(b, next));
+        return next;
+      });
+    } else {
+      setSessionStreak(0);
+    }
+  };
+
+  const next = () => {
+    if (isLast) {
+      setFinished(true);
+      return;
+    }
+    setQIndex((i) => i + 1);
+    setInputValue('');
+    setAnswerState('unanswered');
+  };
+
+  if (finished) {
+    return (
+      <PracticeOverlay onClose={onClose}>
+        <div className="flex flex-col items-center justify-center py-14 gap-4 text-center px-6">
+          <PartyPopper className="h-12 w-12 text-amber-500" />
+          <h3 className="text-xl font-extrabold text-slate-900 dark:text-white">Session complete!</h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            {studentName} got <span className="font-bold text-emerald-600 dark:text-emerald-400">{correctCount}</span> out of{' '}
+            {set.questions.length} correct, with a best streak of{' '}
+            <span className="inline-flex items-center gap-0.5 font-bold text-amber-600 dark:text-amber-400">
+              {bestStreak} <Flame className="h-3.5 w-3.5" />
+            </span>
+            .
+          </p>
+          <div className="flex gap-3 mt-2">
+            <button
+              onClick={loadSet}
+              className="flex items-center gap-2 rounded-lg bg-indigo-700 px-5 py-2.5 text-xs font-bold text-white hover:bg-indigo-600"
+            >
+              <RotateCcw className="h-3.5 w-3.5" /> Practice again
+            </button>
+            <button
+              onClick={onClose}
+              className="rounded-lg border border-slate-200 dark:border-slate-700 px-5 py-2.5 text-xs font-bold text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </PracticeOverlay>
+    );
+  }
+
+  return (
+    <PracticeOverlay onClose={onClose}>
+      {/* Header: level badge + live streak */}
+      <div className="flex items-center justify-between px-6 pt-5">
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">
+            {studentName} · Level {set.level}.{set.subLevel}
+          </p>
+          <p className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+            Question {qIndex + 1} of {set.questions.length}
+            {question.topic ? ` · ${question.topic}` : ''}
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 rounded-full bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 px-3 py-1.5">
+          <Flame className={`h-4 w-4 ${sessionStreak > 0 ? 'text-amber-500' : 'text-slate-300 dark:text-slate-600'}`} />
+          <span className="text-sm font-extrabold text-amber-700 dark:text-amber-400">{sessionStreak}</span>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="px-6 mt-3">
+        <div className="h-1.5 w-full rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-indigo-600 dark:bg-indigo-500 transition-all"
+            style={{ width: `${((qIndex + (answerState !== 'unanswered' ? 1 : 0)) / set.questions.length) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Question body */}
+      <div className="px-6 py-8">
+        <p className="text-center text-lg font-bold text-slate-900 dark:text-white leading-relaxed">
+          {question.question}
+        </p>
+
+        {question.answer_type === 'choice' && question.choices ? (
+          <div className="mt-6 grid grid-cols-2 gap-3">
+            {question.choices.map((choice) => {
+              const isSelected = inputValue === choice;
+              const isRightChoice = answerState !== 'unanswered' && normalize(choice) === normalize(question.answer);
+              return (
+                <button
+                  key={choice}
+                  onClick={() => selectChoice(choice)}
+                  disabled={answerState !== 'unanswered'}
+                  className={`rounded-xl border-2 px-4 py-3 text-sm font-bold transition ${
+                    isRightChoice
+                      ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-400'
+                      : isSelected
+                      ? 'border-red-400 bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-400'
+                      : 'border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:border-indigo-300 dark:hover:border-indigo-700'
+                  }`}
+                >
+                  {choice}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="mt-6 flex flex-col items-center gap-3">
+            <input
+              type={question.answer_type === 'number' ? 'number' : 'text'}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && checkAnswer()}
+              disabled={answerState !== 'unanswered'}
+              className={`w-40 rounded-lg border-2 px-3.5 py-2.5 text-center text-lg font-bold focus:outline-none ${
+                answerState === 'correct'
+                  ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-400'
+                  : answerState === 'incorrect'
+                  ? 'border-red-400 bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-400'
+                  : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-950 text-slate-900 dark:text-white focus:border-indigo-600'
+              }`}
+              autoFocus
+            />
+            {answerState === 'unanswered' && (
+              <button
+                onClick={checkAnswer}
+                disabled={!inputValue}
+                className="rounded-lg bg-indigo-700 px-6 py-2 text-xs font-bold text-white hover:bg-indigo-600 disabled:opacity-40"
+              >
+                Check
+              </button>
+            )}
+          </div>
+        )}
+
+        {answerState !== 'unanswered' && (
+          <div
+            className={`mt-5 flex items-center justify-center gap-2 text-sm font-bold ${
+              answerState === 'correct' ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+            }`}
+          >
+            {answerState === 'correct' ? (
+              <>
+                <CheckCircle2 className="h-4 w-4" /> Correct!
+              </>
+            ) : (
+              <>
+                <XCircle className="h-4 w-4" /> Not quite — the answer was {question.answer}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {answerState !== 'unanswered' && (
+        <div className="px-6 pb-6">
+          <button
+            onClick={next}
+            className="w-full rounded-lg bg-indigo-700 py-2.5 text-xs font-extrabold text-white hover:bg-indigo-600"
+          >
+            {isLast ? 'Finish session' : 'Next question →'}
+          </button>
+        </div>
+      )}
+    </PracticeOverlay>
+  );
+};
+
+const PracticeOverlay: React.FC<{ onClose: () => void; children: React.ReactNode }> = ({ onClose, children }) => (
+  <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm px-4">
+    <div className="relative w-full max-w-md rounded-2xl bg-white dark:bg-slate-900 shadow-2xl border border-slate-200 dark:border-slate-700">
+      <button
+        onClick={onClose}
+        className="absolute right-3 top-3 rounded-full p-1.5 text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 dark:text-slate-500"
+        aria-label="Close practice session"
+      >
+        <X className="h-4 w-4" />
+      </button>
+      {children}
+    </div>
+  </div>
+);


### PR DESCRIPTION
Backend:
- New GET /api/students/:id/practice endpoint. Reuses the existing generateQuestionsForLevel() level generator (the same one that powers real worksheet PDFs) so practice questions always match the student's real currentLevel/currentSubLevel — never a generic or hardcoded set.
- Skips the Puppeteer/PDF pipeline entirely for speed, since this is a fast in-class activity, not an official exam paper.
- Optional ?topic= query param to target one weak area at a time.
- Deliberately does NOT mutate the official student.streak or levelHistory fields used by the assessment-cycle/evaluation pipeline — practice-session state stays session-local so this can't interfere with the official 3x/year assessment cycle logic other in-flight PRs are working on.
- Uses the same getAuthUser/canAccessStudent auth pattern as the existing diagnostic endpoint.

Frontend:
- New PracticeMode.tsx: an interactive practice session — one question at a time, immediate correct/incorrect feedback, a live streak counter, a progress bar, and an end-of-session summary. Supports the existing number/text/choice question types.
- Wired into PanelViews.tsx's 'Recommended Focus Areas' panel, which previously only showed static text ('Additional practice recommended for X') with no action attached to it. Added a 'Start Practice' button plus a per-topic 'Practice this ->' button so a teacher can launch a session targeted at a specific weak area directly from the student profile.

This turns currentLevel/currentSubLevel/streak — fields that already existed in the data model and were only ever displayed as static numbers — into an actual interactive learning activity, which the project's own README describes as the goal ('gradual, fun activities') but nothing in the codebase implemented yet.