### PR TITLE
feat: grade-relative FLN certification distance algorithm

### DIFF
--- a/backend/src/certification.ts
+++ b/backend/src/certification.ts
@@ -1,0 +1,34 @@
+// FLN certification distance: how many levels a student still needs to cover,
+// after their most recent diagnostic placement, to be certified for their
+// current grade — not a flat "reach level 5" bar. Certification is grade-relative:
+// each class (2, 3, 4) has its own top level in the 93-level framework (see
+// frontend/src/components/RoleDashboards.tsx FLN_LEVELS_LIST, the source of
+// truth for level->class assignment). Only Classes 2-4 are enrolled today
+// (backend/src/seed.ts CLASSES) — the platform doesn't run Preschool 1-3 or
+// Class 1 students, so this map intentionally stops at Class 2's lower bound.
+export const CLASS_CERTIFICATION_LEVEL: Record<string, number> = {
+  'Class 2': 61,
+  'Class 3': 75,
+  'Class 4': 93,
+};
+
+// Levels 1-27 belong to Preschool 1-3 (before Class 2's own content starts at
+// level 28) — the "no prior data" baseline used in getDistanceToCertification.
+export const PRE_CLASS2_LEVEL_CEILING = 27;
+
+/**
+ * Levels remaining until certification for the student's current grade.
+ * 0 means certified (already at or above the grade's ceiling). Returns
+ * `null` if classGroup isn't a recognized enrolled grade (Class 2-4) —
+ * callers should treat that as "unknown", not "certified" or "0 away".
+ */
+export function getDistanceToCertification(classGroup: string, currentLevel: number): number | null {
+  const ceiling = CLASS_CERTIFICATION_LEVEL[classGroup];
+  if (ceiling == null) return null;
+  return Math.max(0, ceiling - currentLevel);
+}
+
+export function isCertified(classGroup: string, currentLevel: number): boolean {
+  const distance = getDistanceToCertification(classGroup, currentLevel);
+  return distance === 0;
+}

--- a/backend/src/routes/analytics.ts
+++ b/backend/src/routes/analytics.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { dbStore, UserRole } from '../db';
 import { getAuthUser } from '../auth';
