### PR TITLE
Remove Streak (Day Streak) from all frontend locations

### DIFF
--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -143,7 +143,6 @@ function EmptyStudents({ students }: { students: Student[] }) {
     { header: 'Name', accessor: 'name', sortKey: 'name', className: 'font-semibold text-slate-800 dark:text-slate-100' },
     { header: 'Class', accessor: 'classGroup', className: '' },
     { header: 'Level', accessor: (s) => `L${s.currentLevel}.${s.currentSubLevel ?? 0}`, className: 'font-mono' },
-    { header: 'Streak', accessor: (s) => `${s.streak} 🔥`, className: '' },
   ];
   return <Table data={students} columns={cols} searchPlaceholder="Search students..." searchKey="name" />;
 }
@@ -531,12 +530,11 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
             </div>
           </div>
           {/* Quick Stats Bar */}
-          <div className="grid grid-cols-4 sm:grid-cols-5 gap-3 mt-4 pt-4 border-t border-slate-100 dark:border-slate-800">
+          <div className="grid grid-cols-4 gap-3 mt-4 pt-4 border-t border-slate-100 dark:border-slate-800">
             <div className="text-center"><div className="text-lg font-bold text-slate-900 dark:text-white">{reports.length}</div><div className="text-[9px] font-mono text-slate-400 dark:text-slate-500 uppercase">Assessments</div></div>
             <div className="text-center"><div className={`text-lg font-bold ${avgScore >= 70 ? 'text-emerald-600' : avgScore >= 50 ? 'text-amber-600' : 'text-red-600'}`}>{avgScore > 0 ? `${avgScore}%` : '—'}</div><div className="text-[9px] font-mono text-slate-400 dark:text-slate-500 uppercase">Avg Score</div></div>
             <div className="text-center"><div className="text-lg font-bold text-amber-600">L{s.currentLevel}</div><div className="text-[9px] font-mono text-slate-400 dark:text-slate-500 uppercase">Current Level</div></div>
-            <div className="text-center"><div className="text-lg font-bold text-slate-900 dark:text-white">{s.streak}</div><div className="text-[9px] font-mono text-slate-400 dark:text-slate-500 uppercase">Day Streak</div></div>
-            <div className="text-center hidden sm:block"><div className={`text-lg font-bold ${att ? (att.percentage >= 85 ? 'text-emerald-600' : 'text-amber-600') : 'text-slate-400'}`}>{att ? `${att.percentage}%` : '—'}</div><div className="text-[9px] font-mono text-slate-400 dark:text-slate-500 uppercase">Attendance</div></div>
+            <div className="text-center"><div className={`text-lg font-bold ${att ? (att.percentage >= 85 ? 'text-emerald-600' : 'text-amber-600') : 'text-slate-400'}`}>{att ? `${att.percentage}%` : '—'}</div><div className="text-[9px] font-mono text-slate-400 dark:text-slate-500 uppercase">Attendance</div></div>
           </div>
         </div>
 
@@ -559,9 +557,8 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
                   <div className="w-12 h-12 rounded-full bg-white/10 flex items-center justify-center text-2xl font-bold">{s.name.charAt(0)}</div>
                   <div><div className="font-bold text-lg">{s.name}</div><div className="text-xs text-slate-400">{s.classGroup} - {s.section}</div></div>
                 </div>
-                <div className="grid grid-cols-2 gap-3 pt-2 border-t border-white/10">
+                <div className="grid grid-cols-1 gap-3 pt-2 border-t border-white/10">
                   <div className="text-center"><div className="text-2xl font-bold text-emerald-400">L{s.currentLevel}</div><div className="text-[9px] text-slate-400 uppercase font-mono">Current Level</div></div>
-                  <div className="text-center"><div className="text-2xl font-bold text-amber-400">{s.streak}</div><div className="text-[9px] text-slate-400 uppercase font-mono">Day Streak</div></div>
                 </div>
                 <div className="pt-1"><div className="flex justify-between text-xs text-slate-400 mb-1"><span>Progress to L{s.targetLevel}</span><span>{Math.round((s.currentLevel / s.targetLevel) * 100)}%</span></div><div className="h-2 bg-white/10 rounded-full overflow-hidden"><div className="h-full bg-emerald-500 rounded-full transition-all" style={{ width: `${Math.min(100, (s.currentLevel / s.targetLevel) * 100)}%` }} /></div></div>
               </div>
@@ -715,7 +712,7 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
               <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-3">
                 <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Academic Summary</h3>
                 <div className="space-y-2.5 text-sm">
