### PR TITLE
Remove streak field and increment logic from backend

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -109,7 +109,6 @@ export interface Student {
   targetLevel: number;
   aadharMasked: string; // Mandatory, unique identifier masked (§13.2 R-6)
   levelHistory: { level: number; subLevel?: number; date: string; reason: string }[];
-  streak: number;
   assignedDiagnosticQuestions?: Question[];
   // Extended profile — optional, filled in by the student's own school/teacher.
   // guardianContact and address are PII and are redacted for roles beyond
@@ -1323,7 +1322,6 @@ export class DBStore {
         targetLevel: 3,
         aadharMasked: 'XXXX-XXXX-4521',
         levelHistory: [{ level: 1, date: '2026-04-10', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 5
       },
       {
         id: 's2',
@@ -1337,7 +1335,6 @@ export class DBStore {
         targetLevel: 4,
         aadharMasked: 'XXXX-XXXX-9874',
         levelHistory: [{ level: 2, date: '2026-04-10', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 3
       },
       {
         id: 's3',
@@ -1351,7 +1348,6 @@ export class DBStore {
         targetLevel: 5,
         aadharMasked: 'XXXX-XXXX-1122',
         levelHistory: [{ level: 3, date: '2026-04-10', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 7
       },
       {
         id: 's4',
@@ -1364,7 +1360,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-5566',
         levelHistory: [{ level: 1, date: '2026-05-15', reason: 'Volunteer Diagnostic Placement' }],
-        streak: 1
       },
       {
         id: 's5',
@@ -1377,7 +1372,6 @@ export class DBStore {
         targetLevel: 3,
         aadharMasked: 'XXXX-XXXX-8811',
         levelHistory: [{ level: 1, date: '2026-05-20', reason: 'Volunteer Diagnostic Placement' }],
-        streak: 2
       },
       {
         id: 's6',
@@ -1391,7 +1385,6 @@ export class DBStore {
         targetLevel: 4,
         aadharMasked: 'XXXX-XXXX-7231',
         levelHistory: [{ level: 2, date: '2026-06-01', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 4
       },
       {
         id: 's7',
@@ -1405,7 +1398,6 @@ export class DBStore {
         targetLevel: 6,
         aadharMasked: 'XXXX-XXXX-1002',
         levelHistory: [{ level: 3, date: '2026-06-01', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 9
       },
       {
         id: 's8',
@@ -1419,7 +1411,6 @@ export class DBStore {
         targetLevel: 3,
         aadharMasked: 'XXXX-XXXX-3490',
         levelHistory: [{ level: 2, date: '2026-06-01', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 3
       },
       {
         id: 's9',
@@ -1433,7 +1424,6 @@ export class DBStore {
         targetLevel: 5,
         aadharMasked: 'XXXX-XXXX-1992',
         levelHistory: [{ level: 3, date: '2026-06-15', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 6
       },
       {
         id: 's10',
@@ -1447,7 +1437,6 @@ export class DBStore {
         targetLevel: 6,
         aadharMasked: 'XXXX-XXXX-8822',
         levelHistory: [{ level: 4, date: '2026-06-15', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 11
       },
       {
         id: 's11',
@@ -1461,7 +1450,6 @@ export class DBStore {
         targetLevel: 4,
         aadharMasked: 'XXXX-XXXX-3344',
         levelHistory: [{ level: 2, date: '2026-06-15', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 5
       },
       {
         id: 's12',
@@ -1474,7 +1462,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-4545',
         levelHistory: [{ level: 1, date: '2026-06-05', reason: 'Volunteer Diagnostic Placement' }],
-        streak: 2
       },
       {
         id: 's13',
@@ -1487,7 +1474,6 @@ export class DBStore {
         targetLevel: 3,
         aadharMasked: 'XXXX-XXXX-2121',
         levelHistory: [{ level: 1, date: '2026-06-05', reason: 'Volunteer Diagnostic Placement' }],
-        streak: 3
       },
       {
         id: 's14',
@@ -1501,7 +1487,6 @@ export class DBStore {
         targetLevel: 4,
         aadharMasked: 'XXXX-XXXX-1155',
         levelHistory: [{ level: 2, date: '2026-06-20', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 6
       },
       {
         id: 's15',
@@ -1515,7 +1500,6 @@ export class DBStore {
         targetLevel: 5,
         aadharMasked: 'XXXX-XXXX-2266',
         levelHistory: [{ level: 3, date: '2026-06-20', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 8
       },
       {
         id: 's16',
@@ -1529,7 +1513,6 @@ export class DBStore {
         targetLevel: 6,
         aadharMasked: 'XXXX-XXXX-3377',
         levelHistory: [{ level: 4, date: '2026-06-20', reason: 'Onboarding Diagnostic Placement' }],
-        streak: 12
       },
       // ── Unplaced students (empty levelHistory) for Pending Diagnostics ──
       {
@@ -1543,7 +1526,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-6677',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_2',
@@ -1556,7 +1538,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-7788',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_3',
@@ -1570,7 +1551,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-8899',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_4',
@@ -1584,7 +1564,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-9900',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_5',
@@ -1598,7 +1577,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1100',
         levelHistory: [],
-        streak: 0
       },
       // ── Additional placed students at Level 8 ──
       {
@@ -1614,7 +1592,6 @@ export class DBStore {
         targetLevel: 9,
         aadharMasked: 'XXXX-XXXX-1201',
         levelHistory: [{ level: 4, date: '2026-04-15', reason: 'Onboarding Diagnostic Placement' }, { level: 6, date: '2026-05-20', reason: 'Mid-year worksheet performance' }, { level: 8, date: '2026-07-01', reason: 'End-of-year worksheet performance' }],
-        streak: 15
       },
       {
         id: 's18',
@@ -1629,7 +1606,6 @@ export class DBStore {
         targetLevel: 9,
         aadharMasked: 'XXXX-XXXX-1202',
         levelHistory: [{ level: 3, date: '2026-05-01', reason: 'Onboarding Diagnostic Placement' }, { level: 5, date: '2026-06-10', reason: 'Baseline worksheet' }, { level: 8, date: '2026-07-03', reason: 'Mid-year worksheet' }],
-        streak: 10
       },
       {
         id: 's19',
@@ -1644,7 +1620,6 @@ export class DBStore {
         targetLevel: 9,
         aadharMasked: 'XXXX-XXXX-1203',
         levelHistory: [{ level: 2, date: '2026-04-20', reason: 'Onboarding Diagnostic Placement' }, { level: 8, date: '2026-06-25', reason: 'Remedial intervention' }],
-        streak: 6
       },
       // ── Students at Level 10 ──
       {
@@ -1660,7 +1635,6 @@ export class DBStore {
         targetLevel: 11,
         aadharMasked: 'XXXX-XXXX-1204',
         levelHistory: [{ level: 5, date: '2026-04-10', reason: 'Onboarding Diagnostic Placement' }, { level: 7, date: '2026-05-15', reason: 'Baseline worksheet' }, { level: 10, date: '2026-06-30', reason: 'Mid-year worksheet' }],
-        streak: 18
       },
       {
         id: 's21',
@@ -1675,7 +1649,6 @@ export class DBStore {
         targetLevel: 11,
         aadharMasked: 'XXXX-XXXX-1205',
         levelHistory: [{ level: 6, date: '2026-05-05', reason: 'Onboarding Diagnostic Placement' }, { level: 8, date: '2026-06-01', reason: 'Baseline worksheet' }, { level: 10, date: '2026-07-02', reason: 'Mid-year worksheet' }],
-        streak: 14
       },
       // ── Students at Level 12 ──
       {
@@ -1691,7 +1664,6 @@ export class DBStore {
         targetLevel: 13,
         aadharMasked: 'XXXX-XXXX-1206',
         levelHistory: [{ level: 7, date: '2026-04-25', reason: 'Onboarding Diagnostic Placement' }, { level: 10, date: '2026-06-05', reason: 'Baseline worksheet' }, { level: 12, date: '2026-07-04', reason: 'Mid-year worksheet' }],
-        streak: 20
       },
       {
         id: 's23',
@@ -1706,7 +1678,6 @@ export class DBStore {
         targetLevel: 13,
         aadharMasked: 'XXXX-XXXX-1207',
         levelHistory: [{ level: 8, date: '2026-05-10', reason: 'Onboarding Diagnostic Placement' }, { level: 12, date: '2026-06-28', reason: 'Baseline worksheet' }],
-        streak: 11
       },
       // ── Students at Level 15 ──
       {
@@ -1722,7 +1693,6 @@ export class DBStore {
         targetLevel: 16,
         aadharMasked: 'XXXX-XXXX-1208',
         levelHistory: [{ level: 8, date: '2026-04-10', reason: 'Onboarding Diagnostic Placement' }, { level: 11, date: '2026-05-20', reason: 'Baseline worksheet' }, { level: 15, date: '2026-07-01', reason: 'Mid-year worksheet' }],
-        streak: 25
       },
       {
         id: 's25',
@@ -1737,7 +1707,6 @@ export class DBStore {
         targetLevel: 16,
         aadharMasked: 'XXXX-XXXX-1209',
         levelHistory: [{ level: 10, date: '2026-05-15', reason: 'Onboarding Diagnostic Placement' }, { level: 15, date: '2026-07-02', reason: 'Baseline worksheet' }],
-        streak: 8
       },
       // ── Students at various other levels ──
       {
@@ -1753,7 +1722,6 @@ export class DBStore {
         targetLevel: 6,
         aadharMasked: 'XXXX-XXXX-1210',
         levelHistory: [{ level: 2, date: '2026-04-10', reason: 'Onboarding Diagnostic Placement' }, { level: 5, date: '2026-06-20', reason: 'Baseline worksheet' }],
-        streak: 7
       },
       {
         id: 's27',
@@ -1767,7 +1735,6 @@ export class DBStore {
         targetLevel: 4,
         aadharMasked: 'XXXX-XXXX-1211',
         levelHistory: [{ level: 1, date: '2026-05-15', reason: 'Volunteer Diagnostic Placement' }, { level: 3, date: '2026-06-25', reason: 'Baseline worksheet' }],
-        streak: 4
       },
       {
         id: 's28',
@@ -1782,7 +1749,6 @@ export class DBStore {
         targetLevel: 7,
         aadharMasked: 'XXXX-XXXX-1212',
         levelHistory: [{ level: 2, date: '2026-05-01', reason: 'Onboarding Diagnostic Placement' }, { level: 4, date: '2026-06-05', reason: 'Baseline worksheet' }, { level: 6, date: '2026-07-01', reason: 'Mid-year worksheet' }],
-        streak: 9
       },
       {
         id: 's29',
@@ -1797,7 +1763,6 @@ export class DBStore {
         targetLevel: 5,
         aadharMasked: 'XXXX-XXXX-1213',
         levelHistory: [{ level: 1, date: '2026-05-20', reason: 'Volunteer Diagnostic Placement' }, { level: 4, date: '2026-07-02', reason: 'Baseline worksheet' }],
-        streak: 3
       },
       {
         id: 's30',
@@ -1812,7 +1777,6 @@ export class DBStore {
         targetLevel: 8,
         aadharMasked: 'XXXX-XXXX-1214',
         levelHistory: [{ level: 3, date: '2026-04-25', reason: 'Onboarding Diagnostic Placement' }, { level: 5, date: '2026-06-01', reason: 'Baseline worksheet' }, { level: 7, date: '2026-07-03', reason: 'Mid-year worksheet' }],
-        streak: 12
       },
       {
         id: 's31',
@@ -1827,7 +1791,6 @@ export class DBStore {
         targetLevel: 7,
         aadharMasked: 'XXXX-XXXX-1215',
         levelHistory: [{ level: 2, date: '2026-04-20', reason: 'Onboarding Diagnostic Placement' }, { level: 6, date: '2026-06-18', reason: 'Baseline worksheet' }],
-        streak: 5
       },
       {
         id: 's32',
@@ -1842,7 +1805,6 @@ export class DBStore {
         targetLevel: 10,
         aadharMasked: 'XXXX-XXXX-1216',
         levelHistory: [{ level: 5, date: '2026-05-05', reason: 'Onboarding Diagnostic Placement' }, { level: 7, date: '2026-06-10', reason: 'Baseline worksheet' }, { level: 9, date: '2026-07-02', reason: 'Mid-year worksheet' }],
-        streak: 13
       },
       {
         id: 's33',
@@ -1857,7 +1819,6 @@ export class DBStore {
         targetLevel: 12,
         aadharMasked: 'XXXX-XXXX-1217',
         levelHistory: [{ level: 6, date: '2026-05-10', reason: 'Onboarding Diagnostic Placement' }, { level: 8, date: '2026-06-15', reason: 'Baseline worksheet' }, { level: 11, date: '2026-07-04', reason: 'Mid-year worksheet' }],
-        streak: 16
       },
       {
         id: 's34',
@@ -1872,7 +1833,6 @@ export class DBStore {
         targetLevel: 8,
         aadharMasked: 'XXXX-XXXX-1218',
         levelHistory: [{ level: 3, date: '2026-05-20', reason: 'Onboarding Diagnostic Placement' }, { level: 7, date: '2026-07-01', reason: 'Baseline worksheet' }],
-        streak: 8
       },
       {
         id: 's35',
@@ -1887,7 +1847,6 @@ export class DBStore {
         targetLevel: 12,
         aadharMasked: 'XXXX-XXXX-1219',
         levelHistory: [{ level: 6, date: '2026-05-15', reason: 'Onboarding Diagnostic Placement' }, { level: 9, date: '2026-06-20', reason: 'Baseline worksheet' }, { level: 11, date: '2026-07-03', reason: 'Mid-year worksheet' }],
-        streak: 9
       },
       {
         id: 's36',
@@ -1902,7 +1861,6 @@ export class DBStore {
         targetLevel: 14,
         aadharMasked: 'XXXX-XXXX-1220',
         levelHistory: [{ level: 8, date: '2026-05-01', reason: 'Onboarding Diagnostic Placement' }, { level: 11, date: '2026-06-10', reason: 'Baseline worksheet' }, { level: 13, date: '2026-07-02', reason: 'Mid-year worksheet' }],
-        streak: 17
       },
       {
         id: 's37',
@@ -1917,7 +1875,6 @@ export class DBStore {
         targetLevel: 15,
         aadharMasked: 'XXXX-XXXX-1221',
         levelHistory: [{ level: 9, date: '2026-05-10', reason: 'Onboarding Diagnostic Placement' }, { level: 12, date: '2026-06-20', reason: 'Baseline worksheet' }, { level: 14, date: '2026-07-04', reason: 'Mid-year worksheet' }],
-        streak: 19
       },
       {
         id: 's38',
@@ -1932,7 +1889,6 @@ export class DBStore {
         targetLevel: 10,
         aadharMasked: 'XXXX-XXXX-1222',
         levelHistory: [{ level: 4, date: '2026-04-25', reason: 'Onboarding Diagnostic Placement' }, { level: 9, date: '2026-06-28', reason: 'Baseline worksheet' }],
-        streak: 7
       },
       {
         id: 's39',
@@ -1947,7 +1903,6 @@ export class DBStore {
         targetLevel: 7,
         aadharMasked: 'XXXX-XXXX-1223',
         levelHistory: [{ level: 2, date: '2026-04-10', reason: 'Onboarding Diagnostic Placement' }, { level: 4, date: '2026-05-25', reason: 'Baseline worksheet' }, { level: 6, date: '2026-07-01', reason: 'Mid-year worksheet' }],
-        streak: 11
       },
       // ── Students in Bathinda (lagging district) ──
       {
@@ -1963,7 +1918,6 @@ export class DBStore {
         targetLevel: 3,
         aadharMasked: 'XXXX-XXXX-1224',
         levelHistory: [{ level: 1, date: '2026-05-01', reason: 'Onboarding Diagnostic Placement' }, { level: 2, date: '2026-06-20', reason: 'Baseline worksheet' }],
-        streak: 2
       },
       {
         id: 's41',
@@ -1978,7 +1932,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1225',
         levelHistory: [{ level: 1, date: '2026-06-01', reason: 'Volunteer Diagnostic Placement' }],
-        streak: 1
       },
       {
         id: 's42',
@@ -1993,7 +1946,6 @@ export class DBStore {
         targetLevel: 4,
         aadharMasked: 'XXXX-XXXX-1226',
         levelHistory: [{ level: 1, date: '2026-05-10', reason: 'Onboarding Diagnostic Placement' }, { level: 3, date: '2026-06-25', reason: 'Baseline worksheet' }],
-        streak: 4
       },
       // ── Students in Amritsar (low-strength school) ──
       {
@@ -2009,7 +1961,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1227',
         levelHistory: [{ level: 1, date: '2026-06-10', reason: 'Volunteer Diagnostic Placement' }],
-        streak: 1
       },
       {
         id: 's44',
@@ -2024,7 +1975,6 @@ export class DBStore {
         targetLevel: 3,
         aadharMasked: 'XXXX-XXXX-1228',
         levelHistory: [{ level: 1, date: '2026-06-10', reason: 'Volunteer Diagnostic Placement' }, { level: 2, date: '2026-07-01', reason: 'Baseline worksheet' }],
-        streak: 2
       },
       // ── Students in Jaipur Rural North ──
       {
@@ -2040,7 +1990,6 @@ export class DBStore {
         targetLevel: 6,
         aadharMasked: 'XXXX-XXXX-1229',
         levelHistory: [{ level: 2, date: '2026-05-15', reason: 'Onboarding Diagnostic Placement' }, { level: 5, date: '2026-06-28', reason: 'Baseline worksheet' }],
-        streak: 6
       },
       {
         id: 's46',
@@ -2055,7 +2004,6 @@ export class DBStore {
         targetLevel: 4,
         aadharMasked: 'XXXX-XXXX-1230',
         levelHistory: [{ level: 1, date: '2026-05-20', reason: 'Volunteer Diagnostic Placement' }, { level: 3, date: '2026-07-01', reason: 'Baseline worksheet' }],
-        streak: 3
       },
       // ── Unplaced students needing diagnostics ──
       {
@@ -2070,7 +2018,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1231',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_7',
@@ -2084,7 +2031,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1232',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_8',
@@ -2098,7 +2044,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1233',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_9',
@@ -2112,7 +2057,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1234',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_10',
@@ -2126,7 +2070,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1235',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_11',
@@ -2140,7 +2083,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1236',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_12',
@@ -2154,7 +2096,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1237',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_13',
@@ -2168,7 +2109,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1238',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_14',
@@ -2182,7 +2122,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1239',
         levelHistory: [],
-        streak: 0
       },
       {
         id: 's_new_15',
@@ -2196,7 +2135,6 @@ export class DBStore {
         targetLevel: 2,
         aadharMasked: 'XXXX-XXXX-1240',
         levelHistory: [],
-        streak: 0
       }
     ];
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -631,7 +631,6 @@ const students = await dbStore.getStudents();
       targetLevel: 2,
       aadharMasked: rawAadhar, // Store raw unmasked Aadhar in DB so Superadmin sees it, others get masked dynamically
       levelHistory: [],
-      streak: 0,
       gender: gender || undefined,
       dob: dob || undefined,
       guardianName: guardianName || undefined,
@@ -747,8 +746,7 @@ const students = await dbStore.getStudents();
           qrData: {
             age: student.age, classGroup: student.classGroup, section: student.section,
             schoolId: student.schoolId, currentLevel: student.currentLevel,
-            currentSubLevel: student.currentSubLevel, targetLevel: student.targetLevel,
-            streak: student.streak
+            currentSubLevel: student.currentSubLevel, targetLevel: student.targetLevel
           }
         }]
       });
@@ -1275,8 +1273,7 @@ const students = await dbStore.getStudents();
             currentLevel: classNum * 10,
             targetLevel: 93,
             aadharMasked: 'XXXX-XXXX-1234',
-            levelHistory: [],
-            streak: 0
+            levelHistory: []
           }
         ];
       }
@@ -1318,8 +1315,7 @@ const students = await dbStore.getStudents();
             currentLevel: classNumber * 10,
             targetLevel: 93,
             aadharMasked: 'XXXX-XXXX-1234',
-            levelHistory: [],
-            streak: 0
+            levelHistory: []
           }
         ];
       }
@@ -2027,7 +2023,7 @@ const students = await dbStore.getStudents();
       studentData: {
         age: s.age, classGroup: s.classGroup, section: s.section, schoolId: s.schoolId,
         currentLevel: s.currentLevel, currentSubLevel: s.currentSubLevel,
-        targetLevel: s.targetLevel, streak: s.streak
+        targetLevel: s.targetLevel
       }
     }));
 
@@ -2248,7 +2244,7 @@ const students = await dbStore.getStudents();
     // Idempotency: a student can only submit a given worksheet once. If this
     // exact (worksheetId, studentId) pair was already submitted (e.g. the
     // client retried after a timeout), return the existing result instead of
-    // re-running the AI evaluation, re-mutating the student's level/streak,
+    // re-running the AI evaluation, re-mutating the student's level,
     // and re-appending to level history / delay logs.
     const existingSubmissions = await dbStore.getAnswerSubmissions();
     const existingSubmission = existingSubmissions.find(s => s.worksheetId === worksheetId && s.studentId === studentId);
@@ -2343,8 +2339,7 @@ const students = await dbStore.getStudents();
       currentLevel: evaluation.recommendedLevel,
       currentSubLevel: newSubLevel,
       targetLevel: Math.min(93, evaluation.recommendedLevel + 1),
-      levelHistory,
-      streak: student.streak + 1
+      levelHistory
     });
 
     // Logging & escalation updates if delayed
@@ -3267,8 +3262,7 @@ const students = await dbStore.getStudents();
             qrData: {
               age: student.age, classGroup: student.classGroup, section: student.section,
               schoolId: student.schoolId, currentLevel: student.currentLevel,
-              currentSubLevel: student.currentSubLevel, targetLevel: student.targetLevel,
-              streak: student.streak
+              currentSubLevel: student.currentSubLevel, targetLevel: student.targetLevel
             }
           }]
         });

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -256,10 +256,6 @@ function randomAge(classIndex: number): number {
   return base + Math.floor(Math.random() * 2);
 }
 
-function randomStreak(): number {
-  return Math.floor(Math.random() * 20);
-}
-
 function generateAadhaar(): string {
   const last4 = String(Math.floor(Math.random() * 9000) + 1000);
   return `XXXX-XXXX-${last4}`;
@@ -459,7 +455,6 @@ async function main() {
                     reason: 'Onboarding Diagnostic Placement',
                   },
                 ],
-                streak: randomStreak(),
               });
             }
           }


### PR DESCRIPTION
Closes #165

Backend companion to #164 (frontend Streak removal). Removes `streak` from the data layer, not just the display:

- `backend/src/db.ts`: dropped `streak: number` from the `Student` interface, and all 61 `streak: N` values from the seeded demo dataset
- `backend/src/seed.ts`: deleted the now-unused `randomStreak()` helper and its call site
- `backend/src/index.ts`: dropped `streak: 0` from student creation, dropped the `student.streak + 1` increment that fired on worksheet-evaluation submit, dropped `streak` from two `qrData` payloads (loosely-typed `Record<string, unknown>`, no downstream reader) and from the levels-backend roster payload, cleaned up one stale comment

Grepped the whole `backend/` tree for any remaining `.streak`/`streak:` — none left.

## Verified
- `npm run lint` (tsc --noEmit) clean on both workspaces
- Ran `npx tsx src/seed.ts` against a scratch MongoDB (`fln_streaktest`) — seeded cleanly (86,400 students, no errors)
- Queried the scratch DB directly: `db.students.countDocuments({streak: {$exists:true}})` → 0
- Scratch DB dropped after verification