### PR TITLE
PanelViews.tsx split — Batch 2: single-shared-value panels

### DIFF
--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -1,7 +1,7 @@
 import { apiFetch } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { User, UserRole, Student, ClassGroup, School, EvaluationReport, Worksheet, LogEntry, Ticket } from '../types';
-import { Users, ShieldAlert, BookOpen, Calendar, ArrowRight, CheckCircle2, XCircle, SlidersHorizontal, Layers, Award, MapPin, School as SchoolIcon, BarChart3, FileText, ClipboardList, Building2, GraduationCap, BookMarked, Globe, Settings, Database, RefreshCw, Search, ChevronDown } from 'lucide-react';
+import { Users, BookOpen, Calendar, ArrowRight, CheckCircle2, XCircle, SlidersHorizontal, Layers, Award, MapPin, School as SchoolIcon, BarChart3, FileText, ClipboardList, Building2, GraduationCap, BookMarked, Globe, Settings, Database, RefreshCw, Search, ChevronDown } from 'lucide-react';
 import { Table, Column } from './Table';
 import { MetricCard } from './Card';
 import { STATE_NAMES, DISTRICT_NAMES, BLOCK_NAMES } from '../constants';
@@ -13,6 +13,9 @@ import { AdaptiveTestPanel } from './panels/AdaptiveTestPanel';
 import { TestHistoryPanel } from './panels/TestHistoryPanel';
 import { WorksheetTemplatesPanel } from './panels/WorksheetTemplatesPanel';
 import { SystemSettingsPanel } from './panels/SystemSettingsPanel';
+import { StudentListPanel } from './panels/StudentListPanel';
+import { DiagnosticTestPanel } from './panels/DiagnosticTestPanel';
+import { PerformancePanel } from './panels/PerformancePanel';
 
 interface PanelViewsProps {
   activePanel: string;
@@ -68,14 +71,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
   const panel = activePanel;
 
   // ===================== TEACHER PANELS =====================
-  if (panel === 'student_list') {
-    return (
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
-        <PageHeader title="Student Roster" desc="Complete list of registered students across your classes" icon={<Users className="h-5 w-5" />} />
-        <EmptyStudents students={students} />
-      </div>
-    );
-  }
+  if (panel === 'student_list') return <StudentListPanel students={students} />;
 
   if (panel === 'student_profile') {
     const s = students.find(x => x.id === sel) || students[0];
@@ -617,34 +613,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
     );
   }
 
-  if (panel === 'diagnostic_test') {
-    const pending = students.filter(s => s.levelHistory.length === 0);
-    const completed = students.filter(s => s.levelHistory.length > 0);
-    return (
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
-          <PageHeader title="Pending Diagnostics" desc={`${pending.length} students need initial assessment`} icon={<ShieldAlert className="h-5 w-5 text-amber-500" />} />
-          {pending.length === 0 ? <p className="text-xs text-slate-400 dark:text-slate-500 text-center py-8">All students placed.</p> : (
-            <div className="space-y-3">{pending.map(s => (
-              <div key={s.id} className="flex justify-between items-center p-3 border border-slate-200 dark:border-slate-700 rounded-lg">
-                <div><div className="font-medium text-sm">{s.name}</div><div className="text-xs text-slate-400 dark:text-slate-500">{s.classGroup} - {s.section}</div></div>
-                <span className="text-[10px] font-mono font-bold text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950 px-2 py-1 rounded border border-amber-200 dark:border-amber-800">Run Diagnostic</span>
-              </div>
-            ))}</div>
-          )}
-        </div>
-        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
-          <PageHeader title="Completed Diagnostics" desc={`${completed.length} students have been placed`} icon={<CheckCircle2 className="h-5 w-5 text-green-500" />} />
-          <div className="space-y-3">{completed.map(s => (
-            <div key={s.id} className="flex justify-between items-center p-3 border border-slate-200 dark:border-slate-700 rounded-lg">
-              <div><div className="font-medium text-sm">{s.name}</div><div className="text-xs text-slate-400 dark:text-slate-500">Placed at L{s.currentLevel}.{s.currentSubLevel ?? 0}</div></div>
-              <span className="text-[10px] font-mono font-bold text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950 px-2 py-1 rounded border border-green-200 dark:border-green-800">Completed</span>
-            </div>
-          ))}</div>
-        </div>
-      </div>
-    );
-  }
+  if (panel === 'diagnostic_test') return <DiagnosticTestPanel students={students} />;
 
   if (panel === 'adaptive_test') return <AdaptiveTestPanel />;
 
@@ -714,32 +683,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
     );
   }
 
