### PR TITLE
fix: wire Worksheets panel to real data + track real Pending status

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -215,6 +215,11 @@ export interface Worksheet {
   cycle: CycleName;
   date: string;
   questions: Question[];
+  // Which students this worksheet was actually generated for — needed to
+  // compute how many are still pending evaluation (studentIds.length minus
+  // the number with a matching EvaluationReport.worksheetId). Optional so
+  // older/other worksheet-creation paths that don't set it still validate.
+  studentIds?: string[];
   locks: {
     locked: boolean;
     lockedByRole: UserRole | null;

--- a/backend/src/routes/diagnosticBulk.ts
+++ b/backend/src/routes/diagnosticBulk.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import fs from 'fs';
 import { randomUUID } from 'crypto';
-import { dbStore, UserRole, Question } from '../db';
+import { dbStore, UserRole, Question, Worksheet } from '../db';
 import { getAuthUser } from '../auth';
 import { generateDiagnosticPaper } from '../paperGenerator';
 import { generateQuestionsForLevel } from '../levelGenerator';
@@ -155,6 +155,41 @@ export function registerDiagnosticBulkRoutes(app: express.Express) {
             }
           }
         }
+
+        // Persist a real Worksheet record so this generation shows up as
+        // "Pending" on the teacher's Worksheets page until evaluation
+        // reports come in — previously this bulk-generation job only lived
+        // in the in-memory `bulkJobs` map, invisible to that page entirely.
+        const matchedClass = classes.find(c => c.className === `Class ${classNumber}`);
+        const nowIso = new Date().toISOString();
+        const thirtyDaysOut = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+        const realStudentIds = paperStudents
+          .map(s => s.studentId)
+          .filter(id => id && !id.startsWith('PLACEHOLDER_'));
+        const worksheet: Worksheet = {
+          id: 'ws_' + randomUUID(),
+          classId: matchedClass?.id || `class_${classNumber}`,
+          className: `Class ${classNumber}`,
+          section: matchedClass?.section || 'A',
+          schoolId: user.schoolId || matchedClass?.schoolId || '',
+          generatedByRole: user.role,
+          generatedByEmail: user.email,
+          cycle: 'Baseline',
+          date: nowIso,
+          questions: [],
+          studentIds: realStudentIds,
+          locks: { locked: false, lockedByRole: null, lockedByEmail: null, timestamp: null },
+          timing: {
+            examDate: nowIso.slice(0, 10),
+            printWindowStart: nowIso,
+            printWindowEnd: thirtyDaysOut,
+            examWindowStart: nowIso,
+            examWindowEnd: thirtyDaysOut,
+            submissionWindowEnd: thirtyDaysOut,
+          },
+          delayLogs: { delayedAttemptsCount: 0, submittingTeachers: [] },
+        };
+        await dbStore.addWorksheet(worksheet);
 
         await dbStore.addLog({
           id: 'log_' + Date.now(),

--- a/backend/src/routes/worksheets.ts
+++ b/backend/src/routes/worksheets.ts
@@ -124,6 +124,39 @@ async function generateLevelWorksheetsViaLevelsBackend(
 }
 
 export function registerWorksheetRoutes(app: express.Express) {
+  // List worksheets (class-level generation records), scoped by role the
+  // same way /api/evaluation/reports is. Used by the frontend's Worksheets
+  // page to compute real Pending vs Evaluated counts, instead of the old
+  // hardcoded WORKSHEETS_MOCK fixture.
+  app.get('/api/worksheets', async (req, res) => {
+    const user = getAuthUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const worksheets = await dbStore.getWorksheets();
+
+    if (user.role === UserRole.SUPERADMIN) {
+      return res.json(worksheets);
+    }
+    if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
+      return res.json(worksheets.filter(w => w.schoolId === user.schoolId));
+    }
+    if (user.role === UserRole.VOLUNTEER) {
+      return res.json(worksheets.filter(w => user.assignedSchools?.includes(w.schoolId)));
+    }
+    if (user.role === UserRole.ADMIN || user.role === UserRole.DISTRICT_ADMIN || user.role === UserRole.BLOCK_ADMIN) {
+      const schools = await dbStore.getSchools();
+      const schoolById = new Map(schools.map(sc => [sc.id, sc]));
+      return res.json(worksheets.filter(w => {
+        const school = schoolById.get(w.schoolId);
+        if (!school) return false;
+        if (user.role === UserRole.ADMIN) return school.stateCode === user.stateCode;
+        if (user.role === UserRole.DISTRICT_ADMIN) return school.districtCode === user.districtCode;
+        return school.blockCode === user.blockCode; // BLOCK_ADMIN
+      }));
+    }
+    return res.json(worksheets);
+  });
+
   app.post('/api/worksheets/generate', async (req, res) => {
     const user = getAuthUser(req);
     if (!user) return res.status(401).json({ error: 'Unauthorized' });

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -81,15 +81,6 @@ const DIAGNOSTIC_HISTORY = [
   { id: 'dh5', student: 'Jasmine Kaur', date: '2026-02-20', score: 5, total: 10, placedLevel: 8, evaluator: 'Amit Kumar' },
 ];
 
-const WORKSHEETS_MOCK = [
-  { id: 'ws1', cycle: 'Baseline', class: 'Class 2-A', date: '2026-01-10', questions: 10, status: 'Evaluated', avgScore: '78%' },
-  { id: 'ws2', cycle: 'Mid-year', class: 'Class 2-A', date: '2026-02-20', questions: 10, status: 'Evaluated', avgScore: '65%' },
-  { id: 'ws3', cycle: 'Baseline', class: 'Class 3-A', date: '2026-01-10', questions: 10, status: 'Evaluated', avgScore: '85%' },
-  { id: 'ws4', cycle: 'Mid-year', class: 'Class 3-A', date: '2026-03-01', questions: 10, status: 'Evaluated', avgScore: '72%' },
-  { id: 'ws5', cycle: 'End-of-year', class: 'Class 2-A', date: '2026-05-15', questions: 12, status: 'Pending', avgScore: '-' },
-  { id: 'ws6', cycle: 'End-of-year', class: 'Class 3-A', date: '2026-05-20', questions: 12, status: 'Pending', avgScore: '-' },
-];
-
 const CONTENT_ITEMS = [
   { id: 'c1', title: 'Number Line 1-10', type: 'Visual Aid', level: 'L1-L4', language: 'English, Punjabi', status: 'Approved' },
   { id: 'c2', title: 'Addition with Objects', type: 'Lesson Plan', level: 'L7-L12', language: 'English, Hindi', status: 'Approved' },
@@ -955,21 +946,62 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
   }
 
   if (panel === 'worksheets') {
+    // Real data: group real EvaluationReport records by cycle + class,
+    // instead of the old WORKSHEETS_MOCK fixture (which never made an API
+    // call at all — every teacher saw the same 6 invented rows). Cycle
+    // name is derived from the closest levelHistory entry on the report's
+    // student, matching the same Baseline/Midline/Endline naming standardized
+    // in #179.
+    const cycleForReport = (r: EvaluationReport): string => {
+      const s = students.find(st => st.id === r.studentId);
+      if (!s || s.levelHistory.length === 0) return 'Assessment';
+      const reportTime = new Date(r.timestamp).getTime();
+      let closest = s.levelHistory[0];
+      let closestDiff = Math.abs(new Date(closest.date).getTime() - reportTime);
+      for (const lh of s.levelHistory) {
+        const diff = Math.abs(new Date(lh.date).getTime() - reportTime);
+        if (diff < closestDiff) { closest = lh; closestDiff = diff; }
+      }
+      return closest.reason || 'Assessment';
+    };
+    type CycleGroup = { cycle: string; classGroup: string; reports: EvaluationReport[] };
+    const groups = new Map<string, CycleGroup>();
+    reportsList.forEach(r => {
+      const s = students.find(st => st.id === r.studentId);
+      const classGroup = s?.classGroup || 'Unknown Class';
+      const cycle = cycleForReport(r);
+      const key = `${cycle}__${classGroup}`;
+      if (!groups.has(key)) groups.set(key, { cycle, classGroup, reports: [] });
+      groups.get(key)!.reports.push(r);
+    });
+    const cycleGroups = Array.from(groups.values()).sort((a, b) =>
+      Math.max(...b.reports.map(r => new Date(r.timestamp).getTime())) -
+      Math.max(...a.reports.map(r => new Date(r.timestamp).getTime()))
+    );
     return (
       <div className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <MetricCard title="Total Worksheets" value={WORKSHEETS_MOCK.length} subtext="Across all cycles" icon={ClipboardList} />
-          <MetricCard title="Evaluated" value={WORKSHEETS_MOCK.filter(w => w.status === 'Evaluated').length} subtext="Graded and scored" icon={CheckCircle2} />
-          <MetricCard title="Pending" value={WORKSHEETS_MOCK.filter(w => w.status === 'Pending').length} subtext="Awaiting evaluation" icon={FileText} />
+          <MetricCard title="Total Worksheets" value={reportsList.length} subtext="Across all cycles" icon={ClipboardList} />
+          <MetricCard title="Evaluated" value={reportsList.length} subtext="Graded and scored" icon={CheckCircle2} />
+          <MetricCard title="Cycle Groups" value={cycleGroups.length} subtext="Cycle x class combinations" icon={FileText} />
         </div>
         <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
-          <PageHeader title="Worksheet Cycles" desc="Baseline, Mid-year, and End-of-year assessments" />
-          <div className="space-y-3 mt-4">{WORKSHEETS_MOCK.map(w => (
-            <div key={w.id} className="flex justify-between items-center p-4 border border-slate-200 dark:border-slate-700 rounded-lg">
-              <div><div className="font-semibold text-sm">{w.cycle} — {w.class}</div><div className="text-xs text-slate-400 dark:text-slate-500">{w.date} · {w.questions} questions</div></div>
-              <div className="text-right"><span className={`text-xs font-mono font-bold px-2 py-1 rounded ${w.status === 'Evaluated' ? 'text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800' : 'text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800'}`}>{w.status}</span><div className="text-xs text-slate-400 dark:text-slate-500 mt-1">Avg: {w.avgScore}</div></div>
-            </div>
-          ))}</div>
+          <PageHeader title="Worksheet Cycles" desc="Baseline, Midline, and Endline assessments" />
+          <div className="space-y-3 mt-4">
+            {cycleGroups.length === 0 && (
+              <div className="text-sm text-slate-400 dark:text-slate-500 py-4 text-center">No worksheet evaluations yet.</div>
+            )}
+            {cycleGroups.map(g => {
+              const avgPct = Math.round(g.reports.reduce((a, r) => a + (r.score / r.totalQuestions) * 100, 0) / g.reports.length);
+              const latestDate = new Date(Math.max(...g.reports.map(r => new Date(r.timestamp).getTime()))).toLocaleDateString();
+              return (
+                <div key={`${g.cycle}__${g.classGroup}`} className="flex justify-between items-center p-4 border border-slate-200 dark:border-slate-700 rounded-lg">
+                  <div><div className="font-semibold text-sm">{g.cycle} — {g.classGroup}</div><div className="text-xs text-slate-400 dark:text-slate-500">{latestDate} · {g.reports.length} worksheet{g.reports.length === 1 ? '' : 's'}</div></div>
+                  <div className="text-right"><span className="text-xs font-mono font-bold px-2 py-1 rounded text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800">Evaluated</span><div className="text-xs text-slate-400 dark:text-slate-500 mt-1">Avg: {avgPct}%</div></div>
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -1,6 +1,6 @@
 import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
-import { User, UserRole, Student, ClassGroup, School, EvaluationReport, LogEntry, Ticket } from '../types';
+import { User, UserRole, Student, ClassGroup, School, EvaluationReport, Worksheet, LogEntry, Ticket } from '../types';
 import { Users, ShieldAlert, BookOpen, Calendar, ArrowRight, CheckCircle2, XCircle, SlidersHorizontal, Layers, Award, MapPin, School as SchoolIcon, BarChart3, FileText, ClipboardList, Building2, GraduationCap, BookMarked, Globe, Settings, Database, RefreshCw, Search, ChevronDown } from 'lucide-react';
 import { Table, Column } from './Table';
 import { MetricCard } from './Card';
@@ -143,6 +143,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
   const [apiSchools, setApiSchools] = useState<School[]>([]);
   const [apiUsers, setApiUsers] = useState<any[]>([]);
   const [apiReports, setApiReports] = useState<EvaluationReport[]>([]);
+  const [apiWorksheets, setApiWorksheets] = useState<Worksheet[]>([]);
   const [apiTeachers, setApiTeachers] = useState<any[]>([]);
 
   useEffect(() => {
@@ -150,6 +151,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
     apiFetch('/api/schools', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiSchools(d); }).catch(() => {});
     apiFetch('/api/admin/coordinators', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiUsers(d); }).catch(() => {});
     apiFetch('/api/evaluation/reports', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiReports(d); }).catch(() => {});
+    apiFetch('/api/worksheets', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiWorksheets(d); }).catch(() => {});
     if (currentUser.role === UserRole.SCHOOL || currentUser.role === UserRole.BLOCK_ADMIN) {
       apiFetch('/api/teachers', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiTeachers(d); }).catch(() => {});
     }
@@ -174,6 +176,7 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
   // which rendered as a literal "Unknown" name - showing an empty list on
   // fetch failure is honest, a mismatched fake report is not.
   const reportsList: EvaluationReport[] = apiReports;
+  const worksheetsList: Worksheet[] = apiWorksheets;
   const teachersList = apiTeachers.length > 0 ? apiTeachers : TEACHERS_MOCK;
 
   // Real per-district / per-block rollups, derived from the already-fetched
@@ -946,61 +949,63 @@ const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
   }
 
   if (panel === 'worksheets') {
-    // Real data: group real EvaluationReport records by cycle + class,
-    // instead of the old WORKSHEETS_MOCK fixture (which never made an API
-    // call at all — every teacher saw the same 6 invented rows). Cycle
-    // name is derived from the closest levelHistory entry on the report's
-    // student, matching the same Baseline/Midline/Endline naming standardized
-    // in #179.
-    const cycleForReport = (r: EvaluationReport): string => {
-      const s = students.find(st => st.id === r.studentId);
-      if (!s || s.levelHistory.length === 0) return 'Assessment';
-      const reportTime = new Date(r.timestamp).getTime();
-      let closest = s.levelHistory[0];
-      let closestDiff = Math.abs(new Date(closest.date).getTime() - reportTime);
-      for (const lh of s.levelHistory) {
-        const diff = Math.abs(new Date(lh.date).getTime() - reportTime);
-        if (diff < closestDiff) { closest = lh; closestDiff = diff; }
-      }
-      return closest.reason || 'Assessment';
-    };
-    type CycleGroup = { cycle: string; classGroup: string; reports: EvaluationReport[] };
-    const groups = new Map<string, CycleGroup>();
+    // Real data: each row is a real Worksheet generation record (created
+    // when a teacher runs the Bulk Diagnostic Generator — see
+    // backend/src/routes/diagnosticBulk.ts), not the old WORKSHEETS_MOCK
+    // fixture (which never made an API call at all). A worksheet is
+    // "Pending" until a matching EvaluationReport.worksheetId shows up for
+    // each of its studentIds — a paper takes hours (print, exam, scan)
+    // between generation and results, so this reflects real turnaround
+    // time instead of only ever showing "Evaluated" or nothing at all.
+    const reportsByWorksheet = new Map<string, EvaluationReport[]>();
     reportsList.forEach(r => {
-      const s = students.find(st => st.id === r.studentId);
-      const classGroup = s?.classGroup || 'Unknown Class';
-      const cycle = cycleForReport(r);
-      const key = `${cycle}__${classGroup}`;
-      if (!groups.has(key)) groups.set(key, { cycle, classGroup, reports: [] });
-      groups.get(key)!.reports.push(r);
+      if (!r.worksheetId) return;
+      if (!reportsByWorksheet.has(r.worksheetId)) reportsByWorksheet.set(r.worksheetId, []);
+      reportsByWorksheet.get(r.worksheetId)!.push(r);
     });
-    const cycleGroups = Array.from(groups.values()).sort((a, b) =>
-      Math.max(...b.reports.map(r => new Date(r.timestamp).getTime())) -
-      Math.max(...a.reports.map(r => new Date(r.timestamp).getTime()))
-    );
+    const rows = worksheetsList.map(w => {
+      const total = w.studentIds?.length ?? 0;
+      const evaluated = reportsByWorksheet.get(w.id) ?? [];
+      const evaluatedStudentIds = new Set(evaluated.map(r => r.studentId));
+      const evaluatedCount = evaluatedStudentIds.size;
+      const pendingCount = Math.max(0, total - evaluatedCount);
+      const status: 'Evaluated' | 'Partial' | 'Pending' =
+        pendingCount === 0 && total > 0 ? 'Evaluated' : evaluatedCount > 0 ? 'Partial' : 'Pending';
+      const avgPct = evaluated.length > 0
+        ? Math.round(evaluated.reduce((a, r) => a + (r.score / r.totalQuestions) * 100, 0) / evaluated.length)
+        : null;
+      return { worksheet: w, total, evaluatedCount, pendingCount, status, avgPct };
+    }).sort((a, b) => new Date(b.worksheet.date).getTime() - new Date(a.worksheet.date).getTime());
+
+    const totalWorksheets = rows.length;
+    const evaluatedCount = rows.filter(r => r.status === 'Evaluated').length;
+    const pendingCount = rows.filter(r => r.status !== 'Evaluated').length;
+
+    const statusStyle: Record<string, string> = {
+      Evaluated: 'text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800',
+      Partial: 'text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800',
+      Pending: 'text-slate-600 dark:text-slate-300 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700',
+    };
+
     return (
       <div className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <MetricCard title="Total Worksheets" value={reportsList.length} subtext="Across all cycles" icon={ClipboardList} />
-          <MetricCard title="Evaluated" value={reportsList.length} subtext="Graded and scored" icon={CheckCircle2} />
-          <MetricCard title="Cycle Groups" value={cycleGroups.length} subtext="Cycle x class combinations" icon={FileText} />
+          <MetricCard title="Total Worksheets" value={totalWorksheets} subtext="Across all cycles" icon={ClipboardList} />
+          <MetricCard title="Evaluated" value={evaluatedCount} subtext="All students graded" icon={CheckCircle2} />
+          <MetricCard title="Pending" value={pendingCount} subtext="Awaiting scan/evaluation" icon={FileText} />
         </div>
         <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
-          <PageHeader title="Worksheet Cycles" desc="Baseline, Midline, and Endline assessments" />
+          <PageHeader title="Worksheet Cycles" desc="Baseline, Mid-year, and End-of-year assessments" />
           <div className="space-y-3 mt-4">
-            {cycleGroups.length === 0 && (
-              <div className="text-sm text-slate-400 dark:text-slate-500 py-4 text-center">No worksheet evaluations yet.</div>
+            {rows.length === 0 && (
+              <div className="text-sm text-slate-400 dark:text-slate-500 py-4 text-center">No worksheets generated yet.</div>
             )}
-            {cycleGroups.map(g => {
-              const avgPct = Math.round(g.reports.reduce((a, r) => a + (r.score / r.totalQuestions) * 100, 0) / g.reports.length);
-              const latestDate = new Date(Math.max(...g.reports.map(r => new Date(r.timestamp).getTime()))).toLocaleDateString();
-              return (
-                <div key={`${g.cycle}__${g.classGroup}`} className="flex justify-between items-center p-4 border border-slate-200 dark:border-slate-700 rounded-lg">
-                  <div><div className="font-semibold text-sm">{g.cycle} — {g.classGroup}</div><div className="text-xs text-slate-400 dark:text-slate-500">{latestDate} · {g.reports.length} worksheet{g.reports.length === 1 ? '' : 's'}</div></div>
-                  <div className="text-right"><span className="text-xs font-mono font-bold px-2 py-1 rounded text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800">Evaluated</span><div className="text-xs text-slate-400 dark:text-slate-500 mt-1">Avg: {avgPct}%</div></div>
-                </div>
-              );
-            })}
+            {rows.map(({ worksheet: w, total, evaluatedCount: ec, status, avgPct }) => (
+              <div key={w.id} className="flex justify-between items-center p-4 border border-slate-200 dark:border-slate-700 rounded-lg">
+                <div><div className="font-semibold text-sm">{w.cycle} — {w.className}{w.section ? ` ${w.section}` : ''}</div><div className="text-xs text-slate-400 dark:text-slate-500">{new Date(w.date).toLocaleDateString()} · {ec}/{total} evaluated</div></div>
+                <div className="text-right"><span className={`text-xs font-mono font-bold px-2 py-1 rounded ${statusStyle[status]}`}>{status}</span><div className="text-xs text-slate-400 dark:text-slate-500 mt-1">Avg: {avgPct !== null ? `${avgPct}%` : '—'}</div></div>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -93,6 +93,7 @@ export interface Worksheet {
   cycle: 'Baseline' | 'Mid-year' | 'End-of-year';
   date: string;
   questions: Question[];
+  studentIds?: string[];
   locks: {
     locked: boolean;
     lockedByRole: UserRole | null;


### PR DESCRIPTION
## Summary

Found during a live teacher-dashboard audit (2026-08-19): the Worksheets page's "Worksheet Cycles" list was a hardcoded array (`WORKSHEETS_MOCK`) that never made an API call at all — every teacher saw the same 6 invented rows, regardless of their real class.

**Commit 1** replaces it with real data aggregated from `EvaluationReport`s already fetched elsewhere in the app.

**Commit 2** adds real Pending tracking, per Jinal's workflow requirement: after generating a diagnostic paper there's a genuine 2-3 hour gap (print → exam → scan → evaluate) before results exist — that gap needs to show as "Pending," not be invisible or fabricated. This required a small backend addition since nothing currently tracked "a paper was generated for these students":

- `/api/diagnostic/bulk` now writes a real `Worksheet` record (with the student list) when generation completes — previously that job only lived in an in-memory map, invisible to this page entirely
- New `GET /api/worksheets`, role-scoped the same way `GET /api/evaluation/reports` already is
- Worksheets panel now shows real **Evaluated / Partial / Pending** status per worksheet, computed from real student counts vs. real matching evaluation reports

## Test plan
- [x] `tsc --noEmit` clean on both backend/frontend
- [x] Both builds clean
- [ ] Live-verify once deployed: generate a bulk diagnostic paper as a teacher, confirm it shows as "Pending" on the Worksheets page with 0/N evaluated; submit one student's scan, confirm it moves to "Partial" with correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)