### PR TITLE
Add hover context to landing page stat cards

### DIFF
--- a/frontend/src/components/LandingView.tsx
+++ b/frontend/src/components/LandingView.tsx
@@ -19,6 +19,8 @@ interface Stats {
   totalAssessments: number;
   avgFlnLevel: number;
   totalUsers: number;
+  certifiedCount?: number;
+  certifiedPercent?: number;
 }
 
 export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) => {
@@ -62,11 +64,33 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
   }, []);
 
   const statCards = [
-    { label: 'States & Districts', value: stats ? `${stats.totalStates} States / ${stats.totalDistricts} Districts` : null, desc: 'Across India', icon: MapPin, color: 'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-950/40' },
-    { label: 'Registered Schools', value: stats?.totalSchools?.toLocaleString() ?? null, desc: 'Active institutions', icon: BookOpen, color: 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40' },
-    { label: 'Students Tracked', value: stats?.totalStudents?.toLocaleString() ?? null, desc: 'Enrolled learners', icon: Users, color: 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/40' },
-    { label: 'Assessments Conducted', value: stats?.totalAssessments?.toLocaleString() ?? null, desc: 'Worksheets generated', icon: BarChart3, color: 'text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-950/40' },
-    { label: 'National Avg FLN Level', value: stats ? `L${stats.avgFlnLevel}` : null, desc: 'Average student level', icon: Award, color: 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/40' },
+    {
+      label: 'States & Districts', value: stats ? `${stats.totalStates} States / ${stats.totalDistricts} Districts` : null, desc: 'Across India', icon: MapPin,
+      color: 'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-950/40',
+      hoverDetail: stats ? `Spanning ${stats.totalStates} states/UTs and ${stats.totalDistricts} districts nationwide.` : null,
+    },
+    {
+      label: 'Registered Schools', value: stats?.totalSchools?.toLocaleString() ?? null, desc: 'Active institutions', icon: BookOpen,
+      color: 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40',
+      hoverDetail: stats && stats.totalStates > 0 ? `~${Math.round(stats.totalSchools / stats.totalStates)} schools per state on average.` : null,
+    },
+    {
+      label: 'Students Tracked', value: stats?.totalStudents?.toLocaleString() ?? null, desc: 'Enrolled learners', icon: Users,
+      color: 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/40',
+      hoverDetail: stats?.certifiedCount != null && stats?.certifiedPercent != null
+        ? `${stats.certifiedCount.toLocaleString()} certified at FLN level 5+ (${stats.certifiedPercent}%).`
+        : null,
+    },
+    {
+      label: 'Assessments Conducted', value: stats?.totalAssessments?.toLocaleString() ?? null, desc: 'Worksheets generated', icon: BarChart3,
+      color: 'text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-950/40',
+      hoverDetail: stats && stats.totalStudents > 0 ? `~${(stats.totalAssessments / stats.totalStudents).toFixed(1)} assessments per enrolled student.` : null,
+    },
+    {
+      label: 'National Avg FLN Level', value: stats ? `L${stats.avgFlnLevel}` : null, desc: 'Average student level', icon: Award,
+      color: 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/40',
+      hoverDetail: stats?.certifiedPercent != null ? `${stats.certifiedPercent}% of tracked students are certified (level 5+).` : null,
+    },
   ];
 
   return (
@@ -163,7 +187,7 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
             return (
               <div
                 key={index}
-                className="flex items-center gap-4 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 shadow-sm dark:shadow-slate-950/50 transition hover:shadow-md dark:hover:shadow-slate-950/50"
+                className="group relative flex items-center gap-4 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 shadow-sm dark:shadow-slate-950/50 transition hover:shadow-md dark:hover:shadow-slate-950/50"
               >
                 <div className={`rounded-xl p-3 ${stat.color}`}>
                   <Icon className="h-6 w-6" />
@@ -183,6 +207,11 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin }) =
                     {stat.desc}
                   </p>
                 </div>
+                {stat.hoverDetail && (
+                  <div className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-64 -translate-x-1/2 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 text-xs text-gray-600 dark:text-slate-300 shadow-lg opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+                    {stat.hoverDetail}
+                  </div>
+                )}
               </div>
             );
           })}


### PR DESCRIPTION
Closes #199

The 5 landing-page stat cards were static tiles with no way to see more context.

## What changed
Added a hover popover per card, sourced entirely from real data already available:
- **States & Districts** — full states/districts breakdown
- **Registered Schools** — average schools per state
- **Students Tracked** — certified count + percentage (`certifiedCount`/`certifiedPercent` were already returned by `/api/stats` but unused on the frontend)
- **Assessments Conducted** — average assessments per enrolled student
- **National Avg FLN Level** — certified percentage

No fabricated data, no new backend endpoint — either pulled from fields the backend already returns, or derived arithmetic from the same real numbers already on screen.

## Verified
- `tsc --noEmit` clean