### PR TITLE
fix: clean up teacher and volunteer dashboards for issue 166

### DIFF
--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -71,7 +71,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
 
   if (panel === 'test_history') return <TestHistoryPanel currentUser={currentUser} token={token} />;
 
-  if (panel === 'worksheets') return <WorksheetsPanel reportsList={reportsList} worksheetsList={worksheetsList} />;
+  if (panel === 'worksheets') return <WorksheetsPanel reportsList={reportsList} worksheetsList={worksheetsList} students={students} currentUser={currentUser} token={token} refreshStudents={refreshStudents} />;
 
   if (panel === 'performance') return <PerformancePanel students={students} currentUser={currentUser} />;
 

--- a/frontend/src/components/dashboards/TeacherDashboard.tsx
+++ b/frontend/src/components/dashboards/TeacherDashboard.tsx
@@ -6,14 +6,10 @@ import React, { useState, useEffect } from 'react';
 import { apiFetch, withBase } from '../../services/apiClient';
 import { User, Student, ClassGroup, DashboardProps } from '../../types';
 import { DiagnosticWorkflow } from '../DiagnosticWorkflow';
-import { BulkDiagnosticWorkflow } from '../BulkDiagnosticWorkflow';
-import { WorksheetWorkflow } from '../WorksheetWorkflow';
-import { IcrScanner } from '../IcrScanner';
 import { BaselineUpload } from '../BaselineUpload';
 import { SkillGraphPanel } from '../SkillGraphPanel';
 import { Table, Column } from '../Table';
-import { Layers as BulkIcon } from 'lucide-react';
-import { FLNLevelReferenceModal, LevelBadge } from '../RoleDashboards';
+import { LevelBadge } from '../RoleDashboards';
 import { ClassSummaryBar } from './ClassSummaryBar';
 
 
@@ -24,30 +20,12 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
   const [showAllStudents, setShowAllStudents] = useState(true);
   const [diagnosticStudent, setDiagnosticStudent] = useState<Student | null>(null);
   const [baselineStudent, setBaselineStudent] = useState<Student | null>(null);
-  const [showWorksheetPortal, setShowWorksheetPortal] = useState(false);
-  const [showLevelRef, setShowLevelRef] = useState(false);
   const [showSkillGraph, setShowSkillGraph] = useState(false);
-  const [showIcrScanner, setShowIcrScanner] = useState(false);
-  const [showBulkDiagnostic, setShowBulkDiagnostic] = useState(false);
 
-  // Inline bulk generation state
-  const [bulkJob, setBulkJob] = useState<{ jobId: string; total: number; completed: number; status: string; pdfUrl: string; downloadUrl: string | null; error: string } | null>(null);
-  const [bulkLoading, setBulkLoading] = useState(false);
-  const [bulkError, setBulkError] = useState('');
-
-  // Level-wise bulk generation state
-  const [levelBulkProgress, setLevelBulkProgress] = useState<{ total: number; completed: number; errors: string[] } | null>(null);
-  const [levelBulkLoading, setLevelBulkLoading] = useState(false);
-
-  // Level-Wise Paper Generator — batch pipeline (Levels_backend integration)
-  const [levelBatchId, setLevelBatchId] = useState<string | null>(null);
-  const [levelBatchResults, setLevelBatchResults] = useState<Array<{ studentId: string; studentName: string; sublevelId: string; setNum: number; pdfUrl: string }>>([]);
-  const [levelBatchSkipped, setLevelBatchSkipped] = useState<Array<{ studentId: string; reason: string }>>([]);
-  const [levelBatchError, setLevelBatchError] = useState('');
-  const [levelBatchDownloading, setLevelBatchDownloading] = useState(false);
-
-
-
+  // Issue #166: per-student "Print L{level}.{sub}" action kept on the roster
+  // (it's a per-row interaction, not an operational tool). State below is the
+  // indicator banners + handler — same shape as before, just no longer paired
+  // with the now-removed bulk/level-batch cards.
   const [levelPdfLoading, setLevelPdfLoading] = useState(false);
   const [levelPdfError, setLevelPdfError] = useState('');
 
@@ -76,72 +54,6 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
     }
   };
 
-  // "Generate Batch" — sends every placed student's {studentName, rollNumber,
-  // levelId, sublevelId, setsPerSub} to the backend in one call, which
-  // forwards it to the Levels_backend service as its roster JSON.
-  const handleGenerateLevelBatch = async () => {
-    const placed = classStudents.filter(s => s.levelHistory.length > 0);
-    if (placed.length === 0) {
-      alert('No placed students in this class to generate level-wise papers for.');
-      return;
-    }
-    setLevelBulkLoading(true);
-    setLevelBatchError('');
-    setLevelBatchResults([]);
-    setLevelBatchSkipped([]);
-    setLevelBatchId(null);
-    try {
-      const res = await apiFetch('/api/worksheets/generate-level-batch', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
-        body: JSON.stringify({ studentIds: placed.map(s => s.id) })
-      });
-      const data = await res.json();
-      if (res.ok && data.success) {
-        setLevelBatchId(data.batchId);
-        setLevelBatchResults(data.results || []);
-        setLevelBatchSkipped(data.skipped || []);
-      } else {
-        setLevelBatchError(data.error || 'Batch generation failed.');
-      }
-    } catch {
-      setLevelBatchError('Network error generating the batch.');
-    } finally {
-      setLevelBulkLoading(false);
-    }
-  };
-
-  // "Download Batch ZIP" — streams the batch ZIP (every student's
-  // worksheet.pdf + answer_key.json + coords.json) from Levels_backend via
-  // our own backend, once a batch has finished generating.
-  const handleDownloadLevelBatch = async () => {
-    if (!levelBatchId) return;
-    setLevelBatchDownloading(true);
-    try {
-      const res = await apiFetch(`/api/worksheets/download-batch/${levelBatchId}`);
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Download failed.');
-      }
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `batch_${levelBatchId}.zip`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-    } catch (err: any) {
-      setLevelBatchError(err.message || 'Failed to download batch ZIP.');
-    } finally {
-      setLevelBatchDownloading(false);
-    }
-  };
-
   const fetchTeacherData = async () => {
     try {
       const clsRes = await apiFetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } });
@@ -162,55 +74,6 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
   useEffect(() => {
     fetchTeacherData();
   }, [token]);
