### PR TITLE
feat: add Scan & Upload to Bulk Diagnostic tab; remove exam timer for pilot

### DIFF
--- a/frontend/src/components/BulkDiagnosticWorkflow.tsx
+++ b/frontend/src/components/BulkDiagnosticWorkflow.tsx
@@ -2,6 +2,7 @@ import { apiFetch, withBase } from '../services/apiClient';
 import React, { useState, useEffect } from 'react';
 import { UserRole } from '../types';
 import { FileText, Download, Clock, AlertCircle, CheckCircle2, XCircle } from 'lucide-react';
+import { IcrScanner } from './IcrScanner';
 
 interface BulkDiagnosticWorkflowProps {
   user: any;
@@ -31,6 +32,11 @@ export const BulkDiagnosticWorkflow: React.FC<BulkDiagnosticWorkflowProps> = ({ 
   const [job, setJob] = useState<JobStatus | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  // Scan & Upload is independent of `job` on purpose — in a pilot, an
+  // answer sheet can come back hours or a day after the paper was printed,
+  // long after `job` (in-memory, reset on refresh) is gone. Keep this
+  // reachable regardless of any current generation job's state.
+  const [showIcrScanner, setShowIcrScanner] = useState(false);
 
   // Fetch enrolled students when classLevel changes
   useEffect(() => {
@@ -141,6 +147,17 @@ export const BulkDiagnosticWorkflow: React.FC<BulkDiagnosticWorkflowProps> = ({ 
   };
 
   const progressPercent = job ? Math.round((job.completed / job.totalStudents) * 100) : 0;
+
+  // Sub-view: ICR Scanner — full-screen, with a Back to Bulk Generator button.
+  if (showIcrScanner) {
+    return (
+      <IcrScanner
+        token={token}
+        user={user}
+        onBack={() => setShowIcrScanner(false)}
+      />
+    );
+  }
 
   return (
     <div className="max-w-3xl mx-auto space-y-6 animate-fade-in" id="bulk-diagnostic-workflow">
@@ -302,6 +319,28 @@ export const BulkDiagnosticWorkflow: React.FC<BulkDiagnosticWorkflowProps> = ({ 
           )}
         </div>
       )}
+
+      {/*
+        Scan & Upload — deliberately NOT gated on `job` or its status.
+        In pilot testing an answer sheet can come back hours or a full day
+        after the paper was generated, well after this component's local
+        `job` state (or the whole browser session) is gone. This has to
+        stay reachable on its own, every time this panel is open.
+      */}
+      <div className="bg-white dark:bg-slate-900 border border-zinc-200 dark:border-zinc-700 rounded-2xl p-6 shadow-sm">
+        <h3 className="font-display font-medium text-zinc-900 dark:text-white mb-1">
+          Scan &amp; Upload Answer Sheet
+        </h3>
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-4">
+          Once a student's answer sheet is filled in — whether that's today or a few days from now — scan it here to evaluate it.
+        </p>
+        <button
+          onClick={() => setShowIcrScanner(true)}
+          className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-mono font-semibold text-xs py-4 rounded-xl transition-colors shadow cursor-pointer"
+        >
+          🖨 Scan &amp; Upload Answer Sheet
+        </button>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/panels/DiagnosticTestPanel.tsx
+++ b/frontend/src/components/panels/DiagnosticTestPanel.tsx
@@ -1,12 +1,13 @@
 // Issue #175: rebuild — CSV upload (feeds #178's real bulk-import endpoint),
 // then the existing BulkDiagnosticWorkflow (reused as-is, not rewritten —
-// it already calls the real POST /api/diagnostic/bulk route), plus a simple
-// on-screen exam timer. Pending/Completed lists kept below as supplementary
-// context, same data as before.
-import React, { useState, useEffect, useRef } from 'react';
+// it already calls the real POST /api/diagnostic/bulk route). Pending/
+// Completed lists kept below as supplementary context, same data as before.
+// The exam timer that used to live here was removed for the pilot phase —
+// it wasn't wired to anything and pilot testing isn't timing exams.
+import React, { useState } from 'react';
 import { Student, User } from '../../types';
 import { PageHeader } from './PanelShared';
-import { ShieldAlert, CheckCircle2, Upload, Timer as TimerIcon } from 'lucide-react';
+import { ShieldAlert, CheckCircle2, Upload } from 'lucide-react';
 import { apiFetch } from '../../services/apiClient';
 import { parseCSVText, FLNLevelReferenceModal } from '../RoleDashboards';
 import { BulkDiagnosticWorkflow } from '../BulkDiagnosticWorkflow';
@@ -17,8 +18,6 @@ interface DiagnosticTestPanelProps {
   token: string;
   refreshStudents: () => void;
 }
-
-const TIMER_PRESETS_MIN = [15, 30, 45, 60];
 
 export const DiagnosticTestPanel: React.FC<DiagnosticTestPanelProps> = ({ students, currentUser, token, refreshStudents }) => {
   const pending = students.filter(s => s.levelHistory.length === 0);
@@ -63,32 +62,6 @@ export const DiagnosticTestPanel: React.FC<DiagnosticTestPanelProps> = ({ studen
       e.target.value = '';
     }
   };
-
-  // Simple exam timer — purely client-side, no backend dependency. Counts
-  // down from a chosen duration for the in-class exam window.
-  const [timerMinutes, setTimerMinutes] = useState(30);
-  const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
-  const [timerRunning, setTimerRunning] = useState(false);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => {
-    if (timerRunning && secondsLeft !== null && secondsLeft > 0) {
-      intervalRef.current = setInterval(() => {
-        setSecondsLeft(s => (s !== null && s > 0 ? s - 1 : 0));
-      }, 1000);
-    }
-    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
-  }, [timerRunning, secondsLeft === null]);
-
-  useEffect(() => {
-    if (secondsLeft === 0) setTimerRunning(false);
-  }, [secondsLeft]);
-
-  const startTimer = () => { setSecondsLeft(timerMinutes * 60); setTimerRunning(true); };
-  const pauseTimer = () => setTimerRunning(false);
-  const resumeTimer = () => { if (secondsLeft && secondsLeft > 0) setTimerRunning(true); };
-  const resetTimer = () => { setTimerRunning(false); setSecondsLeft(null); };
-  const formatTime = (s: number) => `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
 
   return (
     <div className="space-y-6">
@@ -139,45 +112,6 @@ export const DiagnosticTestPanel: React.FC<DiagnosticTestPanelProps> = ({ studen
             )}
           </div>
         )}
-      </div>
-
-      {/* Exam timer */}
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-4">
-        <PageHeader title="Exam Timer" desc="A simple on-screen timer for the in-class exam window" icon={<TimerIcon className="h-5 w-5" />} />
-        <div className="flex flex-wrap items-center gap-4">
-          <div className="flex gap-2">
-            {TIMER_PRESETS_MIN.map(m => (
-              <button
-                key={m}
-                onClick={() => setTimerMinutes(m)}
-                disabled={secondsLeft !== null}
-                className={`px-3 py-1.5 text-xs font-mono font-bold rounded border transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
-                  timerMinutes === m ? 'bg-slate-900 dark:bg-white text-white dark:text-slate-900 border-transparent' : 'bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300'
-                }`}
-              >
-                {m}m
-              </button>
-            ))}
-          </div>
-          <div className="font-mono text-2xl font-bold text-slate-900 dark:text-white tabular-nums">
-            {secondsLeft !== null ? formatTime(secondsLeft) : `${String(timerMinutes).padStart(2, '0')}:00`}
-          </div>
-          <div className="flex gap-2">
-            {secondsLeft === null && (
-              <button onClick={startTimer} className="bg-emerald-700 hover:bg-emerald-600 text-white font-mono text-xs font-bold px-4 py-2 rounded-lg transition-colors">Start</button>
-            )}
-            {secondsLeft !== null && secondsLeft > 0 && timerRunning && (
-              <button onClick={pauseTimer} className="bg-amber-600 hover:bg-amber-700 text-white font-mono text-xs font-bold px-4 py-2 rounded-lg transition-colors">Pause</button>
-            )}
-            {secondsLeft !== null && secondsLeft > 0 && !timerRunning && (
-              <button onClick={resumeTimer} className="bg-emerald-700 hover:bg-emerald-600 text-white font-mono text-xs font-bold px-4 py-2 rounded-lg transition-colors">Resume</button>
-            )}
-            {secondsLeft !== null && (
-              <button onClick={resetTimer} className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 font-mono text-xs font-bold px-4 py-2 rounded-lg transition-colors">Reset</button>
-            )}
-          </div>
-          {secondsLeft === 0 && <span className="text-xs font-mono font-bold text-red-600 dark:text-red-400">⏰ Time's up</span>}
-        </div>
       </div>
 
       {/* Bulk diagnostic generation — reuses the existing, already-working


### PR DESCRIPTION
## Context

Two decisions made ahead of Monday's friend-and-family pilot:

### 1. Scan & Upload was unreachable from Bulk Diagnostic

The ICR Scanner only existed in the Worksheets tab (added back by issue #166's dashboard cleanup). A teacher generating a bulk diagnostic paper had no path back to scanning the completed answer sheet without knowing to switch tabs.

**Fix:** added a permanent "Scan & Upload Answer Sheet" button below `BulkDiagnosticWorkflow`'s job status, reusing `IcrScanner` unchanged (same component `WorksheetsPanel.tsx` already uses).

**Deliberately not gated on `job`/`job.status === 'completed'`.** In pilot testing, an answer sheet can come back hours — or a full day — after the paper was printed, well after the in-memory `job` state (or the whole browser session) that generated it is gone. Gating the button on that state would make it disappear exactly when it's needed. It's always visible whenever this panel is open.

### 2. Exam timer removed (not relabeled)

`DiagnosticTestPanel.tsx` had a standalone client-side countdown timer — no backend call, not tied to any job/student/session record, resets on refresh. It never enforced anything; it was just a stopwatch sitting next to the paper generator.

Since the pilot isn't timing exams, this was pure clutter and a likely source of confusion for testers wondering what it was for. Removed the widget, its state/effects, and the now-unused imports (`useEffect`, `useRef`, `Timer` icon, `TIMER_PRESETS_MIN`) entirely rather than relabeling it — nothing here needs to be preserved for a future "real" timer; that would be built fresh, server-side, if ever needed.

## Files changed

- `frontend/src/components/BulkDiagnosticWorkflow.tsx` — added `IcrScanner` import, `showIcrScanner` state, full-screen sub-view (mirrors `WorksheetsPanel.tsx`'s pattern), and the permanent Scan & Upload card.
- `frontend/src/components/panels/DiagnosticTestPanel.tsx` — removed the timer block, its state/effects, and unused imports.

## Testing

- `tsc --noEmit` clean
- `vite build` clean, no new warnings
- Not yet clicked through live in the browser — recommend a quick pass confirming the Scan & Upload button opens the scanner correctly from Diagnostic Test, and that removing the timer didn't affect the CSV upload / pending-completed lists above and below it in the same panel.