### PR TITLE
Reset activePanel on logout/login - stale screen state leaks across role switches

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -97,6 +97,7 @@ export default function App() {
     const handleUnauthorized = () => {
       setToken(null);
       setCurrentUser(null);
+      setActivePanel('workspace');
       localStorage.removeItem('fln_token');
       setCurrentView('home');
       navigate('/');
@@ -110,6 +111,7 @@ export default function App() {
     setToken(newToken);
     localStorage.setItem('fln_token', newToken);
     setCurrentUser(user);
+    setActivePanel('workspace');
     setCurrentView('dashboard');
     navigate('/');
   };
@@ -129,6 +131,7 @@ export default function App() {
   const handleLogout = () => {
     setToken(null);
     setCurrentUser(null);
+    setActivePanel('workspace');
     localStorage.removeItem('fln_token');
     setCurrentView('home');
     navigate('/');


### PR DESCRIPTION
Closes #197

`activePanel` (which page/panel is currently shown) was never reset on session start or end. If a user was viewing a role-specific panel and a different role then logged into the same browser tab, the new session could land directly on the previous role's last-viewed panel - a page that role's own sidebar navigation doesn't even link to - and it would still render real data for that page, since `PanelViews` doesn't independently validate whether the current role is allowed to see `activePanel`.

## What changed
Reset `activePanel` back to its `'workspace'` default at all three places a session can start or end in `frontend/src/App.tsx`:
- `handleLogout` (explicit logout)
- the `fln_unauthorized` window-event handler (forced logout on a 401)
- `handleLoginSuccess` (defense in depth - covers a fresh login even if the previous session somehow ended without going through `handleLogout`)

## Verified
- `tsc --noEmit` clean