-
-  // Poll bulk job progress
-  useEffect(() => {
-    if (!bulkJob || bulkJob.status !== 'running') return;
-    const interval = setInterval(async () => {
-      try {
-        const res = await apiFetch(`/api/diagnostic/bulk/${bulkJob.jobId}/progress`);
-        if (res.ok) {
-          const data = await res.json();
-          setBulkJob(prev => prev ? { ...prev, completed: data.completed, status: data.status, pdfUrl: data.pdfUrl || prev.pdfUrl, downloadUrl: data.downloadUrl || prev.downloadUrl, error: data.error || '' } : prev);
-          if (data.status !== 'running') clearInterval(interval);
-        } else {
-          clearInterval(interval);
-        }
-      } catch {
-        clearInterval(interval);
-      }
-    }, 1500);
-    return () => clearInterval(interval);
-  }, [bulkJob?.jobId, bulkJob?.status]);
-
-
-
-  if (showBulkDiagnostic) {
-    return (
-      <BulkDiagnosticWorkflow
-        user={user}
-        token={token}
-        userRole={user.role}
-        onBack={() => {
-          setShowBulkDiagnostic(false);
-          fetchTeacherData();
-        }}
-      />
-    );
-  }
-
-  if (showIcrScanner) {
-    return (
-      <IcrScanner
-        token={token}
-        user={user}
-        onBack={() => {
-          setShowIcrScanner(false);
-          fetchTeacherData();
-        }}
-      />
-    );
-  }
 
   if (diagnosticStudent) {
     return (
@@ -242,45 +105,6 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
   // Filter students under selected active class
   const classStudents = showAllStudents ? students : (activeClass ? students.filter(s => s.classGroup === activeClass.className && s.section === activeClass.section) : []);
 
-  if (showWorksheetPortal) {
-    const effectiveClass = activeClass || (classes.length > 0 ? classes[0] : null);
-    if (effectiveClass) {
-      const effectiveStudents = students.filter(
-        s => s.classGroup === effectiveClass.className && s.section === effectiveClass.section
-      );
-      return (
-        <WorksheetWorkflow
-          classGroup={effectiveClass}
-          students={effectiveStudents}
-          token={token}
-          userRole={user.role}
-          onBack={() => {
-            setShowWorksheetPortal(false);
-            fetchTeacherData();
-          }}
-        />
-      );
-    } else {
-      return (
-        <div className="p-8 max-w-md mx-auto bg-white dark:bg-slate-900 border border-zinc-200 dark:border-zinc-700 rounded-2xl shadow-sm text-center space-y-4 my-12" id="no-classes-fallback">
-          <div className="w-12 h-12 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center mx-auto">
-            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-            </svg>
-          </div>
-          <h3 className="font-display font-semibold text-zinc-950 dark:text-white text-base">No Classes Found</h3>
-          <p className="text-sm text-zinc-500 dark:text-zinc-400">You must have at least one registered classroom to open the Exam Worksheets Personalization Portal.</p>
-          <button
-            onClick={() => setShowWorksheetPortal(false)}
-            className="px-4 py-2 bg-zinc-950 text-white font-mono font-medium text-xs rounded-lg hover:bg-zinc-850 cursor-pointer animate-pulse"
-          >
-            Go Back
-          </button>
-        </div>
-      );
-    }
-  }
-
   return (
     <div className="space-y-6" id="teacher-dashboard">
       {levelPdfLoading && (
@@ -300,12 +124,6 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
           <p className="text-zinc-550 dark:text-zinc-400 text-sm mt-0.5 font-medium">Teacher: {user.name} · School Scope: gps-mt-001 Model Town</p>
         </div>
         <div className="flex gap-2">
-          <button
-            onClick={() => setShowLevelRef(true)}
-            className="bg-white dark:bg-slate-900 hover:bg-zinc-50 dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-200 font-mono text-xs font-semibold px-4 py-2.5 rounded-lg transition-colors cursor-pointer"
-          >
-            📖 93 FLN Framework
-          </button>
           <button
             onClick={() => setShowSkillGraph(true)}
             className="bg-white dark:bg-slate-900 hover:bg-zinc-50 dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-200 font-mono text-xs font-semibold px-4 py-2.5 rounded-lg transition-colors cursor-pointer"
@@ -346,228 +164,24 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
         ))}
       </div>
 
+      {/* Issue #166: Diagnostic Paper Generator + Level-Wise Paper Generator
+          + Exam Worksheets Engine cards removed from this dashboard. They
+          now live in:
+            - Assessment -> Diagnostic Test (BulkDiagnosticWorkflow + 93 FLN
+              Framework modal — DiagnosticTestPanel.tsx)
+            - Worksheets (Level-Wise batch generator + Open Personalization
+              Portal + ICR Answer Sheet Scanner launchers — WorksheetsPanel.tsx)
+          Per-row actions (Run Diagnostic, Upload Sheet, Print L…, 🌐
+          Interactive) remain because they are roster interactions, not
+          operational tools. */}
+
       {classStudents.length > 0 && (
         <div className="space-y-6">
-          {!showAllStudents && activeClass && (
-            <>
-          {/* 📋 Diagnostic Paper Generator */}
-          <div className="bg-white dark:bg-slate-900 border border-zinc-200 dark:border-zinc-700 rounded-xl p-5 shadow-sm space-y-4">
-            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-              <div className="flex items-center gap-4">
-                <div>
-                  <h3 className="font-display font-semibold text-zinc-900 dark:text-white text-sm">📋 Diagnostic Paper Generator</h3>
-                  <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">Generate baseline diagnostic PDFs for students pending placement.</p>
-                </div>
-                <span className="text-xs font-mono font-bold px-2 py-1 rounded bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800">
-                  {classStudents.filter(s => s.levelHistory.length === 0).length} Pending
-                </span>
-              </div>
-              {!bulkJob || bulkJob?.status === 'failed' ? (
-                <button
-                  type="button"
-                  onClick={async () => {
-                    const targets = classStudents.length > 0 ? classStudents : [];
-                    if (targets.length === 0) {
-                      alert('No students found in this class.');
-                      return;
-                    }
-                    const classMatch = activeClass?.className.match(/\d+/);
-                    const classNumber = classMatch ? parseInt(classMatch[0], 10) : 2;
-                    setBulkLoading(true);
-                    setBulkError('');
-                    setBulkJob(null);
-                    try {
-                      const res = await apiFetch('/api/diagnostic/bulk', {
-                        method: 'POST',
-                        headers: {
-                          'Content-Type': 'application/json',
-                          'Authorization': `Bearer ${token}`
-                        },
-                        body: JSON.stringify({ classNumber, students: targets.map(s => ({ name: s.name, studentId: s.id })) })
-                      });
-                      const data = await res.json();
-                      if (res.ok) {
-                        setBulkJob({ ...data, total: targets.length, completed: 0, pdfUrl: data.pdfUrl || '', downloadUrl: data.downloadUrl || null, error: '' });
-                      } else {
-                        setBulkError(data.error || 'Failed to start bulk generation.');
-                      }
-                    } catch {
-                      setBulkError('Network error starting bulk generation.');
-                    } finally {
-                      setBulkLoading(false);
-                    }
-                  }}
-                  disabled={bulkLoading}
-                  className="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-xs font-mono px-4 py-2.5 rounded-lg transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {bulkLoading ? (
-                    <><span className="animate-spin text-sm">⏳</span> Generating...</>
-                  ) : (
-                    <>Generate Diagnostic Papers</>
-                  )}
-                </button>
-              ) : null}
-            </div>
-
-            {/* Generating state */}
-            {bulkLoading && (
-              <div className="pt-2 border-t border-zinc-100 dark:border-zinc-800">
-                <div className="flex items-center gap-3 p-4 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg">
-                  <span className="animate-spin text-xl">⏳</span>
-                  <div>
-                    <p className="text-sm font-semibold text-blue-800 dark:text-blue-200">Generating Diagnostic Papers...</p>
-                    <p className="text-xs text-blue-600 dark:text-blue-400">Please wait while the papers are being generated for {classStudents.filter(s => s.levelHistory.length === 0).length} students.</p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Bulk job polling & result */}
-            {bulkJob && (
-              <>
-                {/* Poll progress while running */}
-                {bulkJob.status === 'running' && (
-                  <div className="pt-2 border-t border-zinc-100 dark:border-zinc-800">
-                    <div className="flex items-center gap-3 p-4 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg">
-                      <span className="animate-spin text-xl">⏳</span>
-                      <div>
-                        <p className="text-sm font-semibold text-blue-800 dark:text-blue-200">Generating Diagnostic Papers...</p>
-                        <p className="text-xs text-blue-600 dark:text-blue-400">{bulkJob.completed} / {bulkJob.total} papers generated</p>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {/* Completed result */}
-                {bulkJob.status === 'completed' && bulkJob.downloadUrl && (
-                  <div className="pt-2 border-t border-zinc-100 dark:border-zinc-800">
-                    <div className="p-4 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 rounded-lg space-y-3">
-                      <div className="flex items-center gap-2">
-                        <span className="text-green-700 dark:text-green-300 font-bold text-sm">✅ {bulkJob.total} Diagnostic Papers Generated Successfully</span>
-                      </div>
-                      <div className="flex gap-3">
-                        <a
-                          href={bulkJob.pdfUrl ? withBase(bulkJob.pdfUrl) : bulkJob.downloadUrl ? withBase(bulkJob.downloadUrl) : '#'}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex items-center gap-1.5 bg-green-600 hover:bg-green-700 text-white text-xs font-mono font-bold px-4 py-2.5 rounded-lg transition-colors cursor-pointer shadow-sm"
-                        >
-                          🖨️ Print / Open PDF ({bulkJob.total} Papers)
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {/* Failed result */}
-                {bulkJob.status === 'failed' && (
-                  <div className="pt-2 border-t border-zinc-100 dark:border-zinc-800">
-                    <div className="p-3 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-lg">
-                      <p className="text-xs text-red-700 dark:text-red-300 font-medium">❌ Generation Failed: {bulkJob.error || 'Unknown error'}</p>
-                      <button
-                        onClick={() => setBulkJob(null)}
-                        className="mt-2 text-xs text-red-600 underline cursor-pointer"
-                      >
-                        Try Again
-                      </button>
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-
-            {bulkError && !bulkJob && (
-              <div className="p-3 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-lg text-xs text-red-700 dark:text-red-300">⚠️ {bulkError}</div>
-            )}
-          </div>
-
-          {/* 📄 Level-Wise Paper Generator — Levels_backend batch pipeline */}
-          <div className="bg-white dark:bg-slate-900 border border-zinc-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-4">
-            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-              <div>
-                <h3 className="font-display font-semibold text-zinc-900 dark:text-white text-sm">📄 Level-Wise Paper Generator</h3>
-                <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">Generate personalized level-wise question PDFs for placed students via the Levels_backend batch pipeline.</p>
-              </div>
-              <div className="flex items-center gap-3">
-                <span className="text-xs font-mono font-bold px-2 py-1 rounded bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800">
-                  {classStudents.filter(s => s.levelHistory.length > 0).length} Placed
-                </span>
-                <button
-                  type="button"
-                  onClick={handleGenerateLevelBatch}
-                  disabled={levelBulkLoading}
-                  className="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold text-xs font-mono px-4 py-2.5 rounded-lg transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {levelBulkLoading ? (
-                    <><span className="animate-spin text-sm">⏳</span> Generating...</>
-                  ) : (
-                    <>Generate Batch</>
-                  )}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleDownloadLevelBatch}
-                  disabled={!levelBatchId || levelBatchDownloading}
-                  className="bg-zinc-900 hover:bg-zinc-800 text-white font-semibold text-xs font-mono px-4 py-2.5 rounded-lg transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                  title={levelBatchId ? 'Download the whole batch as a ZIP (worksheet.pdf + answer_key.json + coords.json per student)' : 'Generate a batch first'}
-                >
-                  {levelBatchDownloading ? (
-                    <><span className="animate-spin text-sm">⏳</span> Downloading...</>
-                  ) : (
-                    <>⬇️ Download Batch ZIP</>
-                  )}
-                </button>
-              </div>
-            </div>
-
-            {levelBatchError && (
-              <div className="p-2 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded text-xs text-red-700 dark:text-red-300">⚠️ {levelBatchError}</div>
-            )}
-
-            {levelBatchId && (
-              <div className="pt-2 border-t border-zinc-100 dark:border-zinc-800 space-y-2">
-                <div className="flex justify-between text-xs font-mono text-zinc-500 dark:text-zinc-400">
-                  <span>Batch <span className="text-zinc-800 dark:text-zinc-200 font-semibold">{levelBatchId}</span> — {levelBatchResults.length} file(s) generated</span>
-                  {levelBatchSkipped.length > 0 && (
-                    <span className="text-amber-600 dark:text-amber-400 font-semibold">{levelBatchSkipped.length} skipped</span>
-                  )}
-                </div>
-                {levelBatchResults.length > 0 && (
-                  <div className="max-h-40 overflow-y-auto space-y-1">
-                    {levelBatchResults.map((r, i) => (
-                      <div key={`${r.studentId}-${r.sublevelId}-${r.setNum}-${i}`} className="flex items-center justify-between text-xs bg-zinc-50 dark:bg-zinc-800 border border-zinc-100 dark:border-zinc-700 rounded px-2 py-1">
-                        <span className="text-zinc-700 dark:text-zinc-300 font-medium">{r.studentName} <span className="text-zinc-400 dark:text-zinc-500 font-mono">L{r.sublevelId} set{r.setNum}</span></span>
-                        <a href={withBase(r.pdfUrl)} target="_blank" rel="noreferrer" className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-mono font-bold">View PDF</a>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {levelBatchSkipped.length > 0 && (
-                  <div className="p-2 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded text-xs text-amber-700 dark:text-amber-300">
-                    Skipped: {levelBatchSkipped.map(s => s.reason).join('; ')}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-            </>
-          )}
-
-          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-          {/* Class roster table */}
-          <div className="xl:col-span-2 bg-white dark:bg-slate-900 border border-zinc-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          <div className="bg-white dark:bg-slate-900 border border-zinc-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
             <div className="p-4 border-b border-zinc-150 dark:border-zinc-800 flex justify-between items-center bg-zinc-50/50 dark:bg-zinc-800/50">
               <h3 className="font-display font-medium text-zinc-900 dark:text-white text-sm">
                 {showAllStudents ? `All Students — School Roster (${classStudents.length})` : `Classroom Student Roster (${classStudents.length})`}
               </h3>
-              {!showAllStudents && activeClass && (
-              <button
-                onClick={() => setShowWorksheetPortal(true)}
-                className="bg-white dark:bg-slate-800 hover:bg-zinc-50 dark:hover:bg-zinc-700 border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 font-mono text-[10px] font-bold px-3 py-1.5 rounded-lg shadow-sm cursor-pointer hover:border-zinc-400 transition-colors"
-              >
-                Trigger Worksheets Flow
-              </button>
-              )}
             </div>
             <div className="p-4">
               {(() => {
@@ -630,40 +244,8 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
               })()}
             </div>
           </div>
-
-
-          {/* Quick-action worksheets shortcuts */}
-          <div className="xl:col-span-1 space-y-4">
-            <div className="bg-white dark:bg-slate-900 p-5 border border-zinc-200 dark:border-slate-700 rounded-xl shadow-sm space-y-4">
-              <h4 className="font-display font-medium text-zinc-900 dark:text-white text-sm">Exam Worksheets Engine</h4>
-              <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed">
-                Trigger class-wide personalized mathematics worksheets or grade submitted solution sheets using ICR scanner integrations.
-              </p>
-              <button
-                onClick={() => setShowBulkDiagnostic(true)}
-                className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-mono font-semibold text-xs py-3 rounded-lg transition-colors shadow cursor-pointer flex items-center justify-center gap-2"
-              >
-                <BulkIcon className="w-4 h-4" />
-                Bulk Diagnostic Generator
-              </button>
-              <button
-                onClick={() => setShowWorksheetPortal(true)} // Worksheets flow
-                className="w-full bg-zinc-950 text-white font-mono font-semibold text-xs py-3 rounded-lg hover:bg-zinc-850 transition-colors shadow cursor-pointer animate-pulse"
-              >
-                Open Personalization Portal
-              </button>
-              <button
-                onClick={() => setShowIcrScanner(true)}
-                className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-mono font-semibold text-xs py-3 rounded-lg transition-colors shadow cursor-pointer"
-              >
-                ICR Answer Sheet Scanner
-              </button>
-            </div>
-          </div>
         </div>
-      </div>
       )}
-      <FLNLevelReferenceModal isOpen={showLevelRef} onClose={() => setShowLevelRef(false)} />
       <SkillGraphPanel open={showSkillGraph} onClose={() => setShowSkillGraph(false)} />
     </div>
   );

--- a/frontend/src/components/dashboards/VolunteerDashboard.tsx
+++ b/frontend/src/components/dashboards/VolunteerDashboard.tsx
@@ -6,14 +6,10 @@ import React, { useState, useEffect } from 'react';
 import { apiFetch, withBase } from '../../services/apiClient';
 import { User, Student, ClassGroup, DashboardProps } from '../../types';
 import { DiagnosticWorkflow } from '../DiagnosticWorkflow';
-import { BulkDiagnosticWorkflow } from '../BulkDiagnosticWorkflow';
-import { WorksheetWorkflow } from '../WorksheetWorkflow';
-import { IcrScanner } from '../IcrScanner';
 import { BaselineUpload } from '../BaselineUpload';
 import { SkillGraphPanel } from '../SkillGraphPanel';
 import { Table, Column } from '../Table';
-import { Layers as BulkIcon } from 'lucide-react';
-import { FLNLevelReferenceModal, LevelBadge } from '../RoleDashboards';
+import { LevelBadge } from '../RoleDashboards';
 
 
 export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) => {
@@ -23,23 +19,12 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
 
   const [diagnosticStudent, setDiagnosticStudent] = useState<Student | null>(null);
   const [baselineStudent, setBaselineStudent] = useState<Student | null>(null);
-  const [showWorksheetPortal, setShowWorksheetPortal] = useState(false);
-  const [showLevelRef, setShowLevelRef] = useState(false);
   const [showSkillGraph, setShowSkillGraph] = useState(false);
-  const [showIcrScanner, setShowIcrScanner] = useState(false);
-  const [showBulkDiagnostic, setShowBulkDiagnostic] = useState(false);
 
-  // Inline bulk generation state
-  const [bulkJob, setBulkJob] = useState<{ jobId: string; total: number; completed: number; status: string; pdfUrl: string; downloadUrl: string | null; error: string } | null>(null);
-  const [bulkLoading, setBulkLoading] = useState(false);
-  const [bulkError, setBulkError] = useState('');
-
-  // Level-wise bulk generation state
-  const [levelBulkProgress, setLevelBulkProgress] = useState<{ total: number; completed: number; errors: string[] } | null>(null);
-  const [levelBulkLoading, setLevelBulkLoading] = useState(false);
-
-
-
+  // Issue #166: per-student "Print L{level}.{sub}" action kept on the roster
+  // (it's a per-row interaction, not an operational tool). State below is the
+  // indicator banners + handler — same shape as before, just no longer paired
+  // with the now-removed bulk/level-batch cards.
   const [levelPdfLoading, setLevelPdfLoading] = useState(false);
   const [levelPdfError, setLevelPdfError] = useState('');
 
@@ -89,55 +74,6 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
     fetchVolunteerData();
   }, [token]);
 
-  // Poll bulk job progress
-  useEffect(() => {
-    if (!bulkJob || bulkJob.status !== 'running') return;
-    const interval = setInterval(async () => {
-      try {
-        const res = await apiFetch(`/api/diagnostic/bulk/${bulkJob.jobId}/progress`);
-        if (res.ok) {
-          const data = await res.json();
-          setBulkJob(prev => prev ? { ...prev, completed: data.completed, status: data.status, pdfUrl: data.pdfUrl || prev.pdfUrl, downloadUrl: data.downloadUrl || prev.downloadUrl, error: data.error || '' } : prev);
-          if (data.status !== 'running') clearInterval(interval);
-        } else {
-          clearInterval(interval);
-        }
-      } catch {
-        clearInterval(interval);
-      }
-    }, 1500);
-    return () => clearInterval(interval);
-  }, [bulkJob?.jobId, bulkJob?.status]);
-
-
-
-  if (showBulkDiagnostic) {
-    return (
-      <BulkDiagnosticWorkflow
-        user={user}
-        token={token}
-        userRole={user.role}
-        onBack={() => {
-          setShowBulkDiagnostic(false);
-          fetchVolunteerData();
-        }}
-      />
-    );
-  }
-
-  if (showIcrScanner) {
-    return (
-      <IcrScanner
-        token={token}
-        user={user}
-        onBack={() => {
-          setShowIcrScanner(false);
-          fetchVolunteerData();
-        }}
-      />
-    );
-  }
-
   if (diagnosticStudent) {
     return (
       <DiagnosticWorkflow
@@ -167,45 +103,6 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
 
   const classStudents = activeClass ? students.filter(s => s.classGroup === activeClass.className && s.section === activeClass.section) : [];
 
-  if (showWorksheetPortal) {
-    const effectiveClass = activeClass || (classes.length > 0 ? classes[0] : null);
-    if (effectiveClass) {
-      const effectiveStudents = students.filter(
-        s => s.classGroup === effectiveClass.className && s.section === effectiveClass.section
-      );
-      return (
-        <WorksheetWorkflow
-          classGroup={effectiveClass}
-          students={effectiveStudents}
-          token={token}
-          userRole={user.role}
-          onBack={() => {
-            setShowWorksheetPortal(false);
-            fetchVolunteerData();
-          }}
-        />
-      );
-    } else {
-      return (
-        <div className="p-8 max-w-md mx-auto bg-white dark:bg-slate-900 border border-zinc-200 dark:border-zinc-700 rounded-2xl shadow-sm text-center space-y-4 my-12" id="no-classes-fallback">
-          <div className="w-12 h-12 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center mx-auto">
-            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-            </svg>
-          </div>
-          <h3 className="font-display font-semibold text-zinc-950 dark:text-white text-base">No Classes Found</h3>
-          <p className="text-sm text-zinc-500 dark:text-zinc-400">You must have at least one registered classroom to open the Exam Worksheets Personalization Portal.</p>
-          <button
-            onClick={() => setShowWorksheetPortal(false)}
-            className="px-4 py-2 bg-zinc-950 text-white font-mono font-medium text-xs rounded-lg hover:bg-zinc-850 cursor-pointer animate-pulse"
-          >
-            Go Back
-          </button>
-        </div>
-      );
-    }
-  }
-
   return (
     <div className="space-y-6" id="volunteer-dashboard">
       {levelPdfLoading && (
@@ -225,12 +122,6 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
           <p className="text-zinc-550 dark:text-zinc-400 text-sm mt-0.5 font-medium">Volunteer: {user.name}</p>
         </div>
         <div className="flex gap-2">
-          <button
-            onClick={() => setShowLevelRef(true)}
-            className="bg-white dark:bg-slate-900 hover:bg-zinc-50 dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-200 font-mono text-xs font-semibold px-4 py-2.5 rounded-lg transition-colors cursor-pointer"
-          >
-            📖 93 FLN Framework
-          </button>
           <button
             onClick={() => setShowSkillGraph(true)}
             className="bg-white dark:bg-slate-900 hover:bg-zinc-50 dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-200 font-mono text-xs font-semibold px-4 py-2.5 rounded-lg transition-colors cursor-pointer"
@@ -259,193 +150,20 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
 
       {activeClass && (
         <div className="space-y-6">
-          {/* 📋 Diagnostic Paper Generator */}
-          <div className="bg-white dark:bg-slate-900 border border-zinc-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-4">
-            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-              <div>
-                <h3 className="font-display font-semibold text-zinc-900 dark:text-white text-sm">📋 Diagnostic Paper Generator</h3>
-                <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">Generate baseline diagnostic PDFs for students pending placement.</p>
-              </div>
-              <div className="flex items-center gap-3">
-                <span className="text-xs font-mono font-bold px-2 py-1 rounded bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-800">
-                  {classStudents.filter(s => s.levelHistory.length === 0).length} Pending
-                </span>
-                <button
-                  type="button"
-                  onClick={async () => {
-                    const targets = classStudents.length > 0 ? classStudents : [];
-                    if (targets.length === 0) {
-                      alert('No students found in this class.');
-                      return;
-                    }
-                    const classMatch = activeClass?.className.match(/\d+/);
-                    const classNumber = classMatch ? parseInt(classMatch[0], 10) : 2;
-                    setBulkLoading(true);
-                    setBulkError('');
-                    setBulkJob(null);
-                    try {
-                      const res = await apiFetch('/api/diagnostic/bulk', {
-                        method: 'POST',
-                        headers: {
-                          'Content-Type': 'application/json',
-                          'Authorization': `Bearer ${token}`
-                        },
-                        body: JSON.stringify({ classNumber, students: targets.map(s => ({ name: s.name, studentId: s.id })) })
-                      });
-                      const data = await res.json();
-                      if (res.ok) {
-                        setBulkJob({ ...data, total: targets.length, completed: 0, pdfUrl: data.pdfUrl || '', downloadUrl: data.downloadUrl || null, error: '' });
-                      } else {
-                        setBulkError(data.error || 'Failed to start bulk generation.');
-                      }
-                    } catch {
-                      setBulkError('Network error starting bulk generation.');
-                    } finally {
-                      setBulkLoading(false);
-                    }
-                  }}
-                  disabled={bulkLoading || (bulkJob?.status === 'running')}
-                  className="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-xs font-mono px-4 py-2.5 rounded-lg transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {bulkLoading ? (
-                    <><span className="animate-spin text-sm">⏳</span> Starting...</>
-                  ) : bulkJob?.status === 'running' ? (
-                    <><span className="animate-spin text-sm">⏳</span> Generating...</>
-                  ) : (
-                    <>Generate Diagnostic Papers</>
-                  )}
-                </button>
-              </div>
-            </div>
+          {/* Issue #166: Diagnostic Paper Generator + Level-Wise Paper Generator
+              + Exam Worksheets Engine cards removed from this dashboard. They
+              now live in:
+                - Assessment -> Diagnostic Test (BulkDiagnosticWorkflow + 93 FLN
+                  Framework modal — DiagnosticTestPanel.tsx)
+                - Worksheets (Level-Wise batch generator + Open Personalization
+                  Portal + ICR Answer Sheet Scanner launchers — WorksheetsPanel.tsx)
+              Per-row actions (Run Diagnostic, Upload Sheet, Print L…, 🌐
+              Interactive) remain because they are roster interactions, not
+              operational tools. */}
 
-            {/* Inline diagnostic bulk progress */}
-            {(bulkJob || bulkLoading || bulkError) && (
-              <div className="pt-2 border-t border-zinc-100 dark:border-zinc-800 space-y-3">
-                {bulkError && (
-                  <div className="p-3 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-lg text-xs text-red-700 dark:text-red-300">⚠️ {bulkError}</div>
-                )}
-                {bulkJob && (
-                  <>
-                    <div className="flex justify-between text-xs font-mono text-zinc-500 dark:text-zinc-400">
-                      <span>Progress: {bulkJob.completed} / {bulkJob.total} papers</span>
-                      <span className={`font-semibold ${bulkJob.status === 'running' ? 'text-blue-600 dark:text-blue-400' : bulkJob.status === 'completed' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                        {bulkJob.status === 'running' ? 'Generating...' : bulkJob.status === 'completed' ? 'Ready' : 'Failed'}
-                      </span>
-                    </div>
-                    <div className="w-full bg-zinc-100 dark:bg-zinc-800 rounded-full h-2.5 overflow-hidden">
-                      <div className={`h-full rounded-full transition-all duration-500 ${bulkJob.status === 'completed' ? 'bg-green-500' : bulkJob.status === 'failed' ? 'bg-red-500' : 'bg-blue-500'}`}
-                        style={{ width: `${bulkJob.total > 0 ? Math.round((bulkJob.completed / bulkJob.total) * 100) : 0}%` }} />
-                    </div>
-                    {bulkJob.status === 'completed' && (
-                      <div className="flex gap-2 pt-1">
-                        <a
-                          href={bulkJob.pdfUrl ? withBase(bulkJob.pdfUrl) : bulkJob.downloadUrl ? withBase(bulkJob.downloadUrl) : '#'}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex items-center gap-1.5 bg-green-600 hover:bg-green-700 text-white text-xs font-mono font-bold px-3 py-2 rounded-lg transition-colors cursor-pointer"
-                        >
-                          🖨️ Print / Open PDF ({bulkJob.total} Papers)
-                        </a>
-                      </div>
-                    )}
-                    {bulkJob.status === 'failed' && (
-                      <div className="p-2 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded text-xs text-red-700 dark:text-red-300">{bulkJob.error || 'Generation failed.'}</div>
-                    )}
-                  </>
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* 📄 Level-Wise Paper Generator */}
-          <div className="bg-white dark:bg-slate-900 border border-zinc-200 dark:border-slate-700 rounded-xl p-5 shadow-sm space-y-4">
-            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-              <div>
-                <h3 className="font-display font-semibold text-zinc-900 dark:text-white text-sm">📄 Level-Wise Paper Generator</h3>
-                <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">Generate personalized level-wise question PDFs for placed students.</p>
-              </div>
-              <div className="flex items-center gap-3">
-                <span className="text-xs font-mono font-bold px-2 py-1 rounded bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800">
-                  {classStudents.filter(s => s.levelHistory.length > 0).length} Placed
-                </span>
-                <button
-                  type="button"
-                  onClick={async () => {
-                    const placed = classStudents.filter(s => s.levelHistory.length > 0);
-                    if (placed.length === 0) {
-                      alert('No placed students in this class to generate level-wise papers for.');
-                      return;
-                    }
-
-                    setLevelBulkLoading(true);
-                    setLevelBulkProgress({ total: placed.length, completed: 0, errors: [] });
-                    try {
-                      const res = await apiFetch('/api/worksheets/generate-level-batch', {
-                        method: 'POST',
-                        headers: {
-                          'Content-Type': 'application/json',
-                          'Authorization': `Bearer ${token}`
-                        },
-                        body: JSON.stringify({ studentIds: placed.map(s => s.id) })
-                      });
-                      const data = await res.json();
-                      if (!res.ok || !data.success) {
-                        throw new Error(data.error || 'Batch generation failed.');
-                      }
-                      for (const result of data.results || []) {
-                        window.open(withBase(result.pdfUrl), '_blank');
-                      }
-                      setLevelBulkProgress({ total: placed.length, completed: placed.length, errors: [] });
-                    } catch (err: any) {
-                      setLevelBulkProgress({ total: placed.length, completed: 0, errors: [err.message || 'Network error'] });
-                    } finally {
-                      setLevelBulkLoading(false);
-                    }
-                  }}
-                  disabled={levelBulkLoading}
-                  className="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold text-xs font-mono px-4 py-2.5 rounded-lg transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {levelBulkLoading ? (
-                    <><span className="animate-spin text-sm">⏳</span> Generating...</>
-                  ) : (
-                    <>Generate Level-Wise Papers</>
-                  )}
-                </button>
-              </div>
-            </div>
-
-            {/* Inline level-wise progress */}
-            {levelBulkProgress && (
-              <div className="pt-2 border-t border-zinc-100 dark:border-zinc-800 space-y-3">
-                <div className="flex justify-between text-xs font-mono text-zinc-500 dark:text-zinc-400">
-                  <span>Progress: {levelBulkProgress.completed} / {levelBulkProgress.total} papers</span>
-                  <span className={`font-semibold ${levelBulkLoading ? 'text-blue-600 dark:text-blue-400' : 'text-green-600 dark:text-green-400'}`}>
-                    {levelBulkLoading ? 'Generating...' : 'Done'}
-                  </span>
-                </div>
-                <div className="w-full bg-zinc-100 dark:bg-zinc-800 rounded-full h-2.5 overflow-hidden">
-                  <div className={`h-full rounded-full transition-all duration-500 ${!levelBulkLoading ? 'bg-green-500' : 'bg-blue-500'}`}
-                    style={{ width: `${levelBulkProgress.total > 0 ? Math.round((levelBulkProgress.completed / levelBulkProgress.total) * 100) : 0}%` }} />
-                </div>
-                {levelBulkProgress.errors.length > 0 && (
-                  <div className="p-2 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded text-xs text-red-700 dark:text-red-300">
-                    Errors: {levelBulkProgress.errors.join('; ')}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-
-          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-          <div className="xl:col-span-2 bg-white dark:bg-slate-900 border border-zinc-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
+          <div className="bg-white dark:bg-slate-900 border border-zinc-200 dark:border-slate-700 rounded-xl shadow-sm overflow-hidden">
             <div className="p-4 border-b border-zinc-150 dark:border-zinc-800 flex justify-between items-center bg-zinc-50/50 dark:bg-zinc-800/50">
               <h3 className="font-display font-medium text-zinc-900 dark:text-white text-sm">Classroom Student Roster ({classStudents.length})</h3>
-              <button
-                onClick={() => setShowWorksheetPortal(true)}
-                className="bg-white dark:bg-slate-800 hover:bg-zinc-50 dark:hover:bg-zinc-700 border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 font-mono text-[10px] font-bold px-3 py-1.5 rounded-lg shadow-sm cursor-pointer hover:border-zinc-400 transition-colors"
-              >
-                Trigger Worksheets Flow
-              </button>
             </div>
             <div className="p-4">
               {(() => {
@@ -508,38 +226,8 @@ export const VolunteerDashboard: React.FC<DashboardProps> = ({ user, token }) =>
               })()}
             </div>
           </div>
-
-          <div className="xl:col-span-1 space-y-4">
-            <div className="bg-white dark:bg-slate-900 p-5 border border-zinc-200 dark:border-slate-700 rounded-xl shadow-sm space-y-4">
-              <h4 className="font-display font-medium text-zinc-900 dark:text-white text-sm">Exam Worksheets Engine</h4>
-              <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed">
-                Trigger class-wide personalized mathematics worksheets or grade submitted solution sheets using ICR scanner integrations.
-              </p>
-              <button
-                onClick={() => setShowBulkDiagnostic(true)}
-                className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-mono font-semibold text-xs py-3 rounded-lg transition-colors shadow cursor-pointer flex items-center justify-center gap-2"
-              >
-                <BulkIcon className="w-4 h-4" />
-                Bulk Diagnostic Generator
-              </button>
-              <button
-                onClick={() => setShowWorksheetPortal(true)}
-                className="w-full bg-zinc-950 text-white font-mono font-semibold text-xs py-3 rounded-lg hover:bg-zinc-850 transition-colors shadow cursor-pointer animate-pulse"
-              >
-                Open Personalization Portal
-              </button>
-              <button
-                onClick={() => setShowIcrScanner(true)}
-                className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-mono font-semibold text-xs py-3 rounded-lg transition-colors shadow cursor-pointer"
-              >
-                ICR Answer Sheet Scanner
-              </button>
-            </div>
-          </div>
         </div>
-      </div>
       )}
-      <FLNLevelReferenceModal isOpen={showLevelRef} onClose={() => setShowLevelRef(false)} />
       <SkillGraphPanel open={showSkillGraph} onClose={() => setShowSkillGraph(false)} />
     </div>
   );

--- a/frontend/src/components/panels/DiagnosticTestPanel.tsx
+++ b/frontend/src/components/panels/DiagnosticTestPanel.tsx
@@ -8,7 +8,7 @@ import { Student, User } from '../../types';
 import { PageHeader } from './PanelShared';
 import { ShieldAlert, CheckCircle2, Upload, Timer as TimerIcon } from 'lucide-react';
 import { apiFetch } from '../../services/apiClient';
-import { parseCSVText } from '../RoleDashboards';
+import { parseCSVText, FLNLevelReferenceModal } from '../RoleDashboards';
 import { BulkDiagnosticWorkflow } from '../BulkDiagnosticWorkflow';
 
 interface DiagnosticTestPanelProps {
@@ -29,6 +29,11 @@ export const DiagnosticTestPanel: React.FC<DiagnosticTestPanelProps> = ({ studen
   const [csvImporting, setCsvImporting] = useState(false);
   const [csvResults, setCsvResults] = useState<any>(null);
   const [csvError, setCsvError] = useState('');
+
+  // Issue #166: 93 FLN Framework reference modal — moved here from the
+  // Teacher/Volunteer dashboards so the framework reference lives next to
+  // the diagnostic test where it's actually used for placement decisions.
+  const [showLevelRef, setShowLevelRef] = useState(false);
 
   const handleCsvUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -91,12 +96,20 @@ export const DiagnosticTestPanel: React.FC<DiagnosticTestPanelProps> = ({ studen
       <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <PageHeader title="Upload Class Roster" desc="Bring in a whole class via CSV before generating diagnostic papers" icon={<Upload className="h-5 w-5" />} />
-          <button
-            onClick={() => { setShowCsvImport(!showCsvImport); setCsvResults(null); setCsvError(''); }}
-            className="bg-emerald-700 hover:bg-emerald-600 text-white font-medium text-xs font-mono px-4 py-2.5 rounded-lg transition-colors cursor-pointer shrink-0"
-          >
-            {showCsvImport ? 'Close CSV Import' : '⬆ Bulk Import CSV'}
-          </button>
+          <div className="flex gap-2 shrink-0">
+            <button
+              onClick={() => setShowLevelRef(true)}
+              className="bg-white dark:bg-slate-900 hover:bg-slate-50 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 font-mono text-xs font-semibold px-4 py-2.5 rounded-lg transition-colors cursor-pointer"
+            >
+              📖 93 FLN Framework
+            </button>
+            <button
+              onClick={() => { setShowCsvImport(!showCsvImport); setCsvResults(null); setCsvError(''); }}
+              className="bg-emerald-700 hover:bg-emerald-600 text-white font-medium text-xs font-mono px-4 py-2.5 rounded-lg transition-colors cursor-pointer"
+            >
+              {showCsvImport ? 'Close CSV Import' : '⬆ Bulk Import CSV'}
+            </button>
+          </div>
         </div>
         {showCsvImport && (
           <div className="border-t border-slate-100 dark:border-slate-800 pt-4 space-y-3">
@@ -197,6 +210,8 @@ export const DiagnosticTestPanel: React.FC<DiagnosticTestPanelProps> = ({ studen
           ))}</div>
         </div>
       </div>
+
+      <FLNLevelReferenceModal isOpen={showLevelRef} onClose={() => setShowLevelRef(false)} />
     </div>
   );
 };

--- a/frontend/src/components/panels/StudentListPanel.tsx
+++ b/frontend/src/components/panels/StudentListPanel.tsx
@@ -1,4 +1,7 @@
 // Extracted from frontend/src/components/PanelViews.tsx (issue #144, PR 3).
+// Issue #166: this panel is the canonical home for the "New Registration"
+// (Register New Student) action. The toggle button + form below live here
+// in the Students section; no register-style action exists on the dashboards.
 import React, { useState } from 'react';
 import { Student, User, UserRole } from '../../types';
 import { PageHeader, EmptyStudents } from './PanelShared';

--- a/frontend/src/components/panels/WorksheetsPanel.tsx
+++ b/frontend/src/components/panels/WorksheetsPanel.tsx
@@ -1,11 +1,30 @@
 // Extracted from frontend/src/components/PanelViews.tsx (issue #144, PR 4).
-import React from 'react';
-import { EvaluationReport, Worksheet } from '../../types';
+import React, { useState, useEffect } from 'react';
+import { EvaluationReport, Worksheet, Student, ClassGroup, User } from '../../types';
 import { PageHeader } from './PanelShared';
 import { MetricCard } from '../Card';
 import { ClipboardList, CheckCircle2, FileText } from 'lucide-react';
+import { apiFetch, withBase } from '../../services/apiClient';
+import { WorksheetWorkflow } from '../WorksheetWorkflow';
+import { IcrScanner } from '../IcrScanner';
 
-export const WorksheetsPanel: React.FC<{ reportsList: EvaluationReport[]; worksheetsList: Worksheet[] }> = ({ reportsList, worksheetsList }) => {
+interface WorksheetsPanelProps {
+  reportsList: EvaluationReport[];
+  worksheetsList: Worksheet[];
+  students: Student[];
+  currentUser: User;
+  token: string;
+  refreshStudents: () => void;
+}
+
+export const WorksheetsPanel: React.FC<WorksheetsPanelProps> = ({
+  reportsList,
+  worksheetsList,
+  students,
+  currentUser,
+  token,
+  refreshStudents,
+}) => {
     // Real data: each row is a real Worksheet generation record (created
     // when a teacher runs the Bulk Diagnostic Generator — see
     // backend/src/routes/diagnosticBulk.ts), not the old WORKSHEETS_MOCK
@@ -44,6 +63,166 @@ export const WorksheetsPanel: React.FC<{ reportsList: EvaluationReport[]; worksh
       Pending: 'text-slate-600 dark:text-slate-300 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700',
     };
 
+    // Issue #166 (Step 2): level-wise batch generator + worksheet personalization
+    // portal launcher + ICR scanner launcher moved here from the Teacher/Volunteer
+    // dashboards. The dashboards no longer render those operational cards — they
+    // now live in the destination they conceptually belong to.
+    const [classes, setClasses] = useState<ClassGroup[]>([]);
+    const [activeClass, setActiveClass] = useState<ClassGroup | null>(null);
+
+    // Sub-view state: when either of these is set we render the full-screen
+    // sub-component instead of the panel overview, with a back button on each.
+    const [showPersonalizationPortal, setShowPersonalizationPortal] = useState(false);
+    const [showIcrScanner, setShowIcrScanner] = useState(false);
+
+    // Level-Wise Paper Generator state — same shape as the dashboard's old inline
+    // implementation, lifted here unchanged (reuses the existing API surface).
+    const [levelBatchId, setLevelBatchId] = useState<string | null>(null);
+    const [levelBatchResults, setLevelBatchResults] = useState<Array<{ studentId: string; studentName: string; sublevelId: string; setNum: number; pdfUrl: string }>>([]);
+    const [levelBatchSkipped, setLevelBatchSkipped] = useState<Array<{ studentId: string; reason: string }>>([]);
+    const [levelBatchError, setLevelBatchError] = useState('');
+    const [levelBatchDownloading, setLevelBatchDownloading] = useState(false);
+    const [levelBulkLoading, setLevelBulkLoading] = useState(false);
+
+    // Fetch the caller's classes — same source the dashboards use, just moved here
+    // so this panel can drive the level-wise generator + WorksheetWorkflow.
+    useEffect(() => {
+      const fetchClasses = async () => {
+        try {
+          const clsRes = await apiFetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } });
+          const clsData = await clsRes.json();
+          if (Array.isArray(clsData)) {
+            setClasses(clsData);
+            if (clsData.length > 0) setActiveClass(clsData[0]);
+          }
+        } catch (err) {
+          console.error(err);
+        }
+      };
+      fetchClasses();
+    }, [token]);
+
+    const classStudents = activeClass
+      ? students.filter(s => s.classGroup === activeClass.className && s.section === activeClass.section)
+      : [];
+
+    // "Generate Batch" — sends every placed student's id to the backend, which
+    // forwards it to the Levels_backend service. Same handler the dashboard
+    // used to inline; preserved verbatim per #166's "no duplicate implementations"
+    // rule.
+    const handleGenerateLevelBatch = async () => {
+      const placed = classStudents.filter(s => s.levelHistory.length > 0);
+      if (placed.length === 0) {
+        alert('No placed students in this class to generate level-wise papers for.');
+        return;
+      }
+      setLevelBulkLoading(true);
+      setLevelBatchError('');
+      setLevelBatchResults([]);
+      setLevelBatchSkipped([]);
+      setLevelBatchId(null);
+      try {
+        const res = await apiFetch('/api/worksheets/generate-level-batch', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+          },
+          body: JSON.stringify({ studentIds: placed.map(s => s.id) })
+        });
+        const data = await res.json();
+        if (res.ok && data.success) {
+          setLevelBatchId(data.batchId);
+          setLevelBatchResults(data.results || []);
+          setLevelBatchSkipped(data.skipped || []);
+        } else {
+          setLevelBatchError(data.error || 'Batch generation failed.');
+        }
+      } catch {
+        setLevelBatchError('Network error generating the batch.');
+      } finally {
+        setLevelBulkLoading(false);
+      }
+    };
+
+    // "Download Batch ZIP" — streams the batch ZIP (every student's
+    // worksheet.pdf + answer_key.json + coords.json) from Levels_backend.
+    const handleDownloadLevelBatch = async () => {
+      if (!levelBatchId) return;
+      setLevelBatchDownloading(true);
+      try {
+        const res = await apiFetch(`/api/worksheets/download-batch/${levelBatchId}`);
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || 'Download failed.');
+        }
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `batch_${levelBatchId}.zip`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      } catch (err: any) {
+        setLevelBatchError(err.message || 'Failed to download batch ZIP.');
+      } finally {
+        setLevelBatchDownloading(false);
+      }
+    };
+
+    // Sub-view: ICR Scanner — full-screen, with a Back to Worksheets button.
+    if (showIcrScanner) {
+      return (
+        <IcrScanner
+          token={token}
+          user={currentUser}
+          onBack={() => {
+            setShowIcrScanner(false);
+            refreshStudents();
+          }}
+        />
+      );
+    }
+
+    // Sub-view: Personalization Portal — full-screen WorksheetWorkflow scoped
+    // to the selected class. Falls through to the "no classes" panel if the
+    // caller has no classGroups (mirrors the dashboards' old fallback).
+    if (showPersonalizationPortal) {
+      if (activeClass) {
+        return (
+          <WorksheetWorkflow
+            classGroup={activeClass}
+            students={classStudents}
+            token={token}
+            userRole={currentUser.role}
+            onBack={() => {
+              setShowPersonalizationPortal(false);
+              refreshStudents();
+            }}
+          />
+        );
+      }
+      return (
+        <div className="p-8 max-w-md mx-auto bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-sm text-center space-y-4 my-12" id="no-classes-fallback">
+          <div className="w-12 h-12 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-full flex items-center justify-center mx-auto">
+            <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <h3 className="font-display font-semibold text-slate-900 dark:text-white text-base">No Classes Found</h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">You must have at least one registered classroom to open the Exam Worksheets Personalization Portal.</p>
+          <button
+            onClick={() => setShowPersonalizationPortal(false)}
+            className="px-4 py-2 bg-slate-900 text-white font-mono font-medium text-xs rounded-lg hover:bg-slate-800 cursor-pointer animate-pulse"
+          >
+            Go Back
+          </button>
+        </div>
+      );
+    }
+
     return (
       <div className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -64,6 +243,118 @@ export const WorksheetsPanel: React.FC<{ reportsList: EvaluationReport[]; worksh
               </div>
             ))}
           </div>
+        </div>
+
+        {/* Issue #166: Level-Wise Paper Generator — moved from the Teacher/Volunteer
+            dashboards so the worksheet-generation tools live in the Worksheets
+            destination, where they belong. Same API surface, same handler shape
+            (handleGenerateLevelBatch + handleDownloadLevelBatch). */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+            <PageHeader title="Level-Wise Paper Generator" desc="Generate personalized level-wise question PDFs for placed students via the Levels_backend batch pipeline" />
+            <div className="flex items-center gap-2 shrink-0">
+              {classes.length > 1 && (
+                <select
+                  value={activeClass?.id ?? ''}
+                  onChange={(e) => {
+                    const next = classes.find(c => c.id === e.target.value);
+                    if (next) {
+                      setActiveClass(next);
+                      setLevelBatchId(null);
+                      setLevelBatchResults([]);
+                      setLevelBatchSkipped([]);
+                    }
+                  }}
+                  className="text-xs font-mono border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 rounded-lg px-2 py-2 outline-none focus:border-indigo-500"
+                >
+                  {classes.map(c => (
+                    <option key={c.id} value={c.id}>{c.className} - {c.section}</option>
+                  ))}
+                </select>
+              )}
+              <span className="text-xs font-mono font-bold px-2 py-1 rounded bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800">
+                {classStudents.filter(s => s.levelHistory.length > 0).length} Placed
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={handleGenerateLevelBatch}
+              disabled={levelBulkLoading || !activeClass}
+              className="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold text-xs font-mono px-4 py-2.5 rounded-lg transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {levelBulkLoading ? (
+                <><span className="animate-spin text-sm">⏳</span> Generating...</>
+              ) : (
+                <>Generate Batch</>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={handleDownloadLevelBatch}
+              disabled={!levelBatchId || levelBatchDownloading}
+              className="bg-slate-900 hover:bg-slate-800 text-white font-semibold text-xs font-mono px-4 py-2.5 rounded-lg transition-colors cursor-pointer flex items-center gap-1.5 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              title={levelBatchId ? 'Download the whole batch as a ZIP (worksheet.pdf + answer_key.json + coords.json per student)' : 'Generate a batch first'}
+            >
+              {levelBatchDownloading ? (
+                <><span className="animate-spin text-sm">⏳</span> Downloading...</>
+              ) : (
+                <>⬇️ Download Batch ZIP</>
+              )}
+            </button>
+          </div>
+
+          {levelBatchError && (
+            <div className="p-2 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded text-xs text-red-700 dark:text-red-300">⚠️ {levelBatchError}</div>
+          )}
+
+          {levelBatchId && (
+            <div className="pt-2 border-t border-slate-100 dark:border-slate-800 space-y-2">
+              <div className="flex justify-between text-xs font-mono text-slate-500 dark:text-slate-400">
+                <span>Batch <span className="text-slate-800 dark:text-slate-200 font-semibold">{levelBatchId}</span> — {levelBatchResults.length} file(s) generated</span>
+                {levelBatchSkipped.length > 0 && (
+                  <span className="text-amber-600 dark:text-amber-400 font-semibold">{levelBatchSkipped.length} skipped</span>
+                )}
+              </div>
+              {levelBatchResults.length > 0 && (
+                <div className="max-h-40 overflow-y-auto space-y-1">
+                  {levelBatchResults.map((r, i) => (
+                    <div key={`${r.studentId}-${r.sublevelId}-${r.setNum}-${i}`} className="flex items-center justify-between text-xs bg-slate-50 dark:bg-slate-800 border border-slate-100 dark:border-slate-700 rounded px-2 py-1">
+                      <span className="text-slate-700 dark:text-slate-300 font-medium">{r.studentName} <span className="text-slate-400 dark:text-slate-500 font-mono">L{r.sublevelId} set{r.setNum}</span></span>
+                      <a href={withBase(r.pdfUrl)} target="_blank" rel="noreferrer" className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-mono font-bold">View PDF</a>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {levelBatchSkipped.length > 0 && (
+                <div className="p-2 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded text-xs text-amber-700 dark:text-amber-300">
+                  Skipped: {levelBatchSkipped.map(s => s.reason).join('; ')}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Issue #166: Worksheet Engine launchers — moved from the dashboard's
+            floating "Exam Worksheets Engine" side panel. Each is a full-screen
+            sub-view with a Back button so the user returns to this panel. */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <button
+            onClick={() => setShowPersonalizationPortal(true)}
+            disabled={classes.length === 0}
+            className="bg-slate-900 hover:bg-slate-800 text-white font-mono font-semibold text-xs py-4 rounded-xl transition-colors shadow cursor-pointer animate-pulse disabled:opacity-50 disabled:cursor-not-allowed"
+            title={classes.length === 0 ? 'No classes available' : 'Open the Personalized Worksheet Management flow for the selected class'}
+          >
+            📄 Open Personalization Portal
+          </button>
+          <button
+            onClick={() => setShowIcrScanner(true)}
+            className="bg-emerald-600 hover:bg-emerald-700 text-white font-mono font-semibold text-xs py-4 rounded-xl transition-colors shadow cursor-pointer"
+          >
+            🖨 ICR Answer Sheet Scanner
+          </button>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Implements Issue #166 by removing operational tools from the Teacher and Volunteer dashboards and moving their functionality to the appropriate existing destinations.

## Changes

- Removed Diagnostic Paper Generator from Teacher and Volunteer dashboards.
- Removed Level-Wise Paper Generator from Teacher and Volunteer dashboards.
- Removed the Exam Worksheets Engine from both dashboards.
- Moved level-wise batch generation into the Worksheets page.
- Added Personalization Portal access to Worksheets.
- Added ICR Answer Sheet Scanner access to Worksheets.
- Moved the 93 FLN Framework entry point to Diagnostic Test.
- Kept Register New Student in the Students section.
- Preserved per-student dashboard actions such as Run Diagnostic, Upload Sheet, Print, and Interactive.
- No backend/API changes.

## Verification

- Frontend and backend production builds pass.
- `git diff --check` passes.
- Teacher dashboard manually verified.
- Worksheets destination manually verified.
- ICR Scanner opens correctly.
- Diagnostic Test destination manually verified.
- Student registration destination manually verified.

Closes #166