### PR TITLE
fix: /api/admin/create never saved a real password for new accounts

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import bcrypt from 'bcrypt';
 import { dbStore, UserRole, User } from '../db';
 import { getAuthUser, sanitizeUser } from '../auth';
 
@@ -33,6 +34,7 @@ export function registerAdminRoutes(app: express.Express) {
       name,
       email: email.toLowerCase(),
       role: role as UserRole,
+      passwordHash: await bcrypt.hash(password, 10),
       stateCode: stateCode ? stateCode.toUpperCase() : undefined,
       districtCode: districtCode ? districtCode.toUpperCase() : undefined,
       blockCode: blockCode ? blockCode.toUpperCase() : undefined,


### PR DESCRIPTION
## Problem

Reported live: a teacher account (`j.gupta05072003@gmail.com`, created via Superadmin → Coordinator Management → Register New Coordinator, role = Teacher) got **"Invalid email or password"** when logging in with the password that was set at creation time.

Root cause is in `backend/src/routes/admin.ts`, `POST /api/admin/create` (the endpoint the "Register New Coordinator" form calls — it creates any role including Teacher, not just coordinators):

- The handler validates the submitted password's complexity.
- It then builds the new `User` object **without ever calling `bcrypt.hash()` or setting `passwordHash`** — the field is just absent.
- On login (`routes/auth.ts:34`), the password check does:
  ```ts
  const targetHash = user.passwordHash || SEED_DEMO_PASSWORD_HASH;
  ```
  So any account created through this form silently falls back to only accepting the shared seed demo password, never the password actually entered in the form.

The sibling endpoint `POST /api/teachers` (self-service coordinator → teacher registration, `routes/teachers.ts`) already does this correctly (`passwordHash: await bcrypt.hash(password, 10)`), so this PR just brings `/api/admin/create` in line with it.

## Fix

Added the same `bcrypt.hash(password, 10)` call and set it as `passwordHash` on the new user record.

## Note on already-affected accounts

Any account created through this form **before** this fix (including the reported teacher account) still has no `passwordHash` in the database. Because of the fallback line above, those accounts can currently log in with the seed demo password instead of their real one. This PR does not backfill existing records — worth a follow-up if there are other affected accounts beyond the one reported.

## Testing

- `tsc`/esbuild backend build clean (`node --check dist/server.cjs` passed)
- Not yet reproduced against a live login in the browser — recommend verifying with a fresh test account before/after merge