### PR TITLE
feat: Add opt-in pagination to schools, teachers & evaluation/reports endpoints

### DIFF
--- a/backend/src/routes/evaluation.ts
+++ b/backend/src/routes/evaluation.ts
@@ -1295,34 +1295,49 @@ export function registerEvaluationRoutes(app: express.Express) {
     const user = getAuthUser(req);
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
+    let reports: EvaluationReport[];
     if (user.role === UserRole.SUPERADMIN) {
-      const reports = await dbStore.getEvaluationReports();
-      return res.json(reports);
-    }
-
-    let scopedStudentIds: Set<string>;
-    if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
-      const students = await dbStore.getStudents({ schoolId: user.schoolId });
-      scopedStudentIds = new Set(students.map(s => s.id));
-    } else if (user.role === UserRole.VOLUNTEER) {
-      const students = await dbStore.getStudents({ schoolId: user.assignedSchools || [] });
-      scopedStudentIds = new Set(students.map(s => s.id));
-    } else if (user.role === UserRole.ADMIN || user.role === UserRole.DISTRICT_ADMIN || user.role === UserRole.BLOCK_ADMIN) {
-      const schools = await dbStore.getSchools();
-      const filteredSchools = schools.filter(school => {
-        if (user.role === UserRole.ADMIN) return school.stateCode === user.stateCode;
-        if (user.role === UserRole.DISTRICT_ADMIN) return school.districtCode === user.districtCode;
-        return school.blockCode === user.blockCode; // BLOCK_ADMIN
-      });
-      const schoolIds = filteredSchools.map(s => s.id);
-      const students = await dbStore.getStudents({ schoolId: schoolIds });
-      scopedStudentIds = new Set(students.map(s => s.id));
+      reports = await dbStore.getEvaluationReports();
     } else {
-      const students = await dbStore.getStudents();
-      scopedStudentIds = new Set(students.map(s => s.id));
+      let scopedStudentIds: Set<string>;
+      if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
+        const students = await dbStore.getStudents({ schoolId: user.schoolId });
+        scopedStudentIds = new Set(students.map(s => s.id));
+      } else if (user.role === UserRole.VOLUNTEER) {
+        const students = await dbStore.getStudents({ schoolId: user.assignedSchools || [] });
+        scopedStudentIds = new Set(students.map(s => s.id));
+      } else if (user.role === UserRole.ADMIN || user.role === UserRole.DISTRICT_ADMIN || user.role === UserRole.BLOCK_ADMIN) {
+        const schools = await dbStore.getSchools();
+        const filteredSchools = schools.filter(school => {
+          if (user.role === UserRole.ADMIN) return school.stateCode === user.stateCode;
+          if (user.role === UserRole.DISTRICT_ADMIN) return school.districtCode === user.districtCode;
+          return school.blockCode === user.blockCode; // BLOCK_ADMIN
+        });
+        const schoolIds = filteredSchools.map(s => s.id);
+        const students = await dbStore.getStudents({ schoolId: schoolIds });
+        scopedStudentIds = new Set(students.map(s => s.id));
+      } else {
+        const students = await dbStore.getStudents();
+        scopedStudentIds = new Set(students.map(s => s.id));
+      }
+      reports = await dbStore.getEvaluationReports({ studentIds: Array.from(scopedStudentIds) });
     }
 
-    const reports = await dbStore.getEvaluationReports({ studentIds: Array.from(scopedStudentIds) });
+    // Opt-in pagination (same pattern as GET /api/students, PR #115).
+    // Omitting ?page & ?limit returns the full scoped list — no existing caller breaks.
+    const pageParam = req.query.page as string | undefined;
+    const limitParam = req.query.limit as string | undefined;
+    if (pageParam || limitParam) {
+      const page  = Math.max(1, parseInt(pageParam || '1', 10) || 1);
+      const limit = Math.max(1, Math.min(500, parseInt(limitParam || '50', 10) || 50));
+      const total = reports.length;
+      const start = (page - 1) * limit;
+      res.set('X-Total-Count', String(total));
+      res.set('X-Page',        String(page));
+      res.set('X-Pages',       String(Math.max(1, Math.ceil(total / limit))));
+      return res.json(reports.slice(start, start + limit));
+    }
+
     res.json(reports);
   });
 

--- a/backend/src/routes/schools.ts
+++ b/backend/src/routes/schools.ts
@@ -7,22 +7,38 @@ export function registerSchoolRoutes(app: express.Express) {
     const user = getAuthUser(req);
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
     const schools = await dbStore.getSchools();
+
+    let scoped: typeof schools;
     if (user.role === UserRole.SUPERADMIN || user.role === UserRole.ADMIN) {
-      return res.json(schools);
+      scoped = schools;
+    } else if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
+      scoped = schools.filter(s => s.id === user.schoolId);
+    } else if (user.role === UserRole.VOLUNTEER) {
+      scoped = schools.filter(s => user.assignedSchools?.includes(s.id));
+    } else if (user.role === UserRole.DISTRICT_ADMIN) {
+      scoped = schools.filter(s => s.districtCode === user.districtCode);
+    } else if (user.role === UserRole.BLOCK_ADMIN) {
+      scoped = schools.filter(s => s.blockCode === user.blockCode);
+    } else {
+      scoped = schools;
     }
