### PR TITLE
fix: paginated tables no longer render one button per page

### DIFF
--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -100,6 +100,26 @@ export function Table<T extends Record<string, any>>({
     return processedData.slice(start, start + rowsPerPage);
   }, [processedData, currentPage, rowsPerPage]);
 
+  // Build a windowed page list (first, last, current +/- 1) with '...' gaps,
+  // so wide datasets don't render one button per page (was 645 buttons at 6450 rows).
+  const pageItems = useMemo(() => {
+    const delta = 1;
+    const pages: (number | 'ellipsis')[] = [];
+    const range: number[] = [];
+
+    for (let i = Math.max(2, currentPage - delta); i <= Math.min(totalPages - 1, currentPage + delta); i++) {
+      range.push(i);
+    }
+
+    pages.push(1);
+    if (range[0] > 2) pages.push('ellipsis');
+    pages.push(...range);
+    if (range[range.length - 1] < totalPages - 1) pages.push('ellipsis');
+    if (totalPages > 1) pages.push(totalPages);
+
+    return pages;
+  }, [currentPage, totalPages]);
+
   const handleFilterChange = (key: string, value: string) => {
     setActiveFilters(prev => ({ ...prev, [key]: value }));
     setCurrentPage(1);
@@ -289,19 +309,28 @@ export function Table<T extends Record<string, any>>({
             >
               Previous
             </button>
-            {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => (
-              <button
-                key={page}
-                onClick={() => setCurrentPage(page)}
-                className={`px-3 py-1.5 text-xs font-bold rounded-lg border transition cursor-pointer ${
-                  currentPage === page
-                    ? 'bg-indigo-600 text-white border-indigo-600 shadow-sm'
-                    : 'bg-white text-slate-700 border-slate-200 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-300 dark:border-slate-700 dark:hover:bg-slate-800'
-                }`}
-              >
-                {page}
-              </button>
-            ))}
+            {pageItems.map((item, idx) =>
+              item === 'ellipsis' ? (
+                <span
+                  key={`ellipsis-${idx}`}
+                  className="px-2 py-1.5 text-xs font-mono text-slate-400 dark:text-slate-600 select-none"
+                >
+                  &hellip;
+                </span>
+              ) : (
+                <button
+                  key={item}
+                  onClick={() => setCurrentPage(item)}
+                  className={`px-3 py-1.5 text-xs font-bold rounded-lg border transition cursor-pointer ${
+                    currentPage === item
+                      ? 'bg-indigo-600 text-white border-indigo-600 shadow-sm'
+                      : 'bg-white text-slate-700 border-slate-200 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-300 dark:border-slate-700 dark:hover:bg-slate-800'
+                  }`}
+                >
+                  {item}
+                </button>
+              )
+            )}
             <button
               onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages))}
               disabled={currentPage === totalPages}


### PR DESCRIPTION
## Problem

Reported live on the Superadmin dashboard: Coordinator Management (Registered Coordinators view) has 6450 records. At 10 rows/page that's 645 pages, and the shared `Table` component (`frontend/src/components/Table.tsx`) rendered **one button per page** in a single row. The `Next` button technically exists in the code but gets pushed far off-screen by ~645 page buttons before it, so it's effectively unreachable without a long horizontal scroll — this is what showed up as "no forward/backward navigation" in the screenshot.

## Fix

Replaced the full `Array.from({length: totalPages})` page list with a **windowed pagination** pattern: always show page 1 and the last page, plus up to 1 page on either side of the current page, with `…` filling any gaps. `Previous`/`Next` were already implemented and functional — they just needed the page-number row to stop crowding them off-screen.

Example at page 12 of 645: `1 … 11 12 13 … 645`

## Scope

This is the single shared `Table` component used across the superadmin dashboard (coordinators, schools, teachers, etc.), so the fix applies everywhere large paginated lists are shown, not just Coordinator Management.

## Testing

- `tsc --noEmit` clean
- `vite build` clean, no new warnings
- Not yet verified against a live 6450-row dataset in the browser — recommend a quick visual check on Coordinator Management before merge

Reported by Jinal via screenshot of the Superadmin > Coordinator Management > Registered Coordinators view (6450 records, page-button row overflowing off-screen, Next unreachable).