### PR TITLE
feat: build Test History logging

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -248,6 +248,21 @@ export interface Worksheet {
   };
 }
 
+// Issue #182: one entry per bulk-generation request (diagnostic/practice/
+// remedial/midline/endline), written only from the existing bulk routes at
+// the point they already run — not a new trigger point of its own.
+export interface TestHistoryEntry {
+  id: string;
+  teacherId: string;
+  teacherEmail: string;
+  requestType: 'diagnostic' | 'practice' | 'remedial' | 'midline' | 'endline';
+  timestamp: string;
+  studentCount: number;
+  classId?: string;
+  className?: string;
+  schoolId?: string;
+}
+
 export interface AnswerSubmission {
   id: string;
   worksheetId: string;
@@ -465,6 +480,7 @@ interface DatabaseSchema {
   interventions: Intervention[];
   bestPractices: BestPractice[];
   diagnosticAnswerKeys: DiagnosticAnswerKey[];
+  testHistory: TestHistoryEntry[];
 }
 
 const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
@@ -485,6 +501,7 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   interventions: 'interventions',
   bestPractices: 'best_practices',
   diagnosticAnswerKeys: 'diagnostic_answer_keys',
+  testHistory: 'testHistory',
 };
 
 export class DBStore {
@@ -870,6 +887,15 @@ export class DBStore {
   async getWorksheets() {
     if (this.mongoDb) return await this.mongoDb.collection<Worksheet>('worksheets').find({}).toArray();
     return this.data?.worksheets || [];
+  }
+  async getTestHistory(teacherId?: string) {
+    if (this.mongoDb) {
+      const filter = teacherId ? { teacherId } : {};
+      return await this.mongoDb.collection<TestHistoryEntry>('testHistory').find(filter).sort({ timestamp: -1 }).toArray();
+    }
+    const all = this.data?.testHistory || [];
+    const filtered = teacherId ? all.filter(t => t.teacherId === teacherId) : all;
+    return [...filtered].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
   }
   async getLevelWorksheets() {
     if (this.mongoDb) return await this.mongoDb.collection<LevelWorksheet>('levelWorksheets').find({}).toArray();
@@ -1259,6 +1285,14 @@ export class DBStore {
     await this.mongoDb!.collection('worksheets').insertOne(ws);
     if (this.data) this.data.worksheets.push(ws);
     return ws;
+  }
+
+  async addTestHistoryEntry(entry: TestHistoryEntry) {
+    if (this.mongoDb) {
+      await this.mongoDb.collection('testHistory').insertOne(entry);
+    }
+    if (this.data) this.data.testHistory.push(entry);
+    return entry;
   }
 
   async updateWorksheet(worksheetId: string, updates: Partial<Worksheet>) {
@@ -3283,7 +3317,8 @@ export class DBStore {
       announcements,
       interventions,
       bestPractices,
-      diagnosticAnswerKeys: []
+      diagnosticAnswerKeys: [],
+      testHistory: []
     };
   }
 }

--- a/backend/src/routes/diagnosticBulk.ts
+++ b/backend/src/routes/diagnosticBulk.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import fs from 'fs';
 import { randomUUID } from 'crypto';
-import { dbStore, UserRole, Question, Worksheet } from '../db';
+import { dbStore, UserRole, Question, Worksheet, TestHistoryEntry } from '../db';
 import { getAuthUser } from '../auth';
 import { generateDiagnosticPaper } from '../paperGenerator';
 import { generateQuestionsForLevel } from '../levelGenerator';
@@ -195,6 +195,22 @@ export function registerDiagnosticBulkRoutes(app: express.Express) {
           delayLogs: { delayedAttemptsCount: 0, submittingTeachers: [] },
         };
         await dbStore.addWorksheet(worksheet);
+
+        // Issue #182: log this bulk request to Test History. Only the
+        // diagnostic bulk route exists today — practice/remedial equivalents
+        // (issue #183) will call the same dbStore method once they exist.
+        const testHistoryEntry: TestHistoryEntry = {
+          id: 'th_' + randomUUID(),
+          teacherId: user.id,
+          teacherEmail: user.email,
+          requestType: 'diagnostic',
+          timestamp: nowIso,
+          studentCount: realStudentIds.length,
+          classId: matchedClass?.id,
+          className: `Class ${classNumber}`,
+          schoolId: user.schoolId || matchedClass?.schoolId,
+        };
+        await dbStore.addTestHistoryEntry(testHistoryEntry);
 
         await dbStore.addLog({
           id: 'log_' + Date.now(),

--- a/backend/src/routes/teachers.ts
+++ b/backend/src/routes/teachers.ts
@@ -106,4 +106,26 @@ export function registerTeacherRoutes(app: express.Express) {
       data: { teacherId, firstName, lastName, email: newTeacher.email },
     });
   });
+
+  // Issue #182: a teacher's own bulk-request history — what type of test/
+  // worksheet she's requested, when, and for how many students. A teacher
+  // can always see her own history; admin-tier roles can look up any
+  // teacher's for oversight.
+  app.get('/api/teachers/:id/test-history', async (req, res) => {
+    const user = getAuthUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const targetId = req.params.id;
+    const isSelf = user.id === targetId;
+    const isOversight = [
+      UserRole.SUPERADMIN, UserRole.ADMIN, UserRole.DISTRICT_ADMIN,
+      UserRole.BLOCK_ADMIN, UserRole.SCHOOL,
+    ].includes(user.role);
+    if (!isSelf && !isOversight) {
+      return res.status(403).json({ error: 'Forbidden.' });
+    }
+
+    const history = await dbStore.getTestHistory(targetId);
+    res.json(history);
+  });
 }