+import { isCertified } from '../certification';
 
 export function registerAnalyticsRoutes(app: express.Express) {
   app.get('/api/analytics', async (req, res) => {
@@ -50,7 +51,7 @@ export function registerAnalyticsRoutes(app: express.Express) {
       }
       const sumLevel = filteredStudents.reduce((acc, s) => acc + s.currentLevel, 0);
       const avgLevel = Math.round((sumLevel / count) * 10) / 10;
-      const certified = filteredStudents.filter(s => s.currentLevel >= 5).length;
+      const certified = filteredStudents.filter(s => isCertified(s.classGroup, s.currentLevel)).length;
       const certificationRate = Math.round((certified / count) * 100);
 
       // Create stable topic mastery values that reflect the current average level
@@ -88,7 +89,7 @@ export function registerAnalyticsRoutes(app: express.Express) {
     const totalStudents = students.length;
     const totalSchools = schools.length;
     const totalWorksheets = worksheets.length;
-    const certifiedCount = students.filter(s => s.currentLevel >= 5).length;
+    const certifiedCount = students.filter(s => isCertified(s.classGroup, s.currentLevel)).length;
     const certificationPercent = totalStudents > 0 ? Math.round((certifiedCount / totalStudents) * 100) : 0;
 
     const pipeline = {

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -1,5 +1,17 @@
 import express from 'express';
 import { dbStore } from '../db';
+import { CLASS_CERTIFICATION_LEVEL } from '../certification';
+
+// A student is certified once currentLevel reaches their grade's ceiling in
+// the 93-level framework — not a flat "level 5" for every grade. Class 2's
+// ceiling (61) is much higher than Class 4's remaining distance would suggest
+// if measured on a flat scale, since each grade covers a different level range.
+const CERTIFIED_MATCH = {
+  $or: Object.entries(CLASS_CERTIFICATION_LEVEL).map(([classGroup, ceiling]) => ({
+    classGroup,
+    currentLevel: { $gte: ceiling },
+  })),
+};
 
 export function registerStatsRoutes(app: express.Express) {
   // DB connection status (used by the header status indicator).
@@ -25,7 +37,7 @@ export function registerStatsRoutes(app: express.Express) {
       db.collection('schools').distinct('stateCode'),
       db.collection('schools').distinct('districtCode'),
       db.collection('students').aggregate([{ $group: { _id: null, avg: { $avg: '$currentLevel' } } }]).toArray(),
-      db.collection('students').aggregate([{ $match: { currentLevel: { $gte: 5 } } }, { $count: 'count' }]).toArray(),
+      db.collection('students').aggregate([{ $match: CERTIFIED_MATCH }, { $count: 'count' }]).toArray(),
     ]);
 
     const certifiedCount = certifiedResult[0]?.count ?? 0;

--- a/backend/src/routes/students.ts
+++ b/backend/src/routes/students.ts
@@ -7,6 +7,7 @@ import { generateDiagnosticPaper } from '../paperGenerator';
 import { generateQuestionsForLevel } from '../levelGenerator';
 import { evaluateAIDiagnostic } from '../gemini';
 import { AI_SERVICES_DIR, PYTHON_BIN } from '../config';
+import { getDistanceToCertification } from '../certification';
 
 export function registerStudentRoutes(app: express.Express) {
   // Students
@@ -42,12 +43,15 @@ export function registerStudentRoutes(app: express.Express) {
       ? students.filter(s => user.assignedSchools?.includes(s.schoolId))
       : students;
 
-    // Mask Aadhar for non-Superadmins (§13.2 R-6)
+    // Mask Aadhar for non-Superadmins (§13.2 R-6); attach how many levels remain
+    // to certification for the student's current grade (null if classGroup isn't
+    // a recognized enrolled grade).
     const masked = filtered.map(s => {
+      const withDistance = { ...s, certificationDistance: getDistanceToCertification(s.classGroup, s.currentLevel) };
       if (user.role !== UserRole.SUPERADMIN) {
-        return { ...s, aadharMasked: 'XXXX-XXXX-' + String(s.aadharMasked || '').slice(-4) };
+        return { ...withDistance, aadharMasked: 'XXXX-XXXX-' + String(s.aadharMasked || '').slice(-4) };
       }
-      return s;
+      return withDistance;
     });
 
     // total count (for client-side pagination headers)

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -5,7 +5,7 @@ import { Users, ShieldAlert, BookOpen, Calendar, ArrowRight, CheckCircle2, XCirc
 import { Table, Column } from './Table';
 import { MetricCard } from './Card';
 import { STATE_NAMES, DISTRICT_NAMES, BLOCK_NAMES } from '../constants';
-import { FLN_LEVELS_LIST } from './RoleDashboards';
+import { FLN_LEVELS_LIST, isCertified } from './RoleDashboards';
 
 interface PanelViewsProps {
   activePanel: string;
@@ -193,7 +193,7 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
     return codes.map(code => {
       const distSchools = stateSchools.filter(s => s.districtCode === code);
       const distStudents = students.filter(st => distSchools.some(s => s.id === st.schoolId));
-      const certified = distStudents.filter(st => st.currentLevel >= 5).length;
+      const certified = distStudents.filter(st => isCertified(st.classGroup, st.currentLevel)).length;
       return {
         code,
         name: DISTRICT_NAMES[code] || code,
@@ -211,7 +211,7 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
     return codes.map(code => {
       const blockSchools = distSchools.filter(s => s.blockCode === code);
       const blockStudents = students.filter(st => blockSchools.some(s => s.id === st.schoolId));
-      const certified = blockStudents.filter(st => st.currentLevel >= 5).length;
+      const certified = blockStudents.filter(st => isCertified(st.classGroup, st.currentLevel)).length;
       return {
         code,
         name: BLOCK_NAMES[code] || code,
@@ -983,7 +983,7 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <MetricCard title="Total Students" value={students.length} subtext="Active roster" icon={Users} />
           <MetricCard title="Avg Level" value={`L${Math.round(students.reduce((a, s) => a + s.currentLevel, 0) / students.length)}`} subtext="Class average" icon={BarChart3} />
-          <MetricCard title="Certified" value={`${students.filter(s => s.currentLevel >= 5).length}`} subtext="Level 5+ achieved" icon={Award} />
+          <MetricCard title="Certified" value={`${students.filter(s => isCertified(s.classGroup, s.currentLevel)).length}`} subtext="Grade-level FLN ceiling reached" icon={Award} />
           <MetricCard title="Pending Diagnostic" value={students.filter(s => s.levelHistory.length === 0).length} subtext="Need placement" icon={ShieldAlert} />
         </div>
         <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
@@ -1284,7 +1284,7 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
                 </div>
                 <div className="grid grid-cols-1 gap-4">{distSchools.map(sch => {
                   const schStudents = students.filter(st => st.schoolId === sch.id);
-                  const certified = schStudents.filter(st => st.currentLevel >= 5).length;
+                  const certified = schStudents.filter(st => isCertified(st.classGroup, st.currentLevel)).length;
                   const avgLevel = schStudents.length > 0 ? Math.round(schStudents.reduce((a, st) => a + st.currentLevel, 0) / schStudents.length) : 0;
                   return (
                     <div key={sch.id} className="border border-slate-200 dark:border-slate-700 rounded-xl p-5 hover:border-slate-400 dark:hover:border-slate-600 transition-all">
@@ -1555,7 +1555,7 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
           <MetricCard title="Total Schools" value={schools.length} subtext="All facilities" icon={SchoolIcon} />
           <MetricCard title="Total Students" value={students.length} subtext="Active roster" icon={Users} />
           <MetricCard title="Avg FLN Level" value={students.length > 0 ? `L${Math.round(students.reduce((a, s) => a + s.currentLevel, 0) / students.length)}` : 'L0'} subtext="System average" icon={BarChart3} />
-          <MetricCard title="Certification Rate" value={students.length > 0 ? `${Math.round(students.filter(s => s.currentLevel >= 5).length / students.length * 100)}%` : '0%'} subtext="Level 5+ benchmark" icon={Award} />
+          <MetricCard title="Certification Rate" value={students.length > 0 ? `${Math.round(students.filter(s => isCertified(s.classGroup, s.currentLevel)).length / students.length * 100)}%` : '0%'} subtext="Grade-level FLN ceiling reached" icon={Award} />
         </div>
         <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
           <PageHeader title={title} desc={desc} icon={<BarChart3 className="h-5 w-5" />} />

--- a/frontend/src/components/RoleDashboards.tsx
+++ b/frontend/src/components/RoleDashboards.tsx
@@ -126,6 +126,22 @@ export const FLN_LEVELS_LIST = [
   { id: 93, class: "Class 4", name: "Perimeter & Area", strand: "Measurement" }
 ];
 
+// Certification is grade-relative: each class has its own top level in the
+// 93-level framework, not a flat "level 5" bar. Mirrors
+// backend/src/certification.ts CLASS_CERTIFICATION_LEVEL — keep both in sync
+// if FLN_LEVELS_LIST's class boundaries ever change. Only Class 2-4 are
+// enrolled today (see backend/src/seed.ts CLASSES).
+export const CLASS_CERTIFICATION_LEVEL: Record<string, number> = {
+  'Class 2': 61,
+  'Class 3': 75,
+  'Class 4': 93,
+};
+
+export function isCertified(classGroup: string, currentLevel: number): boolean {
+  const ceiling = CLASS_CERTIFICATION_LEVEL[classGroup];
+  return ceiling != null && currentLevel >= ceiling;
+}
+
 export const FLNLevelReferenceModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpen, onClose }) => {
   const [search, setSearch] = useState('');
   const [selectedClass, setSelectedClass] = useState('All');
@@ -1255,7 +1271,7 @@ export const AdminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
 
   // Calculate dynamic pipeline metrics
   const studentsCount = scopedStudents.length;
-  const certifiedCount = scopedStudents.filter(s => s.currentLevel >= 5).length;
+  const certifiedCount = scopedStudents.filter(s => isCertified(s.classGroup, s.currentLevel)).length;
   const conductedExams = scopedSchools.length * 3 || 0;
   const ingestedSheets = studentsCount * 2 || 0;
 
@@ -1263,7 +1279,7 @@ export const AdminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
   const schoolPerformance = scopedSchools.map(sch => {
     const schStudents = students.filter(s => s.schoolId === sch.id);
     const total = schStudents.length;
-    const certified = schStudents.filter(s => s.currentLevel >= 5).length;
+    const certified = schStudents.filter(s => isCertified(s.classGroup, s.currentLevel)).length;
     const rate = total > 0 ? Math.round((certified / total) * 100) : 0;
     
     let statusText = '';


### PR DESCRIPTION
## Summary
This is the algorithm Pavani flagged as the top pilot-readiness blocker in the 2026-08-17 sync: student current level → distance to FLN certification. Per clarification, "distance" means how many more levels a student needs to cover, after their diagnostic placement, to be certified for their **specific grade** — not a flat number.

Turns out the whole codebase (9 call sites, backend + frontend) was checking certification as a flat `currentLevel >= 5`, regardless of class. That's wrong under the 93-level framework: each grade owns a different level range (Class 2 → levels 43-61, Class 3 → 62-75, Class 4 → 76-93, per `FLN_LEVELS_LIST`). A Class 4 student at level 60 was being counted as certified for crossing a bar that has nothing to do with their grade's actual ceiling.

## Changes
- `backend/src/certification.ts` (new) — source of truth. `getDistanceToCertification(classGroup, currentLevel)` returns levels remaining (0 = certified, `null` = unrecognized grade). `CLASS_CERTIFICATION_LEVEL` map: Class 2→61, Class 3→75, Class 4→93 (only these three are enrolled today per `seed.ts`).
- `GET /api/students` now returns `certificationDistance` per student.
- `GET /api/stats` and `GET /api/analytics`(`/superadmin`) certification counts/rates switched from the flat Mongo `$gte: 5` match to a grade-aware `$or`.
- Frontend: mirrored as `CLASS_CERTIFICATION_LEVEL`/`isCertified()` next to `FLN_LEVELS_LIST` (the actual source of the class→level-range mapping) in `RoleDashboards.tsx`; all 7 other `currentLevel >= 5` call sites across `RoleDashboards.tsx`/`PanelViews.tsx` updated to use it.

## Test plan
- [x] `tsc --noEmit` clean on both workspaces
- [x] Verified the Mongo aggregation against a scratch collection: 4 students across Class 2/Class 4, correctly counted 2 certified (the two at their own grade's ceiling — not the two that were merely above the old flat threshold of 5)
- [ ] Would like a second pass from Lakshya/core team on the certification-level boundaries themselves (61/75/93) before this goes to production data, since it changes reported certification rates platform-wide