### PR TITLE
fix(frontend): set react-router basename so /fln subpath survives client-side navigation

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -17,7 +17,7 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <App />
       </BrowserRouter>
     </QueryClientProvider>


### PR DESCRIPTION
## Summary
- `BrowserRouter` (`frontend/src/main.tsx`) had no `basename`, so react-router treated the app as mounted at the domain root regardless of where it's actually deployed.
- Live symptom on `tenali.fun/fln/`: logging in or out (any of the 3 `navigate('/')` calls in `App.tsx`) dropped the browser URL to `tenali.fun/` — the *Tenali* app root, a completely different app served by a different backend process (port 4000 vs 4002). The FLN app kept rendering correctly in that tab only because it was already loaded in memory client-side; a refresh or bookmark of that URL would load the wrong app entirely.
- Fix: `basename={import.meta.env.BASE_URL}`, which Vite already sets correctly per build (`VITE_BASE_PATH=/fln/` in production per `vite.config.ts`, `/` in dev) — no route path changes needed, both existing routes (`/register-coordinator`, `*`) were already relative to the router root.

## Test plan
- [x] `VITE_BASE_PATH=/fln/ npm run build:frontend` builds clean
- [ ] After deploy: log in via a demo tile on `tenali.fun/fln/`, confirm URL stays under `/fln/...`; log out, confirm URL stays under `/fln/`