### PR TITLE
fix: add missing pymupdf dependency for PDF rasterization

### DIFF
--- a/ai-services/requirements.txt
+++ b/ai-services/requirements.txt
@@ -3,3 +3,4 @@ easyocr>=1.7.0
 pillow>=10.0.0
 pypdf>=3.17.0
 numpy>=1.24.0
+pymupdf>=1.24.0

--- a/ai-services/scripts/pdf_rasterize.py
+++ b/ai-services/scripts/pdf_rasterize.py
@@ -34,7 +34,11 @@ def main():
     output = Path(args.output)
 
     try:
-        import fitz  # PyMuPDF
+        # Import under the `pymupdf` name rather than the legacy `fitz` alias —
+        # importing as `fitz` prints a deprecation warning to stdout, and this
+        # script's stdout is strictly JSON-parsed by the Node caller, so any
+        # extra stdout line breaks that parse.
+        import pymupdf as fitz
     except ImportError as e:
         print(json.dumps({
             "success": False,


### PR DESCRIPTION
## Summary
`pdf_rasterize.py` (used by the cloud-OCR PDF scan path) imports PyMuPDF, but `ai-services/requirements.txt` never listed it — so a fresh environment has zero PyMuPDF installed and every PDF scan fails immediately with an execFileSync error.

Also switches `import fitz` → `import pymupdf as fitz`. The legacy `fitz` alias prints a deprecation warning to stdout on every run; this script's entire stdout is strictly `JSON.parse()`'d by the Node caller (`backend/src/routes/evaluation.ts` line ~799), so that warning line breaks the parse on the very next real PDF scan even once the dependency is installed.

Both of these have been running as a manual, uncommitted hotfix directly on the production server since 2026-08-19 — this closes that gap by making the fix a real part of the repo, so it no longer needs to be hand-reapplied on every future deploy.

## Test plan
- [x] `python3 -m py_compile ai-services/scripts/pdf_rasterize.py` — clean
- [x] This exact fix has already been running in production since 2026-08-19 (server-local patch) — verified there with a real PDF scan through `/api/icr/evaluate-cloud` returning 200 with successful rasterization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)