-  if (panel === 'performance') {
-    const isTeacher = currentUser.role === UserRole.TEACHER || currentUser.role === UserRole.VOLUNTEER;
-    const topStudents = [...students].sort((a, b) => b.currentLevel - a.currentLevel).slice(0, 5);
-    return (
-      <div className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <MetricCard title="Total Students" value={students.length} subtext="Active roster" icon={Users} />
-          <MetricCard title="Avg Level" value={`L${Math.round(students.reduce((a, s) => a + s.currentLevel, 0) / students.length)}`} subtext="Class average" icon={BarChart3} />
-          <MetricCard title="Certified" value={`${students.filter(s => s.currentLevel >= 5).length}`} subtext="Level 5+ achieved" icon={Award} />
-          <MetricCard title="Pending Diagnostic" value={students.filter(s => s.levelHistory.length === 0).length} subtext="Need placement" icon={ShieldAlert} />
-        </div>
-        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
-          <PageHeader title={isTeacher ? "Class Performance" : "School Performance"} desc="FLN level distribution and trends" />
-          <div className="space-y-3">
-            <h4 className="text-xs font-mono font-bold text-slate-500 dark:text-slate-400 uppercase">Top Performing Students</h4>
-            <div className="space-y-2">{topStudents.map(s => (
-              <div key={s.id} className="flex justify-between items-center p-3 border border-slate-100 dark:border-slate-700 rounded-lg">
-                <div className="flex items-center gap-3"><span className="text-sm font-semibold">{s.name}</span><span className="text-xs text-slate-400 dark:text-slate-500">{s.classGroup}</span></div>
-                <div className="flex items-center gap-4"><div className="w-32 h-2 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden"><div className="h-full bg-emerald-500 rounded-full" style={{ width: `${(s.currentLevel / 93) * 100}%` }} /></div><span className="font-mono font-bold text-sm">L{s.currentLevel}</span></div>
-              </div>
-            ))}</div>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  if (panel === 'performance') return <PerformancePanel students={students} currentUser={currentUser} />;
 
   if (panel === 'reports') {
     const isStateAdmin = currentUser.role === UserRole.ADMIN;

--- a/frontend/src/components/panels/DiagnosticTestPanel.tsx
+++ b/frontend/src/components/panels/DiagnosticTestPanel.tsx
@@ -1,0 +1,34 @@
+// Extracted from frontend/src/components/PanelViews.tsx (issue #144, PR 3).
+import React from 'react';
+import { Student } from '../../types';
+import { PageHeader } from './PanelShared';
+import { ShieldAlert, CheckCircle2 } from 'lucide-react';
+
+export const DiagnosticTestPanel: React.FC<{ students: Student[] }> = ({ students }) => {
+    const pending = students.filter(s => s.levelHistory.length === 0);
+    const completed = students.filter(s => s.levelHistory.length > 0);
+    return (
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
+          <PageHeader title="Pending Diagnostics" desc={`${pending.length} students need initial assessment`} icon={<ShieldAlert className="h-5 w-5 text-amber-500" />} />
+          {pending.length === 0 ? <p className="text-xs text-slate-400 dark:text-slate-500 text-center py-8">All students placed.</p> : (
+            <div className="space-y-3">{pending.map(s => (
+              <div key={s.id} className="flex justify-between items-center p-3 border border-slate-200 dark:border-slate-700 rounded-lg">
+                <div><div className="font-medium text-sm">{s.name}</div><div className="text-xs text-slate-400 dark:text-slate-500">{s.classGroup} - {s.section}</div></div>
+                <span className="text-[10px] font-mono font-bold text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950 px-2 py-1 rounded border border-amber-200 dark:border-amber-800">Run Diagnostic</span>
+              </div>
+            ))}</div>
+          )}
+        </div>
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
+          <PageHeader title="Completed Diagnostics" desc={`${completed.length} students have been placed`} icon={<CheckCircle2 className="h-5 w-5 text-green-500" />} />
+          <div className="space-y-3">{completed.map(s => (
+            <div key={s.id} className="flex justify-between items-center p-3 border border-slate-200 dark:border-slate-700 rounded-lg">
+              <div><div className="font-medium text-sm">{s.name}</div><div className="text-xs text-slate-400 dark:text-slate-500">Placed at L{s.currentLevel}.{s.currentSubLevel ?? 0}</div></div>
+              <span className="text-[10px] font-mono font-bold text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950 px-2 py-1 rounded border border-green-200 dark:border-green-800">Completed</span>
+            </div>
+          ))}</div>
+        </div>
+      </div>
+    );
+};

--- a/frontend/src/components/panels/PerformancePanel.tsx
+++ b/frontend/src/components/panels/PerformancePanel.tsx
@@ -1,0 +1,33 @@
+// Extracted from frontend/src/components/PanelViews.tsx (issue #144, PR 3).
+import React from 'react';
+import { Student, User, UserRole } from '../../types';
+import { PageHeader } from './PanelShared';
+import { MetricCard } from '../Card';
+import { Users, BarChart3, Award, ShieldAlert } from 'lucide-react';
+
+export const PerformancePanel: React.FC<{ students: Student[]; currentUser: User }> = ({ students, currentUser }) => {
+    const isTeacher = currentUser.role === UserRole.TEACHER || currentUser.role === UserRole.VOLUNTEER;
+    const topStudents = [...students].sort((a, b) => b.currentLevel - a.currentLevel).slice(0, 5);
+    return (
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <MetricCard title="Total Students" value={students.length} subtext="Active roster" icon={Users} />
+          <MetricCard title="Avg Level" value={`L${Math.round(students.reduce((a, s) => a + s.currentLevel, 0) / students.length)}`} subtext="Class average" icon={BarChart3} />
+          <MetricCard title="Certified" value={`${students.filter(s => s.currentLevel >= 5).length}`} subtext="Level 5+ achieved" icon={Award} />
+          <MetricCard title="Pending Diagnostic" value={students.filter(s => s.levelHistory.length === 0).length} subtext="Need placement" icon={ShieldAlert} />
+        </div>
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
+          <PageHeader title={isTeacher ? "Class Performance" : "School Performance"} desc="FLN level distribution and trends" />
+          <div className="space-y-3">
+            <h4 className="text-xs font-mono font-bold text-slate-500 dark:text-slate-400 uppercase">Top Performing Students</h4>
+            <div className="space-y-2">{topStudents.map(s => (
+              <div key={s.id} className="flex justify-between items-center p-3 border border-slate-100 dark:border-slate-700 rounded-lg">
+                <div className="flex items-center gap-3"><span className="text-sm font-semibold">{s.name}</span><span className="text-xs text-slate-400 dark:text-slate-500">{s.classGroup}</span></div>
+                <div className="flex items-center gap-4"><div className="w-32 h-2 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden"><div className="h-full bg-emerald-500 rounded-full" style={{ width: `${(s.currentLevel / 93) * 100}%` }} /></div><span className="font-mono font-bold text-sm">L{s.currentLevel}</span></div>
+              </div>
+            ))}</div>
+          </div>
+        </div>
+      </div>
+    );
+};

--- a/frontend/src/components/panels/StudentListPanel.tsx
+++ b/frontend/src/components/panels/StudentListPanel.tsx
@@ -1,0 +1,14 @@
+// Extracted from frontend/src/components/PanelViews.tsx (issue #144, PR 3).
+import React from 'react';
+import { Student } from '../../types';
+import { PageHeader, EmptyStudents } from './PanelShared';
+import { Users } from 'lucide-react';
+
+export const StudentListPanel: React.FC<{ students: Student[] }> = ({ students }) => {
+  return (
+      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
+        <PageHeader title="Student Roster" desc="Complete list of registered students across your classes" icon={<Users className="h-5 w-5" />} />
+        <EmptyStudents students={students} />
+      </div>
+  );
+};


### PR DESCRIPTION
Part of #144 (PanelViews.tsx split into per-panel files) — PR 3 of the batched sequence, built on top of #246/#247.

## What changed
Extracted the 3 panels that only ever need `{ students }` from `usePanelData`:
- `panels/StudentListPanel.tsx`
- `panels/DiagnosticTestPanel.tsx`
- `panels/PerformancePanel.tsx` — additionally needs `currentUser` for its `isTeacher` role check ("Class Performance" vs "School Performance" heading).

`PanelViews.tsx`'s 3 `if` blocks are now one-liner router calls, each passing only the props that panel actually uses.

## Unused-import cleanup (per review feedback)
Confirmed `ShieldAlert` became fully dead in `PanelViews.tsx` after this move (only used by `diagnostic_test`/`performance`, both extracted here) — removed it from the top-level `lucide-react` import.

Checked every other import for the same risk. Left alone:
- `ArrowRight`, `Building2`, `Globe`, `Layers`, plus types `ClassGroup`/`LogEntry`/`Ticket` — confirmed via a diff against the pre-refactor baseline (before #246) that these were **already dead before this split ever started**, unrelated to my work.
- `SlidersHorizontal`, `Settings`, `Database`, `RefreshCw` — these did become dead, but as a side effect of the **already-merged #247** (their only usages were in `adaptive_test`/`system_settings`). Flagging here rather than silently bundling an unrelated cleanup into this PR's diff — happy to do a tiny follow-up if wanted, or catch it whenever a later batch happens to touch that import line.

## Verified
- `tsc --noEmit` clean.
- `vite build` succeeds, same bundle-size class.
- Byte-diff of every moved block against the original.
- **Live click-through** as Teacher against a scratch-seeded backend: Diagnostic Test (0 pending / 60 completed, correct), Student List (roster table renders), Performance (4 metric cards + top-5 list, "Class Performance" heading confirms the role-conditional title still works).