### PR TITLE
fix: remove one-click Reset Database button from Superadmin dashboard

### DIFF
--- a/frontend/src/components/dashboards/SuperadminDashboard.tsx
+++ b/frontend/src/components/dashboards/SuperadminDashboard.tsx
@@ -294,17 +294,6 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
           </button>
         </div>
 
-        {/* DB Reset for easy demo */}
-        <button
-          onClick={async () => {
-            if (!window.confirm('Reset all database data to fresh seed state? This is irreversible.')) return;
-            await apiFetch('/api/reset', { method: 'POST' });
-            window.location.reload();
-          }}
-          className="px-3 py-1.5 text-xs font-mono font-bold rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-300 hover:bg-red-100 dark:hover:bg-red-900 transition-colors"
-        >
-          🔄 Reset Database
-        </button>
       </div>
 
       {activeTab === 'overview' && (


### PR DESCRIPTION
## Problem

The Superadmin dashboard (National Oversight Center) has a "🔄 Reset Database" button in the top-right corner. It calls `POST /api/reset`, which (`backend/src/routes/admin.ts:181` → `db.ts:658` `dbStore.reset()`) **deletes every document in every collection** in the live MongoDB Atlas database and re-inserts only the original hardcoded seed dataset.

One click plus a single `window.confirm()` popup is enough to permanently wipe every coordinator, teacher, student, class, worksheet, and evaluation record created since launch — including accounts registered live during testing (this is exactly how it was found: asked what the button does while looking at a real teacher account created earlier today).

With internal pilot testing starting Monday, this button sitting in production is a live data-loss risk for a single misclick.

## Fix

Removed the button and its handler from `SuperadminDashboard.tsx`. The backend `/api/reset` route is left in place (still superadmin-only) in case an intentional reset is ever needed via a direct API call in dev/staging — this PR only removes the one-click UI exposure in production.

## Testing

- `tsc --noEmit` clean
- `vite build` clean
- Confirmed `apiFetch` import still used elsewhere in the file (no dead import left behind)