### PR TITLE
fix: wrap pdfUrl/downloadUrl links with withBase() so they stay under /fln

### DIFF
--- a/frontend/src/components/BulkDiagnosticWorkflow.tsx
+++ b/frontend/src/components/BulkDiagnosticWorkflow.tsx
@@ -1,4 +1,4 @@
-import { apiFetch } from '../services/apiClient';
+import { apiFetch, withBase } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { UserRole } from '../types';
 import { FileText, Download, Clock, AlertCircle, CheckCircle2, XCircle } from 'lucide-react';
@@ -278,7 +278,7 @@ export const BulkDiagnosticWorkflow: React.FC<BulkDiagnosticWorkflowProps> = ({ 
           {job.status === 'completed' && (
             <div className="flex flex-wrap items-center gap-3">
               <a
-                href={job.pdfUrl || job.downloadUrl || '#'}
+                href={job.pdfUrl ? withBase(job.pdfUrl) : job.downloadUrl ? withBase(job.downloadUrl) : '#'}
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold text-sm py-3 px-6 rounded-xl transition-all shadow-sm cursor-pointer"

--- a/frontend/src/components/DiagnosticWorkflow.tsx
+++ b/frontend/src/components/DiagnosticWorkflow.tsx
@@ -1,4 +1,4 @@
-import { apiFetch } from '../services/apiClient';
+import { apiFetch, withBase } from '../services/apiClient';
 import React, { useState } from 'react';
 import { Student, Question, EvaluationReport } from '../types';
 import { SvgLibraryResolver } from './SvgLibraryResolver';
@@ -123,7 +123,7 @@ export const DiagnosticWorkflow: React.FC<DiagnosticWorkflowProps> = ({ student,
           <div className="lg:col-span-2 space-y-4">
             {pdfUrl && (
               <a
-                href={pdfUrl}
+                href={withBase(pdfUrl)}
                 target="_blank"
                 rel="noreferrer"
                 className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 text-white font-medium text-sm py-3 px-6 rounded-xl shadow-md transition-all duration-200 border border-emerald-500/20 active:scale-[0.98]"

--- a/frontend/src/components/RoleDashboards.tsx
+++ b/frontend/src/components/RoleDashboards.tsx
@@ -1749,7 +1749,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
       });
       const data = await res.json();
       if (res.ok && data.pdfUrl) {
-        window.open(data.pdfUrl, '_blank');
+        window.open(withBase(data.pdfUrl), '_blank');
       } else {
         setLevelPdfError(data.error || 'Failed to generate level worksheet.');
       }
@@ -2247,7 +2247,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
                       </div>
                       <div className="flex gap-3">
                         <a
-                          href={bulkJob.pdfUrl || bulkJob.downloadUrl || '#'}
+                          href={bulkJob.pdfUrl ? withBase(bulkJob.pdfUrl) : bulkJob.downloadUrl ? withBase(bulkJob.downloadUrl) : '#'}
                           target="_blank"
                           rel="noreferrer"
                           className="inline-flex items-center gap-1.5 bg-green-600 hover:bg-green-700 text-white text-xs font-mono font-bold px-4 py-2.5 rounded-lg transition-colors cursor-pointer shadow-sm"
@@ -2337,7 +2337,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
                     {levelBatchResults.map((r, i) => (
                       <div key={`${r.studentId}-${r.sublevelId}-${r.setNum}-${i}`} className="flex items-center justify-between text-xs bg-zinc-50 dark:bg-zinc-800 border border-zinc-100 dark:border-zinc-700 rounded px-2 py-1">
                         <span className="text-zinc-700 dark:text-zinc-300 font-medium">{r.studentName} <span className="text-zinc-400 dark:text-zinc-500 font-mono">L{r.sublevelId} set{r.setNum}</span></span>
-                        <a href={r.pdfUrl} target="_blank" rel="noreferrer" className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-mono font-bold">View PDF</a>
+                        <a href={withBase(r.pdfUrl)} target="_blank" rel="noreferrer" className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-mono font-bold">View PDF</a>
                       </div>
                     ))}
                   </div>
@@ -2525,7 +2525,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
       });
       const data = await res.json();
       if (res.ok && data.pdfUrl) {
-        window.open(data.pdfUrl, '_blank');
+        window.open(withBase(data.pdfUrl), '_blank');
       } else {
         setLevelPdfError(data.error || 'Failed to generate level worksheet.');
       }
@@ -2927,7 +2927,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
                     {bulkJob.status === 'completed' && (
                       <div className="flex gap-2 pt-1">
                         <a
-                          href={bulkJob.pdfUrl || bulkJob.downloadUrl || '#'}
+                          href={bulkJob.pdfUrl ? withBase(bulkJob.pdfUrl) : bulkJob.downloadUrl ? withBase(bulkJob.downloadUrl) : '#'}
                           target="_blank"
                           rel="noreferrer"
                           className="inline-flex items-center gap-1.5 bg-green-600 hover:bg-green-700 text-white text-xs font-mono font-bold px-3 py-2 rounded-lg transition-colors cursor-pointer"
@@ -2981,7 +2981,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
                         throw new Error(data.error || 'Batch generation failed.');
                       }
                       for (const result of data.results || []) {
-                        window.open(result.pdfUrl, '_blank');
+                        window.open(withBase(result.pdfUrl), '_blank');
                       }
                       setLevelBulkProgress({ total: placed.length, completed: placed.length, errors: [] });
                     } catch (err: any) {

--- a/frontend/src/components/WorksheetWorkflow.tsx
+++ b/frontend/src/components/WorksheetWorkflow.tsx
@@ -1,4 +1,4 @@
-import { apiFetch } from '../services/apiClient';
+import { apiFetch, withBase } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { ClassGroup, Worksheet, Student, AnswerSubmission, EvaluationReport } from '../types';
 import { SvgLibraryResolver } from './SvgLibraryResolver';
@@ -257,7 +257,7 @@ export const WorksheetWorkflow: React.FC<WorksheetWorkflowProps> = ({ classGroup
                   </button>
                   {pdfUrl && (
                     <a
-                      href={pdfUrl}
+                      href={withBase(pdfUrl)}
                       target="_blank"
                       rel="noreferrer"
                       className="bg-emerald-600 hover:bg-emerald-700 text-white font-mono text-xs font-semibold px-3 py-1.5 rounded border border-emerald-500 flex items-center gap-1.5"


### PR DESCRIPTION
Fixes #238.

## Summary

Reported live via screenshot: after a bulk diagnostic generation completes (Class 3/Class 4, 20 real students), clicking "Print / Open PDF" redirected to `tenali.fun/output/class3_diagnostic_....pdf` — missing the `/fln` prefix — landing on the domain-root app instead of the FLN backend where the PDF actually lives.

## Root cause

Backend returns `pdfUrl`/`downloadUrl` as root-relative paths. Several frontend components used these directly as `href`/`window.open()` targets without the app's base-path prefix — the same class of bug already solved elsewhere in this codebase via `apiFetch()`/`withBase()`, just missed for these specific PDF links.

## Fix

Wrapped every `pdfUrl`/`downloadUrl` consumption site with the existing `withBase()` helper — no backend change needed:
- `BulkDiagnosticWorkflow.tsx` (1 site)
- `DiagnosticWorkflow.tsx` (1 site)
- `RoleDashboards.tsx` (6 sites — teacher + volunteer dashboards, level-batch PDF links)
- `WorksheetWorkflow.tsx` (1 site)

## Test plan
- [x] `tsc --noEmit` clean
- [x] Build clean
- [ ] Live-verify after merge/deploy: generate a bulk diagnostic paper for Class 3 or 4, click "Print / Open PDF", confirm it lands on `tenali.fun/fln/output/...` and the PDF actually loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)