### PR TITLE
feat: formalize a clean numeric Student display ID

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -109,6 +109,12 @@ export interface Student {
   currentSubLevel?: number | null;
   targetLevel: number | null;
   aadharMasked: string; // Mandatory, unique identifier masked (§13.2 R-6)
+  // Clean numeric ID for teacher-facing display (roster, profile, printed
+  // worksheets) — see backend/src/displayId.ts. Derived from the same
+  // non-sensitive state/district/block/school/class/sequence hierarchy
+  // already encoded in `id`, just reformatted to be readable/printable.
+  // Never used as a lookup key — `id` remains the only internal identifier.
+  displayId?: string;
   levelHistory: { level: number; subLevel?: number; date: string; reason: string }[];
   assignedDiagnosticQuestions?: Question[];
   // Extended profile — optional, filled in by the student's own school/teacher.

--- a/backend/src/displayId.ts
+++ b/backend/src/displayId.ts
@@ -1,0 +1,51 @@
+// Issue #184: a clean, printable numeric display ID for students, computed at
+// creation time — separate from the internal `id` primary key, which stays
+// untouched everywhere else in the codebase.
+//
+// Encodes the same non-sensitive hierarchy already present in the existing
+// composite `id` (e.g. `s_HR_AMB_AMB_01_01_C2_01`): state, district, block,
+// school, class, and the student's sequence within that class. State/district
+// are resolved to their index in STATES_UTS (the single source of truth for
+// the geo hierarchy elsewhere in this codebase); block/school/class numbers
+// are read directly off the codes already assigned to the School/ClassGroup.
+//
+// No Aadhaar or PIN-code fragments are used — that approach was explicitly
+// considered and rejected for this issue (see #184).
+import { STATES_UTS } from './geoData';
+
+function pad(n: number, width: number): string {
+  return String(Math.max(0, n)).padStart(width, '0').slice(-width);
+}
+
+export function computeStudentDisplayId(params: {
+  stateCode: string;
+  districtCode: string;
+  blockCode: string; // e.g. "AMB_01"
+  schoolId: string; // e.g. "HR_AMB_AMB_01_01"
+  classGroup: string; // e.g. "Class 2"
+  sequenceInClass: number; // 1-based
+}): string {
+  const state = STATES_UTS.find(s => s.code === params.stateCode);
+  const stateIdx = state ? STATES_UTS.indexOf(state) + 1 : 0;
+  const districtIdx = state
+    ? state.districts.findIndex(d => d.code === params.districtCode) + 1
+    : 0;
+
+  const blockMatch = params.blockCode.match(/(\d+)$/);
+  const blockNum = blockMatch ? parseInt(blockMatch[1], 10) : 0;
+
+  const schoolMatch = params.schoolId.match(/(\d+)$/);
+  const schoolNum = schoolMatch ? parseInt(schoolMatch[1], 10) : 0;
+
+  const classMatch = params.classGroup.match(/(\d+)/);
+  const classNum = classMatch ? parseInt(classMatch[1], 10) : 0;
+
+  return [
+    pad(stateIdx, 2),
+    pad(districtIdx, 1),
+    pad(blockNum, 1),
+    pad(schoolNum, 2),
+    pad(classNum, 1),
+    pad(params.sequenceInClass, 3),
+  ].join('-');
+}

--- a/backend/src/routes/students.ts
+++ b/backend/src/routes/students.ts
@@ -9,6 +9,7 @@ import { evaluateAIDiagnostic } from '../gemini';
 import { AI_SERVICES_DIR, PYTHON_BIN } from '../config';
 import { resolvePrerequisites, describeConcept } from '../competencyPrerequisites';
 import { CURRICULUM_MAPPING } from '../config/curriculumMap';
+import { computeStudentDisplayId } from '../displayId';
 
 export function registerStudentRoutes(app: express.Express) {
   // Students
@@ -188,12 +189,36 @@ export function registerStudentRoutes(app: express.Express) {
       return { error: 'A student with this Aadhar / ID number is already registered.' };
     }
 
+    // Derive the clean numeric display ID (#184) from the school's geo hierarchy
+    // and this student's sequence within their class at this school. Falls back
+    // to zeroed segments if the school record can't be found — should not
+    // happen given schoolId was already required above, but a missing display
+    // ID must never block student creation.
+    const trimmedClassGroup = String(classGroup).trim();
+    const trimmedSection = String(section).trim();
+    let displayId: string | undefined;
+    const school = (await dbStore.getSchools()).find(sc => sc.id === schoolId);
+    if (school) {
+      const classmates = (await dbStore.getStudents({ schoolId })).filter(
+        s => s.classGroup === trimmedClassGroup && s.section === trimmedSection
+      );
+      displayId = computeStudentDisplayId({
+        stateCode: school.stateCode,
+        districtCode: school.districtCode,
+        blockCode: school.blockCode,
+        schoolId: school.id,
+        classGroup: trimmedClassGroup,
+        sequenceInClass: classmates.length + 1,
+      });
+    }
+
     const newStudent: Student = {
       id: 'STD_' + Math.floor(10000 + Math.random() * 90000),
+      displayId,
       name: String(name).trim(),
       age,
-      classGroup: String(classGroup).trim(),
-      section: String(section).trim(),
+      classGroup: trimmedClassGroup,
+      section: trimmedSection,
       schoolId,
       currentLevel: null,
       currentSubLevel: null,

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -3,6 +3,7 @@ import { MongoClient } from 'mongodb';
 import bcrypt from 'bcrypt';
 import { UserRole } from './db';
 import { STATES_UTS } from './geoData';
+import { computeStudentDisplayId } from './displayId';
 import questionBankSeed from './data/question_bank_seed.json';
 
 const SEED_PASSWORD_HASH = bcrypt.hashSync('Fln@2026', 10);
@@ -438,6 +439,14 @@ async function main() {
 
               allStudents.push({
                 id: studentId,
+                displayId: computeStudentDisplayId({
+                  stateCode: state.code,
+                  districtCode: district.code,
+                  blockCode: blockCode,
+                  schoolId: schoolId,
+                  classGroup: className,
+                  sequenceInClass: studentNum,
+                }),
                 name: nextName(),
                 age: randomAge(cIdx),
                 classGroup: className,

--- a/frontend/src/components/WorksheetWorkflow.tsx
+++ b/frontend/src/components/WorksheetWorkflow.tsx
@@ -291,7 +291,7 @@ export const WorksheetWorkflow: React.FC<WorksheetWorkflowProps> = ({ classGroup
                       <div className="flex justify-between items-center border-b border-zinc-200 dark:border-zinc-700 pb-3">
                         <div>
                           <h5 className="font-display font-bold text-zinc-900 dark:text-white uppercase text-sm tracking-tight">{student.name}</h5>
-                          <p className="text-[10px] font-mono text-zinc-400 dark:text-zinc-500">Student ID: {student.id} · Target Level: Level {student.targetLevel !== null && student.targetLevel !== undefined ? student.targetLevel : 'Not Assessed'}</p>
+                          <p className="text-[10px] font-mono text-zinc-400 dark:text-zinc-500">Student ID: {student.displayId || student.id} · Target Level: Level {student.targetLevel !== null && student.targetLevel !== undefined ? student.targetLevel : 'Not Assessed'}</p>
                         </div>
                         <div className="text-right">
                           <span className="text-xs font-mono font-bold uppercase bg-zinc-100 dark:bg-zinc-800 px-2.5 py-1 rounded border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300">

--- a/frontend/src/components/dashboards/TeacherDashboard.tsx
+++ b/frontend/src/components/dashboards/TeacherDashboard.tsx
@@ -566,7 +566,7 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
             <div className="p-4">
               {(() => {
                 const studentColumns: Column<Student>[] = [
-                  { header: 'ID', accessor: 'id', sortKey: 'id', className: 'font-mono text-xs text-slate-400 dark:text-slate-500' },
+                  { header: 'ID', accessor: (s) => s.displayId || s.id, sortKey: 'id', className: 'font-mono text-xs text-slate-400 dark:text-slate-500' },
                   { header: 'Student Name', accessor: 'name', sortKey: 'name', className: 'font-medium text-slate-900 dark:text-slate-100' },
                   {
                     header: 'Current Level',

--- a/frontend/src/components/dashboards/VolunteerDashboard.tsx
+++ b/frontend/src/components/dashboards/VolunteerDashboard.tsx
@@ -450,7 +450,7 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
             <div className="p-4">
               {(() => {
                 const studentColumns: Column<Student>[] = [
-                  { header: 'ID', accessor: 'id', sortKey: 'id', className: 'font-mono text-xs text-slate-400 dark:text-slate-500' },
+                  { header: 'ID', accessor: (s) => s.displayId || s.id, sortKey: 'id', className: 'font-mono text-xs text-slate-400 dark:text-slate-500' },
                   { header: 'Student Name', accessor: 'name', sortKey: 'name', className: 'font-medium text-slate-900 dark:text-slate-100' },
                   {
                     header: 'Current Level',

--- a/frontend/src/components/panels/PanelShared.tsx
+++ b/frontend/src/components/panels/PanelShared.tsx
@@ -22,7 +22,7 @@ export function PageHeader({ title, desc, icon }: { title: string; desc: string;
 
 export function EmptyStudents({ students }: { students: Student[] }) {
   const cols: Column<Student>[] = [
-    { header: 'ID', accessor: 'id', className: 'font-mono text-xs text-slate-400 dark:text-slate-500' },
+    { header: 'ID', accessor: (s) => s.displayId || s.id, className: 'font-mono text-xs text-slate-400 dark:text-slate-500' },
     { header: 'Name', accessor: 'name', sortKey: 'name', className: 'font-semibold text-slate-800 dark:text-slate-100' },
     { header: 'Class', accessor: 'classGroup', className: '' },
     { header: 'Level', accessor: (s) => <LevelBadge level={s.currentLevel} subLevel={s.currentSubLevel} />, className: 'font-mono' },

--- a/frontend/src/components/panels/StudentProfilePanel.tsx
+++ b/frontend/src/components/panels/StudentProfilePanel.tsx
@@ -124,7 +124,7 @@ export const StudentProfilePanel: React.FC<{
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-3 flex-wrap">
                 <h2 className="text-xl font-bold text-slate-900 dark:text-white truncate">{s.name}</h2>
-                <span className="text-xs font-mono font-bold px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-700">ID: {s.id}</span>
+                <span className="text-xs font-mono font-bold px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-700">ID: {s.displayId || s.id}</span>
                 <span className={`text-[10px] font-mono font-bold px-2 py-0.5 rounded ${s.levelHistory.length > 0 ? 'text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800' : 'text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800'}`}>{s.levelHistory.length > 0 ? 'Active' : 'Pending Diagnostic'}</span>
               </div>
               <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5 truncate"><strong>{studentSchool?.name || 'N/A'}</strong> · {s.classGroup} - {s.section}{daysSinceEnroll !== null && ` · Enrolled ${daysSinceEnroll} days ago`}</p>

--- a/frontend/src/components/panels/pdfReportGenerator.ts
+++ b/frontend/src/components/panels/pdfReportGenerator.ts
@@ -58,7 +58,7 @@ export const handleDownloadPDF = (student: Student, r: EvaluationReport) => {
 
         <div class="student-info">
           <div class="info-item">Student Name: <strong>${student.name}</strong></div>
-          <div class="info-item">Student ID: <strong>${student.id}</strong></div>
+          <div class="info-item">Student ID: <strong>${student.displayId || student.id}</strong></div>
           <div class="info-item">Class / Section: <strong>${student.classGroup} - ${student.section}</strong></div>
           <div class="info-item">Report Date: <strong>${new Date(r.timestamp).toLocaleDateString('en-IN', { day: 'numeric', month: 'long', year: 'numeric' })}</strong></div>
         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -53,6 +53,11 @@ export interface Student {
   currentSubLevel?: number | null;
   targetLevel: number | null;
   aadharMasked: string;
+  // Clean numeric ID for teacher-facing display — use this instead of `id`
+  // anywhere a teacher/principal/admin sees a student ID (roster, profile,
+  // printed worksheets). Falls back to `id` only for older records that
+  // predate this field.
+  displayId?: string;
   levelHistory: { level: number; subLevel?: number; date: string; reason: string }[];
   streak: number;
   gender?: 'Male' | 'Female' | 'Other';


### PR DESCRIPTION
## Summary
Closes #184.

Adds a new `displayId` field, computed once at student-creation time, formatted as `SS-D-B-SS-C-SSS` (state-district-block-school-class-sequence) — e.g. `01-1-1-01-2-021` instead of `s_AP_GNT_GNT_01_01_C2_21`.

- **`backend/src/displayId.ts`**: new shared encoding helper. State/district resolved via their index in `STATES_UTS` (the codebase's existing source of truth for the geo hierarchy); block/school/class numbers read directly off the codes already assigned to the School/ClassGroup; sequence = 1 + count of existing students in that school+class+section.
- Wired into `createStudentFromData` (shared by both the single-add and CSV bulk-import routes) and `seed.ts`.
- **The internal `id` primary key is untouched everywhere** — no migration, no breaking change to any existing route or lookup, per the issue's explicit instruction.
- **Frontend**, `displayId` (with fallback to `id` for pre-existing records) now shows in: the roster ID column in both `TeacherDashboard.tsx` and `VolunteerDashboard.tsx`, the separate `StudentListPanel`'s shared roster table (`PanelShared.tsx`), the Student Profile header, the printed-worksheet preview (`WorksheetWorkflow.tsx`), and the downloadable PDF report card.
- **Deliberately NOT changed**: the `studentId` stamped onto the physical ICR answer-sheet PDF in `backend/src/paperGenerator.ts`. That value correlates scanned sheets back to students during grading — a functional identifier, not just a display concern — so changing it risks breaking the ICR pipeline and is out of scope here.

## Test plan
- [x] `tsc --noEmit` clean on both `frontend` and `backend`
- [x] `vite build` succeeds
- [x] Live in Chrome: seeded students show clean sequential display IDs (`01-1-1-01-2-001` … `020`) in both roster views; registered a new student in Class 2 and confirmed it correctly computed `01-1-1-01-2-021` (next in sequence after the 20 already seeded) and rendered immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)