-    if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
-      return res.json(schools.filter(s => s.id === user.schoolId));
+
+    // Opt-in pagination (same pattern as GET /api/students, PR #115).
+    // Omitting ?page & ?limit returns the full scoped list — no existing caller breaks.
+    const pageParam = req.query.page as string | undefined;
+    const limitParam = req.query.limit as string | undefined;
+    if (pageParam || limitParam) {
+      const page  = Math.max(1, parseInt(pageParam || '1', 10) || 1);
+      const limit = Math.max(1, Math.min(500, parseInt(limitParam || '50', 10) || 50));
+      const total = scoped.length;
+      const start = (page - 1) * limit;
+      res.set('X-Total-Count', String(total));
+      res.set('X-Page',        String(page));
+      res.set('X-Pages',       String(Math.max(1, Math.ceil(total / limit))));
+      return res.json(scoped.slice(start, start + limit));
     }
-    if (user.role === UserRole.VOLUNTEER) {
-      return res.json(schools.filter(s => user.assignedSchools?.includes(s.id)));
-    }
-    if (user.role === UserRole.DISTRICT_ADMIN) {
-      return res.json(schools.filter(s => s.districtCode === user.districtCode));
-    }
-    if (user.role === UserRole.BLOCK_ADMIN) {
-      return res.json(schools.filter(s => s.blockCode === user.blockCode));
-    }
-    res.json(schools);
+
+    res.json(scoped);
   });
 
   app.post('/api/schools', async (req, res) => {

--- a/backend/src/routes/teachers.ts
+++ b/backend/src/routes/teachers.ts
@@ -41,6 +41,21 @@ export function registerTeacherRoutes(app: express.Express) {
       };
     });
 
+    // Opt-in pagination (same pattern as GET /api/students, PR #115).
+    // Omitting ?page & ?limit returns the full scoped list — no existing caller breaks.
+    const pageParam = req.query.page as string | undefined;
+    const limitParam = req.query.limit as string | undefined;
+    if (pageParam || limitParam) {
+      const page  = Math.max(1, parseInt(pageParam || '1', 10) || 1);
+      const limit = Math.max(1, Math.min(500, parseInt(limitParam || '50', 10) || 50));
+      const total = enriched.length;
+      const start = (page - 1) * limit;
+      res.set('X-Total-Count', String(total));
+      res.set('X-Page',        String(page));
+      res.set('X-Pages',       String(Math.max(1, Math.ceil(total / limit))));
+      return res.json(enriched.slice(start, start + limit));
+    }
+
     res.json(enriched);
   });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(() => {
         // isn't running in this dev environment — they caused 500s when
         // the frontend fetched /api/students etc. Let the catch-all route
         // everything to the main backend to avoid the misrouting.
-        '/api': 'https://localhost:5000',
+        '/api': { target: process.env.VITE_API_TARGET || 'http://localhost:3000', changeOrigin: true },
         '/output': { target: process.env.VITE_API_TARGET || 'http://localhost:3000', changeOrigin: true },
         '/worksheets': { target: process.env.VITE_API_TARGET || 'http://localhost:3000', changeOrigin: true },
       },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(() => {
         // isn't running in this dev environment — they caused 500s when
         // the frontend fetched /api/students etc. Let the catch-all route
         // everything to the main backend to avoid the misrouting.
-        '/api': { target: process.env.VITE_API_TARGET || 'http://localhost:3000', changeOrigin: true },
+        '/api': 'https://localhost:5000',
         '/output': { target: process.env.VITE_API_TARGET || 'http://localhost:3000', changeOrigin: true },
         '/worksheets': { target: process.env.VITE_API_TARGET || 'http://localhost:3000', changeOrigin: true },
       },


### PR DESCRIPTION
@jgupta05072003-code Ma'am please review this PR as approved to work upon by you.

This PR extends the opt-in pagination pattern from PR #115 (`GET /api/students`) to three more large-list endpoints:

- `GET /api/schools` — up to 1,440 records
- `GET /api/teachers` — large for Block Admin scope
- `GET /api/evaluation/reports` — large for State Admin scope

**How it works:**
- Pass `?page=1&limit=50` → get a page + `X-Total-Count`, `X-Page`, `X-Pages` headers
- Omit the params → full list, same as before (no breaking change)
- Limit clamped to max 500
- Pagination always runs **after** role-scoping

**Files changed:**
- `backend/src/routes/schools.ts`
- `backend/src/routes/teachers.ts`
- `backend/src/routes/evaluation.ts`

Backend only — no frontend changes needed yet.

npm run lint succeeds with no error
npm run build succeeds with no error

Closes #145 

<img width="960" height="511" alt="Screenshot 2026-08-21 215004" src="https://github.com/user-attachments/assets/ba096079-8d48-4171-9fa3-f5903bfeceb7" />
