### PR TITLE
fix: ICR scan pages[] handling, garbled cloud results, and mislabeled scan header

### DIFF
--- a/backend/src/routes/evaluation.ts
+++ b/backend/src/routes/evaluation.ts
@@ -153,10 +153,16 @@ export function registerEvaluationRoutes(app: express.Express) {
     const user = getAuthUser(req);
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
-    const { classId, studentId, pdfBase64, fileBase64, filename } = req.body;
-    const inputBase64 = fileBase64 || pdfBase64;
+    const { classId, studentId, pdfBase64, fileBase64, filename, pages } = req.body;
+    // The frontend's two-stage scan flow (IcrTwoStageScan) sends a `pages`
+    // array once the blue-ink filter step has run, instead of a single
+    // fileBase64/pdfBase64 — one entry per filtered page. This route only
+    // evaluates one image per call, so take the first page here; full
+    // multi-page evaluation is tracked separately.
+    const firstPageDataUrl = Array.isArray(pages) && pages.length > 0 ? pages[0]?.imageDataUrl : undefined;
+    const inputBase64 = fileBase64 || pdfBase64 || firstPageDataUrl;
     if (!inputBase64) {
-      return res.status(400).json({ error: 'fileBase64 or pdfBase64 is required.' });
+      return res.status(400).json({ error: 'fileBase64, pdfBase64, or pages is required.' });
     }
 
     // Fast path: no classId → single-image OCR. Just run EasyOCR once and

--- a/frontend/src/components/IcrScanner.tsx
+++ b/frontend/src/components/IcrScanner.tsx
@@ -337,6 +337,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
     answers?: Record<string, { value: string; confidence: number; blue_pixels: number }>;
     debug?: { image_size?: [number, number]; blue_pixel_ratio?: number };
     processingTimeMs?: number;
+    ocrAnalysis?: { ocrEngine?: string };
   }) => {
     console.log('[OCR Result] received from two-stage scan:', data);
     if (!data.success || !data.answers) {
@@ -403,6 +404,10 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
     const matched = ocrValues.filter(v => v && v.trim()).length;
     const total = loadedQuestions.length;
     const pct = Math.round((matched / Math.max(1, total)) * 100);
+    // Use whichever engine/provider actually produced this result (set by
+    // IcrTwoStageScan — 'EasyOCR (PyTorch Fast Reader)' for the local path,
+    // 'Cloud OCR (<model>)' for the cloud path) instead of assuming local.
+    const actualEngine = data.ocrAnalysis?.ocrEngine || 'EasyOCR (PyTorch Fast Reader)';
 
     const firstRes = {
       studentId: selectedStudentId || 'SCAN',
@@ -415,7 +420,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
       newLevel: 1,
       subLevel: 0,
       extractedAnswers: extracted,
-      ocrEngine: 'EasyOCR (PyTorch Fast Reader)',
+      ocrEngine: actualEngine,
       ocrAnalysis: {
         rawOcrText: Object.entries(answers).map(([k, v]) => `${k}: ${v.value}`).join(' | '),
         extractedTokens: Object.entries(answers).map(([k, v]) => ({
@@ -423,7 +428,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
           confidence: v.confidence,
         })),
         processingTimeMs: data.processingTimeMs ?? 0,
-        ocrEngine: 'EasyOCR (PyTorch Fast Reader)',
+        ocrEngine: actualEngine,
       },
       status: 'completed',
     };
@@ -772,8 +777,12 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                   </svg>
                 </div>
                 <div>
-                  <h4 className="text-sm font-display font-semibold text-zinc-900">EasyOCR Scan Complete</h4>
-                  <p className="text-xs text-zinc-500">Sub-second PyTorch character extraction</p>
+                  <h4 className="text-sm font-display font-semibold text-zinc-900">
+                    {ocrPreviewData?.ocrEngine?.startsWith('Cloud OCR') ? 'Cloud Scan Complete' : 'EasyOCR Scan Complete'}
+                  </h4>
+                  <p className="text-xs text-zinc-500">
+                    {ocrPreviewData?.ocrEngine || 'Sub-second PyTorch character extraction'}
+                  </p>
                 </div>
               </div>
               <p className="text-xs text-zinc-600 leading-relaxed bg-white/60 p-3 rounded-lg border border-emerald-100">

--- a/frontend/src/components/IcrTwoStageScan.tsx
+++ b/frontend/src/components/IcrTwoStageScan.tsx
@@ -493,8 +493,12 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
         }
         // Prefer the structured `studentResponses` from Ollama's JSON-output mode
         // (question_number → response, with status: answered|blank|unclear).
-        // Fall back to the legacy `extractedTokens` (whitespace-split) when
-        // the model returned prose or the JSON parse failed.
+        // Next, prefer the backend's already-parsed `answers` array (present
+        // whenever `structured: true` — see /api/icr/evaluate-cloud) — this
+        // is the model's real per-question answers, not raw OCR text.
+        // Only fall back to `extractedTokens` (the raw token stream, which
+        // can include JSON punctuation from the model's own response text)
+        // when neither structured shape is available.
         const answers: Record<string, { value: string; confidence: number; blue_pixels: number }> = {};
         if (data.studentResponses && Array.isArray(data.studentResponses)) {
           for (const r of data.studentResponses) {
@@ -511,6 +515,14 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
               blue_pixels: 0,
             };
           }
+        } else if (data.answers && Array.isArray(data.answers) && data.answers.length > 0) {
+          data.answers.forEach((v: any, i: number) => {
+            answers[`q_${i + 1}`] = {
+              value: String(v ?? ''),
+              confidence: 0.8,
+              blue_pixels: 0,
+            };
+          });
         } else if (data.extractedTokens && data.extractedTokens.length > 0) {
           data.extractedTokens.forEach((t: any, i: number) => {
             const v = String(t?.text ?? '').trim();
@@ -536,7 +548,7 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
                       bbox: t.bbox,
                     })),
                     processingTimeMs: data.processingTimeMs ?? clientMs,
