### PR TITLE
feat: Student Profile shows full per-question exam history

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -380,7 +380,7 @@ export interface EvaluationReport {
   // the teacher-override endpoint requires it to exist on the report it's
   // correcting, since a correction is meaningless without knowing which
   // question is being corrected.
-  questionResults?: { questionId: string; submittedAnswer: string; isCorrect: boolean }[];
+  questionResults?: { questionId: string; question?: string; correctAnswer?: string; submittedAnswer: string; isCorrect: boolean }[];
   teacherReviewed?: boolean;
   reviewedBy?: string; // reviewing teacher's email
   reviewedAt?: string;

--- a/backend/src/routes/evaluation.ts
+++ b/backend/src/routes/evaluation.ts
@@ -456,6 +456,8 @@ export function registerEvaluationRoutes(app: express.Express) {
           questionResults: diagQuestions.length > 0
             ? diagQuestions.map(q => ({
                 questionId: q.question_id,
+                question: q.question,
+                correctAnswer: q.answer,
                 submittedAnswer: extractedAnswers[q.question_id] ?? '',
                 isCorrect: extractedCorrectness[q.question_id] ?? false,
               }))
@@ -1179,6 +1181,8 @@ export function registerEvaluationRoutes(app: express.Express) {
       // individual mis-scanned answers via the override endpoint.
       questionResults: studentQuestions.map(q => ({
         questionId: q.question_id,
+        question: q.question,
+        correctAnswer: q.answer,
         submittedAnswer: answers[q.question_id] || '',
         isCorrect: (answers[q.question_id] || '').trim().toLowerCase() === q.answer.trim().toLowerCase(),
       })),
@@ -1324,6 +1328,16 @@ export function registerEvaluationRoutes(app: express.Express) {
 
   // Evaluation History
   app.get('/api/evaluation/:studentId/history', async (req, res) => {
+    // Was missing auth entirely — any unauthenticated request could read
+    // any student's full evaluation history. Fixed while wiring #174's
+    // Student Profile exam-history view to this route.
+    const user = getAuthUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const student = await dbStore.getStudentById(req.params.studentId);
+    if (!student) return res.status(404).json({ error: 'Student not found.' });
+    if (!canAccessStudent(user, student)) return res.status(403).json({ error: 'Forbidden.' });
+
     const reps = await dbStore.getEvaluationReports();
     const filtered = reps.filter(r => r.studentId === req.params.studentId);
     res.json(filtered);
@@ -1369,7 +1383,7 @@ export function registerEvaluationRoutes(app: express.Express) {
       const correction = correctionMap.get(q.questionId);
       if (!correction) return q;
       return {
-        questionId: q.questionId,
+        ...q,
         submittedAnswer: correction.correctedAnswer ?? q.submittedAnswer,
         isCorrect: correction.isCorrect,
       };

--- a/frontend/src/components/panels/StudentProfilePanel.tsx
+++ b/frontend/src/components/panels/StudentProfilePanel.tsx
@@ -24,6 +24,9 @@ export const StudentProfilePanel: React.FC<{
   const [searchQuery, setSearchQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
   const [activityFilter, setActivityFilter] = useState<'all' | 'assessment' | 'level_change'>('all');
+  // Issue #174: expand one report at a time to show its full per-question
+  // exam-history breakdown (question, given answer, correct answer, verdict).
+  const [expandedReportId, setExpandedReportId] = useState<string | null>(null);
 
   useEffect(() => {
     if (students.length > 0 && !sel) {
@@ -407,11 +410,56 @@ export const StudentProfilePanel: React.FC<{
                       ))}</div>
                       
                       <div className="pt-2 border-t border-slate-100 dark:border-slate-800 flex justify-between items-center">
-                        <span className="text-[10px] text-slate-400 dark:text-slate-500 font-mono">Per-question answer detail not yet available</span>
+                        {r.questionResults && r.questionResults.length > 0 ? (
+                          <button
+                            onClick={() => setExpandedReportId(expandedReportId === r.id ? null : r.id)}
+                            className="text-[10px] font-mono font-bold text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+                          >
+                            {expandedReportId === r.id ? '▲ Hide' : '▼ Show'} per-question detail ({r.questionResults.length} questions)
+                          </button>
+                        ) : (
+                          <span className="text-[10px] text-slate-400 dark:text-slate-500 font-mono">Per-question answer detail not available for this report</span>
+                        )}
                         <button onClick={() => handleDownloadPDF(s, r)} className="text-xs font-semibold text-emerald-650 hover:text-emerald-800 flex items-center gap-1">
                           📥 Download PDF Report
                         </button>
                       </div>
+
+                      {expandedReportId === r.id && r.questionResults && (
+                        <div className="overflow-x-auto border border-slate-200 dark:border-slate-700 rounded-lg">
+                          <table className="w-full text-left text-xs">
+                            <thead>
+                              <tr className="bg-slate-50 dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400 font-mono uppercase">
+                                <th className="p-2"># Question</th>
+                                <th className="p-2 text-center">Correct Answer</th>
+                                <th className="p-2">Given Answer</th>
+                                <th className="p-2 text-center">Result</th>
+                              </tr>
+                            </thead>
+                            <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                              {r.questionResults.map((q, idx) => (
+                                <tr key={q.questionId}>
+                                  <td className="p-2 font-medium text-slate-900 dark:text-white">
+                                    <span className="font-mono text-[10px] font-bold text-slate-400 mr-1.5">Q{idx + 1}.</span>
+                                    {q.question || q.questionId}
+                                  </td>
+                                  <td className="p-2 text-center font-mono font-bold text-emerald-600 dark:text-emerald-400">{q.correctAnswer ?? '—'}</td>
+                                  <td className="p-2 font-mono">{q.submittedAnswer || '—'}</td>
+                                  <td className="p-2 text-center">
+                                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-mono font-bold ${
+                                      q.isCorrect
+                                        ? 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300'
+                                        : 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300'
+                                    }`}>
+                                      {q.isCorrect ? '✓ Correct' : '✗ Incorrect'}
+                                    </span>
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      )}
                     </div>
                   );
                 })}</div> : <div className="text-center py-8"><p className="text-xs text-slate-400 dark:text-slate-500">No assessment reports yet.</p></div>}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -227,6 +227,12 @@ export interface EvaluationReport {
   recommendedSubLevel?: number;
   timestamp: string;
   reasoning?: EvaluationReasoning;
+  // Issue #180: per-question breakdown, present on reports created after
+  // that feature landed. Optional — older reports predate it.
+  questionResults?: { questionId: string; question?: string; correctAnswer?: string; submittedAnswer: string; isCorrect: boolean }[];
+  teacherReviewed?: boolean;
+  reviewedBy?: string;
+  reviewedAt?: string;
 }
 
 export interface Ticket {


### PR DESCRIPTION
## Summary
Closes #174.

The Academic Record tab's "All Assessment Reports" section had a literal placeholder — "Per-question answer detail not yet available" — for every report. Replaced it with a real expandable breakdown per report: question text, correct answer, the student's given answer, and a right/wrong verdict, sourced from `questionResults` (added on `EvaluationReport` in #180's teacher-override work).

- Extended `questionResults` (`backend/src/db.ts` + `frontend/src/types.ts` — both had drifted, `types.ts` never got #180's fields at all) to also carry `question`/`correctAnswer` text. Both report-creation sites already had the full `Question` object in scope, so this was just persisting data they already had. Also fixed the override endpoint's correction-merge to preserve these fields (was rebuilding a stripped-down object, dropping them) with a spread instead.
- **Score trend over time** is already covered by the existing report list (date + score) plus the "Best Score"/"Recent Score" summary already on the page.
- **Skipped** the "practice/remedial worksheet assignment counts" part of this issue, per its own explicit permission: #183's remediation-groups endpoint classifies students on-demand but doesn't track a historical count, and practice/remedial worksheet generation itself isn't built yet — no real event stream to count.

## A bug found and fixed along the way
`GET /api/evaluation/:studentId/history` had **no authentication or authorization check at all** — any unauthenticated request could read any student's full evaluation history. Added the same auth + `canAccessStudent` check used elsewhere in this file. Currently unused by any frontend code, but it's a live, reachable route, so the fix stands on its own.

## Test plan
- [x] `tsc --noEmit` + `npm run build` clean on both frontend and backend
- [x] Live, end-to-end: submitted a real evaluation via the actual API (one correct answer, one deliberately wrong); confirmed the Student Profile page's Academic Record tab shows "Show per-question detail (2 questions)", expands to a real table with both questions' text/correct answer/given answer/verdict rendering correctly
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)