### PR TITLE
Add a Home button on the dashboard (no way back to landing page while logged in)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -126,6 +126,11 @@ export default function App() {
 
   const handleClearNotifications = () => setAnnouncements([]);
 
+  const handleNavigateHome = () => {
+    setCurrentView('home');
+    navigate('/');
+  };
+
   const handleLogout = () => {
     setToken(null);
     setCurrentUser(null);
@@ -164,7 +169,12 @@ return <SuperadminDashboard user={currentUser} token={token!} />;
         path="*"
         element={
           <div className="flex min-h-screen flex-col font-sans bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100 antialiased">
-            {currentView === 'home' && <LandingView onNavigateToLogin={() => setCurrentView('login')} />}
+            {currentView === 'home' && (
+              <LandingView
+                isLoggedIn={!!(token && currentUser)}
+                onNavigateToLogin={() => setCurrentView(token && currentUser ? 'dashboard' : 'login')}
+              />
+            )}
             {currentView === 'login' && <LoginView onLoginSuccess={handleLoginSuccess} onBackToHome={() => setCurrentView('home')} />}
 
             {currentView === 'dashboard' && currentUser && token && (
@@ -177,6 +187,7 @@ return <SuperadminDashboard user={currentUser} token={token!} />;
                 onMarkNotificationRead={handleMarkNotificationRead}
                 onClearNotifications={handleClearNotifications}
                 onLogout={handleLogout}
+                onNavigateHome={handleNavigateHome}
                 isDark={isDark}
                 onThemeToggle={() => setIsDark(!isDark)}
               >

--- a/frontend/src/components/LandingView.tsx
+++ b/frontend/src/components/LandingView.tsx
@@ -9,6 +9,7 @@ import { Sparkles, Award, Globe, BookOpen, Users, BarChart3, ArrowRight, MapPin 
 
 interface LandingViewProps {
   onNavigateToLogin: () => void;
+  isLoggedIn?: boolean;
 }
 
 interface Stats {
@@ -21,7 +22,7 @@ interface Stats {
   totalUsers: number;
 }
 
-export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) => {
+export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin, isLoggedIn }) => {
   const [fontSize, setFontSize] = useState(100);
   const [stats, setStats] = useState<Stats | null>(null);
   const [statsLoading, setStatsLoading] = useState(true);
@@ -129,7 +130,7 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
               onClick={onNavigateToLogin}
               className="rounded-lg bg-indigo-700 dark:bg-indigo-800 px-6 py-2.5 text-xs font-extrabold text-white shadow-md dark:shadow-slate-950/50 transition-all duration-150 hover:bg-indigo-600 dark:hover:bg-indigo-700 border border-indigo-300 dark:border-indigo-700 active:scale-[0.98] uppercase tracking-wider"
             >
-              Sign In to Dashboard
+              {isLoggedIn ? 'Go to Dashboard' : 'Sign In to Dashboard'}
             </button>
           </div>
         </div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,7 +4,7 @@ import { apiFetch } from '../services/apiClient';
 import {
   Menu, X, Search, Bell, Sun, Moon, LogOut, ChevronRight, ChevronLeft, ChevronDown,
   LayoutDashboard, BookOpen, UserCheck, Calendar, ShieldCheck, HelpCircle, Settings, Users,
-  School, GraduationCap, MapPin, BarChart3, FileText, ClipboardList, ShieldAlert, KeyRound, Clock, Database
+  School, GraduationCap, MapPin, BarChart3, FileText, ClipboardList, ShieldAlert, KeyRound, Clock, Database, Home
 } from 'lucide-react';
 
 interface NavigationItem {
@@ -24,6 +24,7 @@ interface LayoutProps {
   onMarkNotificationRead: (id: string) => void;
   onClearNotifications: () => void;
   onLogout: () => void;
+  onNavigateHome: () => void;
   isDark: boolean;
   onThemeToggle: () => void;
   children: React.ReactNode;
@@ -38,6 +39,7 @@ export const Layout: React.FC<LayoutProps> = ({
   onMarkNotificationRead,
   onClearNotifications,
   onLogout,
+  onNavigateHome,
   isDark,
   onThemeToggle,
   children
@@ -418,6 +420,13 @@ export const Layout: React.FC<LayoutProps> = ({
                 {currentUser.role.replace('_', ' ')}
               </span>
             </div>
+            <button
+              onClick={onNavigateHome}
+              className="rounded-lg p-2 text-slate-400 hover:bg-slate-100 hover:text-indigo-500 transition dark:text-slate-500 dark:hover:bg-slate-800 dark:hover:text-indigo-400"
+              title="Home"
+            >
+              <Home className="h-4.5 w-4.5" />
+            </button>
             <button
               onClick={onLogout}
               className="rounded-lg p-2 text-slate-400 hover:bg-slate-100 hover:text-red-500 transition dark:text-slate-500 dark:hover:bg-slate-800 dark:hover:text-red-400"


### PR DESCRIPTION
Closes #195

Once signed in, there was no way to get back to the public landing page without logging out entirely — `handleLogout` was the only path to the `'home'` view, and it also clears the session.

## What changed
- New Home button in the dashboard header (`Layout.tsx`), next to Logout
- New `handleNavigateHome` in `App.tsx` — switches to the home view without touching `token`/`currentUser`, so the session stays valid
- `LandingView`'s CTA button is now session-aware: shows "Go to Dashboard" (and returns straight there, skipping the login form) when already logged in, "Sign In to Dashboard" otherwise

## Verified
- `tsc --noEmit` clean