-                    ocrEngine: data.ocrEngine || 'Cloud OCR',
+                    ocrEngine: data.ocrEngine || (data.model ? `Cloud OCR (${data.model})` : `Cloud OCR (${cloudProvider})`),
                   },
                   processingTimeMs: data.processingTimeMs ?? clientMs,
                 };


### PR DESCRIPTION
## Summary
Three bugs found during a live audit of the Two-Stage Scan feature on tenali.fun/fln (real teacher account, real scanned answer sheet):

1. **`/api/icr/evaluate-pdf` never read the `pages` field.** Once the blue-ink filter step succeeds, the frontend sends `{ pages: [...] }` — but this route only ever checked `fileBase64`/`pdfBase64`, so the *intended* filter-then-OCR flow failed 100% of the time with `fileBase64 or pdfBase64 is required.` Fixed by falling back to `pages[0].imageDataUrl`.
2. **Cloud OCR (Ollama-Gemma4) returned garbled per-question answers on real scans.** The handler only checked `data.studentResponses` (which the backend never actually sends) before falling straight to `data.extractedTokens` — the raw OCR text stream, which can include literal JSON punctuation from the model's own response (`{`, `"answers":`, `[`). Fixed by preferring the backend's already-parsed `data.answers` array (present whenever `structured: true`) before that fallback.
3. **Results panel always said "EasyOCR Scan Complete / Sub-second PyTorch character extraction"** regardless of whether the local or cloud path produced the result — hardcoded text in `IcrScanner.tsx`. Now reflects the actual engine/provider used.

## Test plan
- [x] `tsc --noEmit` clean on both `backend` and `frontend`
- [x] `vite build` and `esbuild` backend build both clean
- [ ] Live-verify on a real scan through the Two-Stage Scan UI once merged and deployed (filter → local OCR → confirm real answers, not the old error; cloud OCR → confirm parsed answers, not raw JSON tokens; header reflects correct engine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)