### PR TITLE
Add citations to the research files; correct one debunked claim

### DIFF
--- a/Research/ALEKS_case_studies.md
+++ b/Research/ALEKS_case_studies.md
@@ -2,6 +2,16 @@
 
 > **Purpose:** Extract actionable lessons from ALEKS (Assessment and Learning in Knowledge Spaces) for application to the FLN platform.
 
+> **⚠ Provenance — added 2026-08-21. See `fln_source_verification_2026-08-21.md` §1.**
+>
+> **This file contains no citations of any kind** and reads as a summary of McGraw Hill's product description. Its account of the product is consistent with the public record, but **it is vendor material, not evidence.**
+>
+> **ALEKS is a commercial implementation of Knowledge Space Theory, not its source.** For the theory itself, cite the primary literature directly:
+> - Doignon, J.-P. & Falmagne, J.-Cl. (1985). "Spaces for the assessment of knowledge." *International Journal of Man-Machine Studies*, 23(2), 175–196.
+> - Falmagne, J.-C. & Doignon, J.-P. (2011). *Learning Spaces*. Springer. (Names ALEKS as its example application.)
+>
+> ALEKS itself may be cited only as an existence proof that the approach works at scale in a shipped product. Verified provenance: built at UC Irvine under Jean-Claude Falmagne with major NSF funding; licensed out 1997; acquired by McGraw Hill 2013. Falmagne's KST work spans NYU and UC Irvine, with Doignon at Université Libre de Bruxelles.
+
 ---
 
 ## Table of Contents
@@ -95,6 +105,10 @@ Output final knowledge profile → recommend next topics
 
 ## 5. Why 20–25 Questions Suffice
 
+> **⚠ Do not use this section to justify paper length (2026-08-21).** The 20–25 figure is a vendor performance claim with no study behind it, and it depends on **within-session adaptivity** — choosing each question after seeing the answer to the previous one. A printed paper is fixed before the child starts, so the number does not transfer. See §10 of this file, which already records this difference.
+>
+> Paper length must instead be **derived from the prerequisite graph** by apex selection: test only the levels that nothing else in the grade's set depends on, since passing those infers the rest.
+
 | Reason | Explanation |
 |---|---|
 | **Skill dependencies** | Mastering advanced skills implies mastery of prerequisites (e.g., correct subtraction confirms number recognition, counting, comparison, addition) |
@@ -145,6 +159,10 @@ Practice → Retrieval → Adaptive Scheduling → Interleaving → Spaced Revie
 ---
 
 ## 8. Knowledge Tracing (KT) Models
+
+> **Verified 2026-08-21** — unlike the rest of this file, the models below are real published literature and can be cited directly:
+> - **BKT** — Corbett, A. T. & Anderson, J. R. (1995), *User Modeling and User-Adapted Interaction*, 4, 253–278.
+> - **GKT** — Nakagawa, H., Iwasawa, Y. & Matsuo, Y. (2019), IEEE/WIC/ACM Web Intelligence. **This is the closest published architecture to this platform's**, and its stated weakness — "requires an accurate prerequisite graph" — is precisely why the level-network edge work matters.
 
 > KT models track mastery as an **evolving probability over time** — different from KST which maps feasible states.
 

--- a/Research/Assessment_paper_rubric.md
+++ b/Research/Assessment_paper_rubric.md
@@ -1,6 +1,11 @@
 # Assessment Rubric
 
-**Resources:** link_1, link_2
+**Sources.** *(Filled in 2026-08-21 — this line previously read `link_1, link_2`, placeholder text that was never replaced. See `fln_source_verification_2026-08-21.md` §2.)*
+
+- Learning outcomes are derived from **NIPUN Bharat's Lakshya Soochi** (Ministry of Education, Government of India), verified against the primary source.
+- **The weightages and Bloom's-level assignments below have no source.** They are unsourced judgement calls presented here as a blueprint, and must not be cited as an established standard.
+
+> **⚠ Read the grade labels carefully.** "Class *N*: Baseline Test" contains **Class *N*−1** content — a baseline test deliberately covers the previous year's syllabus. Where an age is given it describes the *content's* age, not the test-taker's. Read literally, these headings shift a grade.
 
 ---
 