--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -69,7 +69,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
 
   if (panel === 'adaptive_test') return <AdaptiveTestPanel />;
 
-  if (panel === 'test_history') return <TestHistoryPanel />;
+  if (panel === 'test_history') return <TestHistoryPanel currentUser={currentUser} token={token} />;
 
   if (panel === 'worksheets') return <WorksheetsPanel reportsList={reportsList} worksheetsList={worksheetsList} />;
 

--- a/frontend/src/components/panels/TestHistoryPanel.tsx
+++ b/frontend/src/components/panels/TestHistoryPanel.tsx
@@ -1,26 +1,106 @@
-// Extracted from frontend/src/components/PanelViews.tsx (issue #144, PR 2).
-import React from 'react';
+// Issue #182: real bulk-request history (was a hardcoded mock array — same
+// bug class as FLN-C/#170). Fetches from GET /api/teachers/:id/test-history.
+import React, { useState, useEffect } from 'react';
+import { apiFetch } from '../../services/apiClient';
 import { PageHeader } from './PanelShared';
 import { FileText } from 'lucide-react';
+import { User } from '../../types';
 
-const DIAGNOSTIC_HISTORY = [
-  { id: 'dh1', student: 'Amanpreet Singh', date: '2026-03-15', score: 8, total: 10, placedLevel: 12, evaluator: 'Ritu Sharma' },
-  { id: 'dh2', student: 'Rohit Kumar', date: '2026-01-10', score: 9, total: 10, placedLevel: 36, evaluator: 'Ritu Sharma' },
-  { id: 'dh3', student: 'Arjun Verma', date: '2026-04-01', score: 6, total: 10, placedLevel: 6, evaluator: 'Amit Kumar' },
-  { id: 'dh4', student: 'Neha Gupta', date: '2026-03-01', score: 7, total: 10, placedLevel: 38, evaluator: 'Ritu Sharma' },
-  { id: 'dh5', student: 'Jasmine Kaur', date: '2026-02-20', score: 5, total: 10, placedLevel: 8, evaluator: 'Amit Kumar' },
-];
+interface TestHistoryEntry {
+  id: string;
+  teacherId: string;
+  teacherEmail: string;
+  requestType: 'diagnostic' | 'practice' | 'remedial' | 'midline' | 'endline';
+  timestamp: string;
+  studentCount: number;
+  classId?: string;
+  className?: string;
+  schoolId?: string;
+}
 