-                  {[['Total Assessments', String(reports.length)], ['Avg Score', reports.length > 0 ? `${avgScore}%` : 'N/A'], ['Current Level', `L${s.currentLevel}.${s.currentSubLevel ?? 0}`], ['Target Level', `L${s.targetLevel}`], ['Sub-Level Status', s.currentSubLevel === 0 ? 'Mastery' : s.currentSubLevel === 1 ? 'Easier' : 'Remedial'], ['Day Streak', `${s.streak}`], ['Attendance', att ? `${att.percentage}% (${att.present}/${att.total} days)` : 'N/A']].map(([l, v]) => (
+                  {[['Total Assessments', String(reports.length)], ['Avg Score', reports.length > 0 ? `${avgScore}%` : 'N/A'], ['Current Level', `L${s.currentLevel}.${s.currentSubLevel ?? 0}`], ['Target Level', `L${s.targetLevel}`], ['Sub-Level Status', s.currentSubLevel === 0 ? 'Mastery' : s.currentSubLevel === 1 ? 'Easier' : 'Remedial'], ['Attendance', att ? `${att.percentage}% (${att.present}/${att.total} days)` : 'N/A']].map(([l, v]) => (
                     <div key={l as string} className="flex justify-between border-b border-slate-50 dark:border-slate-800 pb-1.5"><span className="text-slate-500 dark:text-slate-400">{l}</span><span className="font-medium text-slate-800 dark:text-slate-100">{v}</span></div>
                   ))}
                 </div>
@@ -1298,7 +1295,7 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
         <PageHeader title="Student Progress Tracking" desc="Monitor FLN level advancement across assigned schools" icon={<GraduationCap className="h-5 w-5" />} />
         <div className="space-y-3">{students.sort((a, b) => b.currentLevel - a.currentLevel).map(s => (
           <div key={s.id} className="flex items-center gap-4 p-3 border border-slate-200 dark:border-slate-700 rounded-lg">
-            <div className="flex-1"><div className="font-medium text-sm">{s.name}</div><div className="text-xs text-slate-400 dark:text-slate-500">{s.classGroup} · Streak: {s.streak}</div></div>
+            <div className="flex-1"><div className="font-medium text-sm">{s.name}</div><div className="text-xs text-slate-400 dark:text-slate-500">{s.classGroup}</div></div>
             <div className="w-40"><div className="flex justify-between text-[10px] text-slate-500 dark:text-slate-400 mb-1"><span>L{s.currentLevel}</span><span>Target L{s.targetLevel}</span></div><div className="w-full h-1.5 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden"><div className="h-full bg-emerald-500 rounded-full" style={{ width: `${(s.currentLevel / s.targetLevel) * 100}%` }} /></div></div>
             <span className={`text-[10px] font-mono font-bold px-2 py-0.5 rounded ${s.levelHistory.length > 0 ? 'text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800' : 'text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800'}`}>{s.levelHistory.length > 0 ? 'Placed' : 'Pending'}</span>
           </div>

--- a/frontend/src/components/RoleDashboards.tsx
+++ b/frontend/src/components/RoleDashboards.tsx
@@ -2398,10 +2398,6 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
                     accessor: (s) => <span className="font-mono text-slate-500 dark:text-slate-400 text-xs">Level {s.targetLevel}</span>
                   },
                   {
-                    header: 'Streak',
-                    accessor: (s) => <span className="font-mono font-semibold text-slate-800 dark:text-slate-200">{s.streak} 🔥</span>
-                  },
-                  {
                     header: 'Diagnostic Status',
                     accessor: (s) => s.levelHistory.length === 0 ? (
                       <div className="flex items-center gap-1.5">
@@ -3059,10 +3055,6 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
                   {
                     header: 'Target Level',
                     accessor: (s) => <span className="font-mono text-slate-500 dark:text-slate-400 text-xs">Level {s.targetLevel}</span>
-                  },
-                  {
-                    header: 'Streak',
-                    accessor: (s) => <span className="font-mono font-semibold text-slate-800 dark:text-slate-200">{s.streak} 🔥</span>
                   },
                   {
                     header: 'Diagnostic Status',


### PR DESCRIPTION
Closes #164

Removes the fire-emoji Streak feature from all 6 places it rendered on screen — it implied daily habit-tracking, but the platform only tests students 3x/year (Baseline/Midline/Endline), so it never meant anything real:

- Dashboard roster table (Teacher + Volunteer dashboard duplicate) — `RoleDashboards.tsx`
- Student List table (`EmptyStudents` in `PanelViews.tsx`) — an extra spot found beyond the 4 originally called out in the issue, same fire-emoji column
- Student Profile: two stat tiles (top summary card + quick-stats bar) — `PanelViews.tsx`
- Student Profile summary list ("Day Streak" row)
- Sidebar student list line

Left `streak` on the `Student` type and in `STUDENTS_MOCK` alone — that mock array is deleted wholesale by the separate FLN-C fix, so touching the type now would break its object literals early for no benefit. Backend field/increment-logic removal is the paired issue #165.

## Verified
- `tsc --noEmit` clean
- Adjusted grid layouts (4-col → cleaner spacing, 2-col → 1-col) where a removed tile would've left an awkward gap