### PR TITLE
feat: gap-analysis engine for Practice vs. Remedial assignment

### DIFF
--- a/backend/src/routes/classes.ts
+++ b/backend/src/routes/classes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { dbStore, UserRole } from '../db';
+import { dbStore, UserRole, CYCLE_NAMES } from '../db';
 import { getAuthUser } from '../auth';
 
 export function registerClassRoutes(app: express.Express) {
@@ -16,5 +16,85 @@ export function registerClassRoutes(app: express.Express) {
       filtered = classes;
     }
     res.json(filtered);
+  });
+
+  // Issue #183: gap-analysis engine. Computed on-demand from live data every
+  // call — nothing here is persisted or cached, so it's never stale and
+  // there's no new collection to keep in sync.
+  app.get('/api/classes/:id/remediation-groups', async (req, res) => {
+    const user = getAuthUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const classes = await dbStore.getClasses();
+    const cls = classes.find(c => c.id === req.params.id);
+    if (!cls) return res.status(404).json({ error: 'Class not found.' });
+
+    const isUnrestricted = [UserRole.SUPERADMIN, UserRole.ADMIN, UserRole.DISTRICT_ADMIN, UserRole.BLOCK_ADMIN].includes(user.role);
+    const hasSchoolAccess = cls.schoolId === user.schoolId || (user.assignedSchools && user.assignedSchools.includes(cls.schoolId));
+    const isOwningTeacher = cls.teacherId === user.id;
+    if (!isUnrestricted && !hasSchoolAccess && !isOwningTeacher) {
+      return res.status(403).json({ error: 'Forbidden.' });
+    }
+
+    const students = (await dbStore.getStudents({ schoolId: cls.schoolId })).filter(
+      s => s.classGroup === cls.className && s.section === cls.section
+    );
+
+    const worksheets = await dbStore.getWorksheets();
+    const worksheetCycleById = new Map(worksheets.map(w => [w.id, w.cycle]));
+
+    const allReports = await dbStore.getEvaluationReports({ studentIds: students.map(s => s.id) });
+
+    const REMEDIATION_CYCLES: string[] = [CYCLE_NAMES[0], CYCLE_NAMES[1]]; // Baseline, Mid-year
+
+    const groups = students.map(s => {
+      const studentReports = allReports
+        .filter(r => r.studentId === s.id)
+        .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+      const cycleReport = studentReports.find(r => {
+        const cycle = worksheetCycleById.get(r.worksheetId);
+        return cycle !== undefined && REMEDIATION_CYCLES.includes(cycle);
+      });
+      const report = cycleReport || studentReports[0];
+
+      const weakTopics = report
+        ? Object.entries(report.conceptMastery)
+            .filter(([, mastery]) => mastery === 'Needs Practice')
+            .map(([topic]) => topic)
+        : [];
+      const assessedTopicCount = report ? Object.keys(report.conceptMastery).length : 0;
+
+      // currentLevel < targetLevel is NOT a useful "behind schedule" signal in
+      // this codebase — targetLevel is defined as currentLevel + 1 essentially
+      // everywhere it's set (seed.ts, evaluation routes), so that comparison
+      // is true for nearly every student by construction. currentSubLevel is
+      // the real signal: it's computed elsewhere from actual performance at
+      // the student's current level (0 = Mastery, 1 = Easier/partial passes,
+      // 2 = Remedial/failed everything at that level).
+      const strugglingAtCurrentLevel = s.currentSubLevel === 2;
+      const majorityWeak = assessedTopicCount > 0 && weakTopics.length > assessedTopicCount / 2;
+      const group: 'Practice' | 'Remedial' = (strugglingAtCurrentLevel || majorityWeak) ? 'Remedial' : 'Practice';
+
+      return {
+        studentId: s.id,
+        studentName: s.name,
+        currentLevel: s.currentLevel,
+        targetLevel: s.targetLevel,
+        group,
+        weakTopics,
+        hasReport: !!report,
+        cycleMatched: !!cycleReport,
+        reportCycle: report ? (worksheetCycleById.get(report.worksheetId) ?? null) : null,
+      };
+    });
+
+    res.json({
+      classId: cls.id,
+      className: cls.className,
+      section: cls.section,
+      practice: groups.filter(g => g.group === 'Practice'),
+      remedial: groups.filter(g => g.group === 'Remedial'),
+    });
   });
 }


### PR DESCRIPTION
## Summary
Closes #183.

New `GET /api/classes/:id/remediation-groups`, computed on-demand from live data every call — no new collection, nothing cached or persisted, so it's never stale.

For each student in the class:
- Finds their most recent evaluation report from a **Baseline or Mid-year** cycle worksheet (falls back to their most recent report of any cycle if none match, flagged via `cycleMatched`/`hasReport`).
- Extracts `weakTopics` from that report's existing `conceptMastery` field — the same "Needs Practice" tags already shown on the Reports page today.
- Classifies **Remedial** if `currentSubLevel === 2` (the codebase's existing signal for "failed everything at this level" — see `evaluation.ts`'s own `newSubLevel` logic) **or** a majority of assessed topics are weak. **Practice** otherwise.

## A design correction worth flagging
The issue's wording suggests using `currentLevel` vs `targetLevel` as the "behind schedule" signal. I checked, and `targetLevel` is defined as `currentLevel + 1` essentially everywhere it's set in this codebase (`seed.ts`, every evaluation route) — so that comparison is true for nearly every student by construction and would have misclassified almost everyone as Remedial. `currentSubLevel` is the real, already-established signal for "how is this student actually doing at their current level," so I used that instead.

No frontend wiring in this PR — the issue explicitly scopes that as a follow-up once the endpoint exists.

## Test plan
- [x] `tsc --noEmit` + `npm run build` clean
- [x] Live against real seeded data: a student with `currentSubLevel=2` correctly grouped Remedial.
- [x] Live against a real evaluation: submitted a worksheet where a student got Number Sense right but failed both Subtraction questions; confirmed the endpoint picked up the real `conceptMastery`, correctly matched the Baseline-cycle report, and correctly kept her in Practice (not a topic majority, still `currentSubLevel` 0) while surfacing "Subtraction" as her specific weak topic — exactly the "struggling with X" detail the issue asks for.
- [x] Authorization: a teacher from a different school gets 403 on another school's class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)