### PR TITLE
Fix dead pointer: Intervention Tracking card links to a non-existent page

### DIFF
--- a/frontend/src/components/RoleDashboards.tsx
+++ b/frontend/src/components/RoleDashboards.tsx
@@ -2142,24 +2142,6 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
         <div className="space-y-6">
           {!showAllStudents && activeClass && (
             <>
-          {/* 💊 Intervention Quick Action */}
-          <div className="bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-indigo-950 dark:to-purple-950 border border-indigo-200 dark:border-indigo-800 rounded-xl p-4 shadow-sm">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-full bg-indigo-100 dark:bg-indigo-900 flex items-center justify-center text-lg">
-                  💊
-                </div>
-                <div>
-                  <h3 className="text-sm font-bold text-slate-900 dark:text-white">Intervention Tracking</h3>
-                  <p className="text-[10px] text-slate-500 dark:text-slate-400">Record remedial actions for struggling students</p>
-                </div>
-              </div>
-              <div className="text-[10px] font-mono text-slate-400 dark:text-slate-500 bg-white dark:bg-zinc-800 px-3 py-1.5 rounded-full border border-slate-200 dark:border-zinc-600">
-                Use sidebar → Interventions
-              </div>
-            </div>
-          </div>
-
           {/* 📋 Diagnostic Paper Generator */}
           <div className="bg-white dark:bg-slate-900 border border-zinc-200 dark:border-zinc-700 rounded-xl p-5 shadow-sm space-y-4">
             <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">


### PR DESCRIPTION
Closes #169

The Teacher dashboard's "Intervention Tracking" card said "Use sidebar → Interventions" — no such sidebar item exists anywhere in the app. Confirmed via grep against `Layout.tsx`'s nav definitions: no match. It was a signpost pointing to a page that was never built.

Removed the card. Only one occurrence (unlike most other dashboard cards in this file, there's no Volunteer-dashboard duplicate of this one).

Building the real Interventions page (the long-term option from the issue) is left as a future follow-up, not done here.

## Verified
- `tsc --noEmit` clean
- Confirmed no dangling "Interventions" nav entry in `Layout.tsx`