### PR TITLE
Superadmin Analytics: remove hardcoded trend badges, fake school leaderboard, misleading AI-interview label

### DIFF
--- a/frontend/src/components/SuperAdminExecutiveDashboard.tsx
+++ b/frontend/src/components/SuperAdminExecutiveDashboard.tsx
@@ -218,18 +218,8 @@ export const SuperAdminExecutiveDashboard: React.FC<SuperAdminDashboardProps> = 
 
     if (rankingsStateFilter !== 'ALL') {
       list = list.filter(school => school.stateCode === rankingsStateFilter);
-
-      // If no schools in database match the filtered state, dynamically generate 5 realistic rankings for that state
-      if (list.length === 0) {
-        const stateName = STATE_NAMES[rankingsStateFilter] || rankingsStateFilter;
-        list = [
-          { id: `SCH-MOCK-1`, name: `GSSS Model Town ${stateName}`, stateCode: rankingsStateFilter, schoolType: 'Government', performanceScore: 92.4, completionRate: 96.8, studentSatisfaction: 4.8, interviewSuccessRate: 91.2 },
-          { id: `SCH-MOCK-2`, name: `Jawahar Navodaya Vidyalaya ${stateName}`, stateCode: rankingsStateFilter, schoolType: 'Model', performanceScore: 89.2, completionRate: 94.5, studentSatisfaction: 4.6, interviewSuccessRate: 88.4 },
-          { id: `SCH-MOCK-3`, name: `Delhi Public School ${stateName}`, stateCode: rankingsStateFilter, schoolType: 'Private', performanceScore: 86.8, completionRate: 92.1, studentSatisfaction: 4.5, interviewSuccessRate: 85.6 },
-          { id: `SCH-MOCK-4`, name: `St. Xavier Primary Academy ${stateName}`, stateCode: rankingsStateFilter, schoolType: 'Private Aided', performanceScore: 84.1, completionRate: 90.4, studentSatisfaction: 4.3, interviewSuccessRate: 83.2 },
-          { id: `SCH-MOCK-5`, name: `Government High School ${stateName}`, stateCode: rankingsStateFilter, schoolType: 'Government', performanceScore: 81.5, completionRate: 88.2, studentSatisfaction: 4.1, interviewSuccessRate: 80.8 }
-        ];
-      }
+      // No fake fallback rankings when a state has no real ranked schools -
+      // the render side shows an honest empty state instead (see below).
     }
 
     return list.sort((a, b) => {
@@ -537,50 +527,38 @@ export const SuperAdminExecutiveDashboard: React.FC<SuperAdminDashboardProps> = 
             <KPICard
               title="Registered & Active Schools"
               value={kpis.totalRegisteredSchools?.toLocaleString()}
-              subtext={`${kpis.totalRegisteredSchools ? Math.round((kpis.activeSchools / kpis.totalRegisteredSchools) * 100) : 100}% Operational`}
+              subtext={kpis.totalRegisteredSchools ? `${Math.round((kpis.activeSchools / kpis.totalRegisteredSchools) * 100)}% Operational` : 'Loading…'}
               icon={School}
-              badge="+4.2%"
-              badgeType="up"
             />
             <KPICard
               title="Total Students Enrolled"
               value={kpis.totalStudents?.toLocaleString()}
               subtext="Enrolled across FLN"
               icon={Users}
-              badge="+8.1%"
-              badgeType="up"
             />
             <KPICard
               title="Total Teachers"
               value={kpis.totalTeachers?.toLocaleString()}
               subtext="Active Educators"
               icon={ShieldCheck}
-              badge="+2.4%"
-              badgeType="up"
             />
             <KPICard
               title="Total Assessments Conducted"
               value={kpis.totalExamsConducted?.toLocaleString()}
               subtext="Assessments sync"
               icon={FileCheck}
-              badge="+12%"
-              badgeType="up"
             />
             <KPICard
-              title="Total AI Interviews Completed"
+              title="Total Evaluations Completed"
               value={kpis.totalInterviewsCompleted?.toLocaleString()}
-              subtext="AI Mock Evaluations"
+              subtext="Diagnostic + worksheet evaluations"
               icon={Zap}
-              badge="+15%"
-              badgeType="up"
             />
             <KPICard
               title="Average Performance Score"
               value={kpis.avgPerformanceScore !== undefined ? `${kpis.avgPerformanceScore}%` : '—'}
               subtext="National Index"
               icon={Award}
-              badge="+3.5%"
-              badgeType="up"
             />
           </div>
 
@@ -1264,6 +1242,13 @@ export const SuperAdminExecutiveDashboard: React.FC<SuperAdminDashboardProps> = 
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-100 dark:divide-slate-800/60 font-medium">
+                      {sortedSchoolRankings.length === 0 && (
+                        <tr>
+                          <td colSpan={8} className="py-8 px-3 text-center text-slate-400 dark:text-slate-500">
+                            No ranked schools yet for this filter.
+                          </td>
+                        </tr>
+                      )}
                       {sortedSchoolRankings.map((school: any, idx: number) => (
                         <tr key={school.id} className="hover:bg-slate-50/80 dark:hover:bg-slate-800/40 transition-colors">
                           <td className="py-3 px-3">


### PR DESCRIPTION
Closes #196

Verified against the live component first - most of the Superadmin Analytics dashboard (6 KPI tile main values, Recent Insights feed, performance-by-school-type) is already genuinely wired to real MongoDB aggregations. Three specific things were still fake or misleading:

1. **Hardcoded trend badges** on all 6 KPI tiles (`+4.2%`, `+8.1%`, `+2.4%`, `+12%`, `+15%`, `+3.5%`) - literal strings that never change regardless of real data, since there's no period-over-period comparison being computed. Removed rather than fabricate a fake trend.
2. **Fake school leaderboard** - silently generated 5 invented `SCH-MOCK-*` schools with made-up scores whenever a filtered state had no real ranked schools. Removed the fallback; the rankings table now shows an honest "No ranked schools yet for this filter" empty state.
3. **Misleading "Total AI Interviews Completed"** - wired to a real number (evaluation report count) but the label implies a nonexistent AI-interview feature. Renamed to "Total Evaluations Completed" with an accurate subtext.

## Note on #198
Investigated alongside this (same file) - turned out to already be correctly handled. `SuperAdminExecutiveDashboard.tsx:234` has `if (loading) return <skeleton/>;`, an early return guarding the entire component including the KPI grid, so there's no code path where a tile renders `undefined`/blank before the fetch resolves. Closed #198 separately with the verification, no code change there.

## Verified
- `tsc --noEmit` clean