### PR TITLE
fix: remove /api/classes nationwide fallback for zero-class teachers

### DIFF
--- a/backend/src/routes/classes.ts
+++ b/backend/src/routes/classes.ts
@@ -11,10 +11,10 @@ export function registerClassRoutes(app: express.Express) {
     if (user.role === UserRole.SUPERADMIN || user.role === UserRole.ADMIN || user.role === UserRole.DISTRICT_ADMIN || user.role === UserRole.BLOCK_ADMIN) {
       return res.json(classes);
     }
-    let filtered = classes.filter(c => c.schoolId === user.schoolId || (user.assignedSchools && user.assignedSchools.includes(c.schoolId || '')));
-    if (filtered.length === 0) {
-      filtered = classes;
-    }
+    // A teacher/school-scoped user with zero classes should see an empty
+    // list — that's a correct, expected state for a new account, not a
+    // reason to widen scope to every class in the database (issue #291).
+    const filtered = classes.filter(c => c.schoolId === user.schoolId || (user.assignedSchools && user.assignedSchools.includes(c.schoolId || '')));
     res.json(filtered);
   });
 

--- a/frontend/src/components/dashboards/TeacherDashboard.tsx
+++ b/frontend/src/components/dashboards/TeacherDashboard.tsx
@@ -59,8 +59,13 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
       const clsRes = await apiFetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` } });
       const clsData = await clsRes.json();
       if (Array.isArray(clsData)) {
-        setClasses(clsData);
-        if (clsData.length > 0) setActiveClass(clsData[0]);
+        // Defensive scope check (issue #291) — the backend is the source of
+        // truth for scoping, but a teacher's own class-tab bar should never
+        // render another school's classes even if a future backend change
+        // regresses.
+        const scoped = clsData.filter((c: ClassGroup) => c.schoolId === user.schoolId);
+        setClasses(scoped);
+        if (scoped.length > 0) setActiveClass(scoped[0]);
       }
 
       const stdRes = await apiFetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });


### PR DESCRIPTION
Closes #291

## Problem

`backend/src/routes/classes.ts:14-17` fell back to returning **every class in the database** whenever a school-scoped user had zero classes assigned to their own school:

```js
if (filtered.length === 0) {
  filtered = classes;
}
```

A brand-new teacher account (0 real classes) got every "Class 1"–"Class 4" × Section "A" across every seeded school in every state — reported live as what looked like an infinite/duplicated column loop on the Teacher Dashboard's class-tab bar.

## Fix

- **Backend:** removed the fallback entirely. An empty result for a teacher with no classes is the correct answer.
- **Frontend (`TeacherDashboard.tsx`):** added a defensive client-side filter (`c.schoolId === user.schoolId`) on the class-tab bar as a second line of defense, so a future backend regression on this route can't reproduce the same symptom.

## Testing

- `tsc --noEmit` and backend build both clean.
- Verified live against a local isolated MongoDB (not production): created a fresh teacher account scoped to a school with 0 classes. Before the fix this would have returned all 20 seeded classes nationwide; confirmed the fix now returns `[]`.