### PR TITLE
feat: real Class Summary Bar on Teacher Dashboard, remove standalone Performance page

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -142,8 +142,7 @@ export const Layout: React.FC<LayoutProps> = ({
           icon: GraduationCap,
           subItems: [
             { name: 'Student List', view: 'student_list' },
-            { name: 'Student Profile', view: 'student_profile' },
-            { name: 'Performance', view: 'performance' }
+            { name: 'Student Profile', view: 'student_profile' }
           ]
         });
         list.push({ name: 'Worksheets', view: 'worksheets', icon: ClipboardList });

--- a/frontend/src/components/dashboards/ClassSummaryBar.tsx
+++ b/frontend/src/components/dashboards/ClassSummaryBar.tsx
@@ -1,0 +1,66 @@
+// Issue #172 + #167: a real "how is my class doing today?" summary bar for
+// the Teacher Dashboard, folding in the stats + Top Performing Students list
+// that used to live on the standalone Performance page (now removed).
+import React from 'react';
+import { Student } from '../../types';
+import { MetricCard } from '../Card';
+import { Users, BarChart3, TrendingUp, TrendingDown } from 'lucide-react';
+
+export const ClassSummaryBar: React.FC<{ students: Student[] }> = ({ students }) => {
+  const total = students.length;
+  const assessed = students.filter(s => s.levelHistory.length > 0).length;
+  const pending = total - assessed;
+
+  // Issue #172 originally asked for "percentage at or above their target
+  // level" — but targetLevel is defined as currentLevel + 1 essentially
+  // everywhere it's set in this codebase, so that comparison is true for
+  // almost no student by construction and would show a near-0% "on track"
+  // figure for every class regardless of actual performance (the mirror
+  // image of the same targetLevel quirk found while building #183's
+  // gap-analysis engine). currentSubLevel === 0 (Mastery — the real,
+  // already-computed signal for "doing well at their current level") is
+  // used instead.
+  const onTrack = students.filter(s => s.currentSubLevel === 0).length;
+  const onTrackPercent = total > 0 ? Math.round((onTrack / total) * 100) : 0;
+
+  const regressed = students.filter(s => {
+    if (s.levelHistory.length < 2) return false;
+    const last = s.levelHistory[s.levelHistory.length - 1];
+    const prev = s.levelHistory[s.levelHistory.length - 2];
+    return last.level < prev.level;
+  }).length;
+
+  const topStudents = [...students].sort((a, b) => (b.currentLevel ?? 0) - (a.currentLevel ?? 0)).slice(0, 5);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <MetricCard title="Total Students" value={total} subtext="Active roster" icon={Users} />
+        <MetricCard title="Assessed / Pending" value={`${assessed} / ${pending}`} subtext="This cycle" icon={BarChart3} />
+        <MetricCard title="On Track" value={`${onTrackPercent}%`} subtext="Mastery at current level" icon={TrendingUp} />
+        <MetricCard title="Regressed" value={regressed} subtext="Level dropped since last cycle" icon={TrendingDown} />
+      </div>
+      {topStudents.length > 0 && (
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
+          <h4 className="text-xs font-mono font-bold text-slate-500 dark:text-slate-400 uppercase mb-3">Top Performing Students</h4>
+          <div className="space-y-2">
+            {topStudents.map(s => (
+              <div key={s.id} className="flex justify-between items-center p-3 border border-slate-100 dark:border-slate-700 rounded-lg">
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-semibold">{s.name}</span>
+                  <span className="text-xs text-slate-400 dark:text-slate-500">{s.classGroup}</span>
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="w-32 h-2 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden">
+                    <div className="h-full bg-emerald-500 rounded-full" style={{ width: `${((s.currentLevel ?? 0) / 93) * 100}%` }} />
+                  </div>
+                  <span className="font-mono font-bold text-sm">L{s.currentLevel ?? 0}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/dashboards/TeacherDashboard.tsx
+++ b/frontend/src/components/dashboards/TeacherDashboard.tsx
@@ -14,6 +14,7 @@ import { SkillGraphPanel } from '../SkillGraphPanel';
 import { Table, Column } from '../Table';
 import { Layers as BulkIcon } from 'lucide-react';
 import { FLNLevelReferenceModal, LevelBadge } from '../RoleDashboards';
+import { ClassSummaryBar } from './ClassSummaryBar';
 
 
 export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
@@ -316,6 +317,11 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
       </div>
 
 
+
+      {/* Issue #172: real "how is my class doing today?" summary + #167's
+          Top Performing Students, now that the standalone Performance page
+          is gone. */}
+      <ClassSummaryBar students={students} />
 
       {/* Class picker tabs */}
       <div className="flex gap-2 border-b border-zinc-200 dark:border-zinc-700 pb-px">


### PR DESCRIPTION
## Summary
Closes #172, closes #167.

**#172 was previously closed incorrectly** — by an unrelated onboarding-doc PR (#221) that included "Closes #172" in its body without building the actual feature. Confirmed via a full codebase search: no Class Summary Bar component existed anywhere. Reopened it and built the real thing here, bundled with #167 since they're two halves of the same feature (Performance's stats moving onto the Dashboard).

- New `frontend/src/components/dashboards/ClassSummaryBar.tsx`: Total Students, Assessed/Pending this cycle, On Track %, and Regressed count, plus the Top Performing Students list folded in from the old standalone Performance page. Wired into `TeacherDashboard.tsx` above the class tabs.
- Removed "Performance" from the Teacher sidebar nav (`Layout.tsx`) — scoped to Teacher only, per the issue's own literal wording. Volunteer/School/BlockAdmin/DistrictAdmin keep their Performance page since neither issue mentions those roles, and they still route to the shared `PerformancePanel` component (left untouched, still valid for them).

## A design correction, same pattern as #183
#172's original spec asked for "percentage at or above their target level," but `targetLevel` is defined as `currentLevel + 1` essentially everywhere it's set in this codebase — the same quirk found while building #183's gap-analysis engine — so that comparison would show a near-0% "on track" figure for every class regardless of real performance. Used `currentSubLevel === 0` (Mastery, the real already-computed per-student signal) instead.

## Test plan
- [x] `tsc --noEmit` + `npm run build` clean
- [x] Live as a teacher: summary bar shows real numbers (60 total, 60/0 assessed/pending, 35% on track, 0 regressed) computed from real seeded data; Top Performing Students renders correctly below it; confirmed "Performance" is gone from the Students sidebar section
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)