### PR TITLE
fix: restore Authorization header on apiFetch requests

### DIFF
--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -16,8 +16,15 @@ export function withBase(path: string): string {
 }
 
 // fetch() against a base-relative app path. Drop-in replacement for fetch("/api/...").
-export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
-  const res = await fetch(withBase(path), init);
+// Attaches the stored auth token as a Bearer header unless the caller already set one.
+export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers);
+  if (!headers.has('Authorization')) {
+    const token = localStorage.getItem('fln_token');
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const res = await fetch(withBase(path), { ...init, headers });
   if (res.status === 401 && !path.includes('/api/auth/login')) {
     localStorage.removeItem('fln_token');
     window.dispatchEvent(new Event('fln_unauthorized'));


### PR DESCRIPTION
## Summary
- PR #85's merge conflict resolution dropped the Bearer-token attachment logic from `apiFetch`.
- Result: every authenticated API call after login went out with no `Authorization` header, got a 401 back, and the new `fln_unauthorized` handler in `App.tsx` immediately logged the user back out to the home page — affecting all roles (superadmin, admin, school, teacher, volunteer).

## Fix
Restore attaching `Authorization: Bearer <fln_token>` to outgoing requests in `apiFetch`, unless the caller already set one.

## Test plan
- [x] Verified locally that the diff restores the header logic present pre-PR#85
- [ ] After merge+deploy: log in with a non-superadmin demo account and confirm the dashboard loads instead of bouncing to home