### PR TITLE
Fix authorization gaps on /api/logbook and /api/admin/coordinators

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -198,7 +198,32 @@ registerStatsRoutes(app);
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
     const logs = await dbStore.getLogbook();
-    res.json(logs);
+
+    // Server-side role scoping - mirrors the pattern used elsewhere in this
+    // file (e.g. /api/admin/coordinators). LogEntry only carries schoolId,
+    // so district/block/state scoping goes through a schools lookup first.
+    if (user.role === UserRole.SUPERADMIN) {
+      return res.json(logs);
+    }
+    if (user.role === UserRole.TEACHER || user.role === UserRole.SCHOOL) {
+      return res.json(logs.filter(l => l.schoolId === user.schoolId));
+    }
+    if (user.role === UserRole.VOLUNTEER) {
+      return res.json(logs.filter(l => user.assignedSchools?.includes(l.schoolId)));
+    }
+
+    const schools = await dbStore.getSchools();
+    let allowedSchoolIds: Set<string>;
+    if (user.role === UserRole.ADMIN) {
+      allowedSchoolIds = new Set(schools.filter(s => s.stateCode === user.stateCode).map(s => s.id));
+    } else if (user.role === UserRole.DISTRICT_ADMIN) {
+      allowedSchoolIds = new Set(schools.filter(s => s.districtCode === user.districtCode).map(s => s.id));
+    } else if (user.role === UserRole.BLOCK_ADMIN) {
+      allowedSchoolIds = new Set(schools.filter(s => s.blockCode === user.blockCode).map(s => s.id));
+    } else {
+      return res.status(403).json({ error: 'Forbidden: role not permitted to view the logbook.' });
+    }
+    res.json(logs.filter(l => allowedSchoolIds.has(l.schoolId)));
   });
   // Admin Creation (by Superadmin)
   app.post('/api/admin/create', async (req, res) => {
@@ -2874,6 +2899,8 @@ const students = await dbStore.getStudents();
       filtered = users.filter(u => u.districtCode === user.districtCode);
     } else if (user.role === UserRole.BLOCK_ADMIN) {
       filtered = users.filter(u => u.blockCode === user.blockCode);
+    } else if (user.role === UserRole.ADMIN) {
+      filtered = users.filter(u => u.stateCode === user.stateCode);
     }
     res.json(filtered.map(sanitizeUser));
   });


### PR DESCRIPTION
Closes #208, closes #209

Two security gaps from the 2026-08-03 role/permission audit, confirmed still present in current `main` before writing any fix.

## #208 — GET /api/logbook missing authorization
Checked authentication but had zero role-based scoping — any authenticated user, any role, got the full national audit log. Added the same scoping pattern already used elsewhere in this file (e.g. `/api/admin/coordinators`): Superadmin unscoped, Teacher/School by own `schoolId`, Volunteer by `assignedSchools`, District/Block/State Admin scoped via a schools-collection lookup (`LogEntry` only carries `schoolId`, not geography codes directly), any other role gets 403.

## #209 — GET /api/admin/coordinators leaks nationwide to State Admin
School/Teacher, Volunteer, District Admin, and Block Admin were all correctly scoped — but State Admin (`UserRole.ADMIN`) wasn't in the if/else chain and fell through completely unfiltered, seeing the same nationwide list as Superadmin. Added the missing `stateCode` filter branch.

## Verified
Live against a scratch MongoDB seed (86,400 students, full seed):
- Logged in as a real State Admin (`admin.ap@fln.org`, stateCode AP) — `GET /api/admin/coordinators` now returns only 7 coordinators, all `stateCode: AP` (previously would've returned the full national list)
- Inserted two test logbook entries (one for an AP school, one for an Arunachal Pradesh school) — the AP admin's `GET /api/logbook` returned only the AP entry; re-checked as Superadmin, both entries still returned (unscoped, as intended)
- `tsc --noEmit` clean
- Scratch DB dropped after