--- a/Research/Child_psychology.md
+++ b/Research/Child_psychology.md
@@ -8,7 +8,7 @@ This file consolidates the child-development theory (from NISHTHA FLN) with the 
 - [2. Cognitive Development](#2-cognitive-development)
 - [3. Socio-Emotional & Self-Regulation](#3-socio-emotional--self-regulation)
 - [4. Motivation & Learning Approaches](#4-motivation--learning-approaches)
-- [5. Learning Styles](#5-learning-styles)
+- [5. Representation (formerly "Learning Styles")](#5-representation-formerly-learning-styles)
 - [6. Play & Social Learning](#6-play--social-learning)
 - [7. Language & Identity](#7-language--identity)
 - [8. Applied Cognitive-Load Framework for Question Design](#8-applied-cognitive-load-framework-for-question-design)
@@ -26,7 +26,7 @@ This file consolidates the child-development theory (from NISHTHA FLN) with the 
 
 ## 1. Brain Development & Neuroscience
 
-- Over 85% of a child's cumulative brain development occurs before age 6 — the most critical stimulation window.
+- Over 85% of a child's cumulative brain development occurs before age 6 — the most critical stimulation window. *(Verified 2026-08-21: **contested**. Traceable to NEP 2020, but the figure derives from brain-**size** measurement and has a substantial critique literature. Usable as motivation; not as a basis for design decisions.)*
 - The brain is most flexible/adaptable to learning in early childhood.
 - Positive early experiences support lifelong learning; unfilled early learning gaps continue to widen over time.
 
@@ -53,10 +53,17 @@ This file consolidates the child-development theory (from NISHTHA FLN) with the 
 - Confidence matters for fearlessness in learning. Example response pattern to an error: if a child counts "1, 2, 3, 5…", the teacher should say "Very good! You counted carefully till 3. Let's find the next number together" — never treat the miscount as failure.
 - Competency-based education matches instruction to developmental readiness, not age/time — advance only on mastery.
 
-## 5. Learning Styles
+## 5. Representation (formerly "Learning Styles")
 
-- Modality preferences: visual, auditory, kinaesthetic, tactual — **majority of children prefer visual learning**.
-  - Example: "🍎🍎🍎 + 🍎🍎" is easier for a child to process than only "3 + 2".
+> **⚠ Corrected 2026-08-21 — see `fln_source_verification_2026-08-21.md` §2.**
+> This section previously claimed that children have modality preferences (visual / auditory / kinaesthetic / tactual) and that "the majority of children prefer visual learning." **That is the learning-styles myth and it is contradicted by the literature.** Pashler, McDaniel, Rohrer & Bjork (2008), "Learning Styles: Concepts and Evidence," *Psychological Science in the Public Interest*, reviewed 70+ studies and found no credible evidence that matching instruction to a preferred modality improves learning.
+>
+> **Do not build modality classification into the platform.** A system that generates personalised worksheets is exactly the system that would be tempted to label a child a "visual learner" and serve them a different paper. There is no evidential basis for doing so.
+>
+> The *practice* below survives; only the justification changes.
+
+- **Concrete and pictorial representation reduces load for young children** — "🍎🍎🍎 + 🍎🍎" is easier for a child to process than "3 + 2".
+  - The reason is **not** modality preference. It is that concrete representation removes symbolic abstraction and reading load for a child who cannot yet reliably decode numerals — the concrete → representational → abstract principle (DP2 in `fln_framework_from_scratch.md`). This applies to *all* young children, not to a visual subset.
 - Physical/kinaesthetic activities (jumping while counting, arranging blocks, sorting objects) improve mathematical concept formation.
 - Rhymes/songs help children remember number sequences, tables, and counting order.
 
@@ -98,7 +105,11 @@ Cognitive load = the mental effort required to solve a question. A child may fai
 - Hard: abstract comparison — 4 vs 5
 - Very hard: abstract comparison with close values — 8 vs 9
 
-**Balanced assessment sheet composition** (recommended distribution to avoid triggering fear/random guessing):
+**Balanced assessment sheet composition** (recommended distribution to avoid triggering fear/random guessing).
+
+> **⚠ Platform convention, not a research standard (verified 2026-08-21).** No published standard prescribes this ratio; it has no primary source here or elsewhere. It is retained as a reasonable default and must not be presented as evidence-based.
+>
+> **Design note:** a fixed easy/moderate/hard spread is likely the wrong instrument for a *diagnostic*, whose job is to locate a child's threshold precisely and therefore to concentrate items near it. The ratio suits *practice worksheets*, where confidence matters.
 
 | Level | % of Questions |
 |---|---|
@@ -107,7 +118,8 @@ Cognitive load = the mental effort required to solve a question. A child may fai
 | Hard | 15% |
 
 ### 8.3 Counting (11–30) Difficulty Notes
-- Teen numbers (11–20) are irregular in Hindi/English naming and are harder to generalize than 20s/30s.
+- Teen numbers (11–20) are irregular in Hindi/English naming and are harder to generalize than 20s/30s. **Verified** — Miller, Smith, Zhu & Zhang; Miller & Stigler, "Counting in Chinese" (1987): 4–5 year-old Chinese children count to ~40 where English-speaking children barely reach 15, with no difference below 10; the irregular naming is the cause.
+- **Language-dependence, not yet reflected in the framework (2026-08-21):** NIPUN Bharat mandates mother-tongue instruction, and Hindi number names are considerably *more* irregular than English — most numbers to 100 are near-distinct words rather than compositional. The counting difficulty curve therefore differs by language of instruction.
 - 11–30 needs longer sequence retention and stronger working memory.
 - >10 objects + 3-finger tasks build quantity relations and number composition.
 - Common confusions: 11 & 12, 13 & 30, 15 & 50.
@@ -129,7 +141,7 @@ Cognitive load = the mental effort required to solve a question. A child may fai
 - **Tough** (working memory + mental arithmetic + logical reasoning + transfer): 10,8,6,__ (backward) · "A frog jumps 7 spaces each time. It starts at 14. Where will it be after 8 jumps?" (multi-step transfer problem)
 
 ### 8.7 Yes/No Questions — Use with Caution
-Per Piagetian child-development theory, Yes/No questions are **easy** because they:
+Yes/No questions are **easy** because they: *(Corrected 2026-08-21: this was previously attributed to "Piagetian child-development theory." The attribution is wrong — recognition-versus-recall and the 50% guess rate are psychometrics, not Piaget. The reasoning itself is sound.)*
 - Only require recognition, not generation of an answer
 - Need less working memory/cognitive effort
 - Reduce language load
@@ -145,7 +157,7 @@ Per Piagetian child-development theory, Yes/No questions are **easy** because th
 - Hard: borrowing across zero, e.g. 50 − 27
 - Very hard: missing-number format (e.g. __ − 18 = 24) and word problems
 
-**Common error patterns (useful for automated error-tagging):**
+**Common error patterns (useful for automated error-tagging).** **Verified** — these are the classic documented "buggy algorithms": Brown, J. S. & Burton, R. B. (1978), "Diagnostic Models for Procedural Bugs in Basic Mathematical Skills," *Cognitive Science*, 2, 155–192. Cite that paper rather than this file.
 
 | Error Type | Example | Explanation |
 |---|---|---|
@@ -171,7 +183,7 @@ Per Piagetian child-development theory, Yes/No questions are **easy** because th
 
 ## 9. Why Comparison is the Foundation of Numeracy
 
-Jean Piaget (*The Child's Conception of Number*, 1941) showed children's relationship with numbers starts with **comparison** — before a child can count, order, or conserve quantity, they can already tell which pile has more/less, or when two things look the same. Every higher numerical skill (sequencing, counting, conservation of quantity) builds on this basic comparison ability. This is why **comparison-based tasks should be the starting point** for any foundational numeracy intervention or assessment.
+Jean Piaget (*La genèse du nombre chez l'enfant*, 1941; English translation *The Child's Conception of Number*, 1952 — one work, not two) showed children's relationship with numbers starts with **comparison** — before a child can count, order, or conserve quantity, they can already tell which pile has more/less, or when two things look the same. Every higher numerical skill (sequencing, counting, conservation of quantity) builds on this basic comparison ability. This is why **comparison-based tasks should be the starting point** for any foundational numeracy intervention or assessment.
 
 ## 10. Relevance to Our Project
 

--- a/Research/FLN_Assessment_Framework.md
+++ b/Research/FLN_Assessment_Framework.md
@@ -64,7 +64,10 @@
 | Meets (M) | Sufficient knowledge; successfully completes basic grade-level tasks |
 | Exceeds (E) | Superior knowledge; completes complex grade-level tasks |
 
-**FLS 2022 National Numeracy Results:** Meets global MPL: 42% | Partially meets: 37% | Below/exceeds: 21%.
+**FLS 2022 National Numeracy Results:** Meets global MPL: 42% | Partially meets: 37% | Below/exceeds: 21%. *(**Verified 2026-08-21** — reconciles exactly with the official finding that 48% of Grade 3 learners fell below global proficiency in numeracy.)*
+
+> **⚠ The state-level sentences below are unverified and should not be repeated (2026-08-21).** They could not be confirmed against the FLS report and read as internally inconsistent. In **PARAKH 2024**, Lakshadweep, Jharkhand and Tripura rank at the *bottom* in Grade 3 mathematics — a different study, so not a direct contradiction, but a reason to check before citing.
+
 Only **Lakshadweep** met global minimum proficiency at state level. Top performers: Jharkhand (55% Meets), Daman & Diu/DNH (52%), Tripura (50%). Bihar had the highest share exceeding proficiency (18%). Girls generally score lower than boys in numeracy across most states.
 
 ## 5. Class-wise Comparison — GPF (UNESCO) vs India (NIPUN Bharat/NAS), Numeracy
@@ -77,6 +80,8 @@ Only **Lakshadweep** met global minimum proficiency at state level. Top performe
 | **Grade 3 ★ MPL** | 3-digit operations; standard algorithms; fractions; measurement; data reading | 3-digit operations (own way & standard algorithm); shapes/spatial; measurement; data handling | ✓ Aligned (NIPUN Lakshya = GPF MPL) |
 | Grade 4 | Multiply/divide 3-digit; compare fractions; perimeter; bar charts; shape properties | NAS tests similar skills; not GPF cut-score linked | ~ Partial |
 | Grade 5 ★ SDG 4.1.1(b) | Multi-step problems; unlike-denominator fractions; area/perimeter; graphs; mean/mode | NAS 2017 data only; GPF field-tested 2019-20 but not linked | ✗ Gap |
+
+> **⚠ Stale as of 2026-08-21 — see `fln_source_verification_2026-08-21.md` §2.** The "critical data gap" argument below (last Grade 5 data from 2017; no SDG 4.1.1 reporting in 4+ years) predates **PARAKH 2024**, released July 2025 — India's first post-pandemic large-scale national learning assessment, with a Grade 3 mathematics national average of 60%. Do not use this framing in a proposal or paper without updating it.
 
 **Key findings from the comparison:**
 - Strong alignment Grades 1–3 (NIPUN's mission grades) — India's national mission is well-grounded in global standards at the foundational stage.

--- a/Research/FLN_foundation.md
+++ b/Research/FLN_foundation.md
@@ -30,7 +30,18 @@ Foundational Literacy and Numeracy (FLN) is the ability of a child to read with 
 
 ## 3. Foundational Numeracy — Definition (NIPUN Bharat, pg. 84)
 
-Foundational Numeracy = the ability to reason and apply simple numerical concepts to daily-life problem solving, built on **number sense** and **spatial understanding**. It includes the ability to:
+Foundational Numeracy = the ability to reason and apply simple numerical concepts to daily-life problem solving.
+
+> **⚠ Corrected 2026-08-21 — see `fln_source_verification_2026-08-21.md` §2.** This definition previously read "built on **number sense** and **spatial understanding**." The primary source names **four** major components of early mathematics, not two:
+>
+> 1. **Numbers and operations on numbers**
+> 2. **Shapes and Spatial Understanding**
+> 3. **Measurement**
+> 4. **Data Handling**
+>
+> Measurement and Data Handling are first-class components of foundational numeracy, not peripheral topics. The framework's Measurement (Chain E) and Data Handling (Chain J) chains should be weighted accordingly — Data Handling currently begins only at Class 2 with three nodes.
+
+It includes the ability to:
 
 1. Understand quantities
 2. Grasp concepts like more/less, larger/smaller


### PR DESCRIPTION
Companion to #269, kept separate because it touches the intern-authored research files and should be reviewed on its own merits.

**None of these files carried a single citation.** This PR adds real sources where the content is sound, labels the conventions that have no source, and corrects the one claim the literature actually contradicts. Everything is **annotated in place rather than rewritten**, so the original wording stays visible and reviewers can see exactly what changed and why.

## The one real correction

**`Child_psychology.md` §5 — learning styles.** The file claimed children have modality preferences (visual / auditory / kinaesthetic / tactual) and that "the majority of children prefer visual learning." That is the learning-styles myth. Pashler, McDaniel, Rohrer & Bjork (2008), *Psychological Science in the Public Interest*, reviewed 70+ studies and found no credible evidence for the meshing hypothesis.

This matters concretely: **a platform that generates personalised worksheets is exactly the system that would be tempted to label a child a "visual learner" and serve them a different paper.** A note has been added against doing that.

The *practice* the section justified survives — young children genuinely do process `🍎🍎🍎 + 🍎🍎` more easily than `3 + 2`. But the reason is that concrete representation removes symbolic abstraction and reading load for a child who cannot yet decode numerals (the concrete → representational → abstract principle), which applies to **all** young children, not a visual subset.

## Sources added where the content was already right

- **`Child_psychology.md` §8.8–8.9** — the subtraction error patterns are the classic documented "buggy algorithms": **Brown & Burton (1978)**, *Cognitive Science* 2, 155–192. This is the most directly useful thing in the folder for the evaluation engine, and it only ever needed a citation.
- **`Child_psychology.md` §8.3** — teen-number irregularity is real: **Miller et al.**; Chinese-speaking 4–5 year-olds count to ~40 where English-speaking children reach ~15, with no difference below 10. Adds the follow-on point that **NIPUN Bharat mandates mother-tongue instruction and Hindi number names are more irregular than English**, so the counting difficulty curve varies by language.
- **`ALEKS_case_studies.md` §8** — the knowledge-tracing models are real published literature (Corbett & Anderson 1995; Nakagawa et al. 2019). **GKT is the closest published architecture to this platform's**, and its stated weakness — "requires an accurate prerequisite graph" — is exactly why the level-network work matters.
- **`FLN_Assessment_Framework.md`** — the FLS 2022 proficiency bands **check out**; they reconcile exactly with the official finding that 48% of Grade 3 learners fell below global proficiency in numeracy.

## Things now labelled as conventions rather than evidence

- **The 50/35/15 easy/moderate/hard ratio** has no published standard behind it. Kept as a default, labelled as one — plus a design note that a fixed spread is probably wrong for a *diagnostic*, whose job is to concentrate items near the child's threshold. It suits practice worksheets.
- **`ALEKS_case_studies.md`** is vendor material, not evidence. ALEKS is a commercial **implementation** of Knowledge Space Theory, not its source — cite Doignon & Falmagne (1985) directly. ALEKS may be cited only as an existence proof.
- **The "20–25 questions suffice" claim must not be used to justify paper length.** It depends on within-session adaptivity — choosing each question after seeing the last answer — which a printed paper cannot do. Paper length should come from apex selection on the prerequisite graph instead.
- **`Assessment_paper_rubric.md` line 3 literally read `**Resources:** link_1, link_2`** — placeholder text never replaced. Now filled in, with the weightages and Bloom's assignments labelled as unsourced judgement calls.

## Two accuracy fixes

- **`FLN_foundation.md` §3** narrowed the official definition of foundational numeracy from **four** components to two, dropping **Measurement** and **Data Handling**. Restored — these are first-class components, which bears directly on how thin those chains currently are.
- **`FLN_Assessment_Framework.md`** — the state-level FLS results are flagged unverified (in PARAKH 2024 those states rank at the *bottom*), and the "critical data gap" argument is flagged **stale**: PARAKH 2024 was released July 2025 and closes part of it. Worth knowing before that framing is used in a proposal.

Full verdict-by-verdict record is in `Research/fln_source_verification_2026-08-21.md` (#269).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3qvhFQnJNtVc34pq6zFnf