-export const TestHistoryPanel: React.FC = () => {
+const REQUEST_TYPE_LABELS: Record<TestHistoryEntry['requestType'], string> = {
+  diagnostic: 'Diagnostic',
+  practice: 'Practice',
+  remedial: 'Remedial',
+  midline: 'Midline',
+  endline: 'Endline',
+};
+
+interface TestHistoryPanelProps {
+  currentUser: User;
+  token: string;
+}
+
+export const TestHistoryPanel: React.FC<TestHistoryPanelProps> = ({ currentUser, token }) => {
+  const [history, setHistory] = useState<TestHistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [typeFilter, setTypeFilter] = useState<'all' | TestHistoryEntry['requestType']>('all');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const res = await apiFetch(`/api/teachers/${currentUser.id}/test-history`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error('Failed to load test history.');
+        const data = await res.json();
+        if (!cancelled) setHistory(data);
+      } catch (err: any) {
+        if (!cancelled) setError(err.message || 'Failed to load test history.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [currentUser.id, token]);
+
+  const filtered = typeFilter === 'all' ? history : history.filter(h => h.requestType === typeFilter);
+
   return (
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
-        <PageHeader title="Test History" desc="Complete record of all diagnostic and worksheet evaluations" icon={<FileText className="h-5 w-5" />} />
-        <div className="space-y-3">{DIAGNOSTIC_HISTORY.map(h => (
-          <div key={h.id} className="flex justify-between items-center p-4 border border-slate-200 dark:border-slate-700 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800">
-            <div><div className="font-semibold text-sm">{h.student}</div><div className="text-xs text-slate-400 dark:text-slate-500">{h.date} · Evaluated by {h.evaluator}</div></div>
-            <div className="text-right"><div className="font-mono font-bold">{h.score}/{h.total}</div><div className="text-xs text-slate-400 dark:text-slate-500">Placed L{h.placedLevel}</div></div>
-          </div>
-        ))}</div>
+    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
+      <PageHeader title="Test History" desc="Your bulk test and worksheet requests" icon={<FileText className="h-5 w-5" />} />
+
+      <div className="flex flex-wrap gap-2">
+        {(['all', 'diagnostic', 'practice', 'remedial', 'midline', 'endline'] as const).map(t => (
+          <button
+            key={t}
+            onClick={() => setTypeFilter(t)}
+            className={`text-[10px] font-mono font-semibold px-2.5 py-1.5 rounded border transition-colors ${
+              typeFilter === t
+                ? 'bg-slate-900 dark:bg-white text-white dark:text-slate-900 border-transparent'
+                : 'bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800'
+            }`}
+          >
+            {t === 'all' ? 'All' : REQUEST_TYPE_LABELS[t]}
+          </button>
+        ))}
       </div>
+
+      {loading && <p className="text-xs text-slate-400 dark:text-slate-500">Loading…</p>}
+      {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+
+      {!loading && !error && filtered.length === 0 && (
+        <p className="text-xs text-slate-400 dark:text-slate-500">No requests yet{typeFilter !== 'all' ? ` of type "${REQUEST_TYPE_LABELS[typeFilter]}"` : ''}.</p>
+      )}
+
+      <div className="space-y-3">
+        {filtered.map(h => (
+          <div key={h.id} className="flex justify-between items-center p-4 border border-slate-200 dark:border-slate-700 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800">
+            <div>
+              <div className="font-semibold text-sm">{REQUEST_TYPE_LABELS[h.requestType]}{h.className ? ` — ${h.className}` : ''}</div>
+              <div className="text-xs text-slate-400 dark:text-slate-500">{new Date(h.timestamp).toLocaleString()}</div>
+            </div>
+            <div className="text-right">
+              <div className="font-mono font-bold">{h.studentCount}</div>
+              <div className="text-xs text-slate-400 dark:text-slate-500">student{h.studentCount === 1 ? '' : 's'}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary
Closes #182.

- New `testHistory` collection + `TestHistoryEntry` type: `teacherId`, `requestType` (diagnostic/practice/remedial/midline/endline), `timestamp`, `studentCount`, `classId`/`className`/`schoolId`.
- Logged from the existing `/api/diagnostic/bulk` route only, at the point that request already runs — no new trigger points added. Once the Practice/Remedial gap-analysis endpoints (#183) exist, they can call the same `dbStore.addTestHistoryEntry()`.
- New `GET /api/teachers/:id/test-history` — a teacher can see her own history; admin-tier roles (superadmin/admin/district/block/school) can look up any teacher's for oversight.
- Frontend: `TestHistoryPanel` was a hardcoded mock array (same bug class as FLN-C/#170) already wired into the sidebar under "Test History" — replaced its contents with a real fetch + request-type filter buttons, no new nav item needed.

## Test plan
- [x] `tsc --noEmit` clean on both `frontend` and `backend` (confirmed the backend-only "Cannot find module 'vite'" error is pre-existing on unmodified `main` too — a workspace-hoisting artifact from installing inside `backend/` alone rather than the repo root, not something this PR introduces)
- [x] `vite build` clean
- [x] Live in Chrome: Test History starts empty with the correct empty-state message; triggered a real bulk diagnostic generation as a teacher (Class 2, 20 students) via the actual dashboard flow; confirmed the entry appeared with the correct type ("Diagnostic — Class 2"), timestamp, and student count (20); confirmed the type filter buttons correctly hide/show entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)