### PR TITLE
fix: Diagnostic Status badge shows real cycle name + date

### DIFF
--- a/frontend/src/components/dashboards/TeacherDashboard.tsx
+++ b/frontend/src/components/dashboards/TeacherDashboard.tsx
@@ -596,7 +596,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
                     ) : (
                       <div className="flex items-center gap-2">
                         <span className="text-green-700 dark:text-green-400 font-mono text-[9px] font-bold uppercase bg-green-50 dark:bg-green-950/40 px-2 py-0.5 rounded border border-green-200 dark:border-green-800">
-                          Placed
+                          {s.levelHistory[s.levelHistory.length - 1].reason} Done · {new Date(s.levelHistory[s.levelHistory.length - 1].date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}
                         </span>
                         <button
                           onClick={() => handlePrintLevelWorksheet(s)}

--- a/frontend/src/components/dashboards/VolunteerDashboard.tsx
+++ b/frontend/src/components/dashboards/VolunteerDashboard.tsx
@@ -480,7 +480,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
                     ) : (
                       <div className="flex items-center gap-2">
                         <span className="text-green-700 dark:text-green-400 font-mono text-[9px] font-bold uppercase bg-green-50 dark:bg-green-950/40 px-2 py-0.5 rounded border border-green-200 dark:border-green-800">
-                          Placed
+                          {s.levelHistory[s.levelHistory.length - 1].reason} Done · {new Date(s.levelHistory[s.levelHistory.length - 1].date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}
                         </span>
                         <button
                           onClick={() => handlePrintLevelWorksheet(s)}


### PR DESCRIPTION
## Summary
Closes #171.

The "Diagnostic Status" badge previously showed a static "Placed" label once `levelHistory.length > 0`, regardless of which cycle was completed or when. It now reads the last `levelHistory` entry and shows `{reason} Done · {date}` — e.g. "BASELINE DONE · 10 APR" — using the real cycle names already standardized in Phase 3 (#179/#177).

Fixed in both `TeacherDashboard.tsx` and `VolunteerDashboard.tsx`, since the column definition is duplicated identically in both files.

## Test plan
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] Live check in Chrome: logged in as a teacher against seeded data (real `levelHistory` entries with `reason: "Baseline"`, `date: "2026-04-10"`), confirmed the roster shows "BASELINE DONE · 10 APR" for placed students, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)