### PR TITLE
fix: remove hardcoded STUDENTS_FALLBACK demo data

### DIFF
--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -45,7 +45,7 @@ const CONTENT_ITEMS = [
 
 export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser, token }) => {
   const {
-    students, schools, usersList, reportsList, worksheetsList, teachersList,
+    students, studentsLoading, schools, usersList, reportsList, worksheetsList, teachersList,
     getDistrictStats, getBlockStats, updateStudentLocally, refreshStudents,
   } = usePanelData(token, currentUser, activePanel);
 
@@ -56,6 +56,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
     return (
       <StudentListPanel
         students={students}
+        studentsLoading={studentsLoading}
         currentUser={currentUser}
         token={token}
         refreshStudents={refreshStudents}
@@ -63,7 +64,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
     );
   }
 
-  if (panel === 'student_profile') return <StudentProfilePanel students={students} schools={schools} reportsList={reportsList} currentUser={currentUser} token={token} updateStudentLocally={updateStudentLocally} />;
+  if (panel === 'student_profile') return <StudentProfilePanel students={students} studentsLoading={studentsLoading} schools={schools} reportsList={reportsList} currentUser={currentUser} token={token} updateStudentLocally={updateStudentLocally} />;
 
   if (panel === 'diagnostic_test') return <DiagnosticTestPanel students={students} currentUser={currentUser} token={token} refreshStudents={refreshStudents} />;
 

--- a/frontend/src/components/panels/PanelShared.tsx
+++ b/frontend/src/components/panels/PanelShared.tsx
@@ -20,12 +20,21 @@ export function PageHeader({ title, desc, icon }: { title: string; desc: string;
   );
 }
 
-export function EmptyStudents({ students }: { students: Student[] }) {
+export function EmptyStudents({ students, loading }: { students: Student[]; loading?: boolean }) {
   const cols: Column<Student>[] = [
     { header: 'ID', accessor: (s) => s.displayId || s.id, className: 'font-mono text-xs text-slate-400 dark:text-slate-500' },
     { header: 'Name', accessor: 'name', sortKey: 'name', className: 'font-semibold text-slate-800 dark:text-slate-100' },
     { header: 'Class', accessor: 'classGroup', className: '' },
     { header: 'Level', accessor: (s) => <LevelBadge level={s.currentLevel} subLevel={s.currentSubLevel} />, className: 'font-mono' },
   ];
-  return <Table data={students} columns={cols} searchPlaceholder="Search students..." searchKey="name" />;
+  return (
+    <Table
+      data={students}
+      columns={cols}
+      searchPlaceholder="Search students..."
+      searchKey="name"
+      loading={loading}
+      emptyMessage="No students registered yet."
+    />
+  );
 }

--- a/frontend/src/components/panels/StudentListPanel.tsx
+++ b/frontend/src/components/panels/StudentListPanel.tsx
@@ -11,6 +11,7 @@ import { parseCSVText } from '../RoleDashboards';
 
 interface StudentListPanelProps {
   students: Student[];
+  studentsLoading?: boolean;
   currentUser: User;
   token: string;
   refreshStudents: () => void;
@@ -18,6 +19,7 @@ interface StudentListPanelProps {
 
 export const StudentListPanel: React.FC<StudentListPanelProps> = ({
   students,
+  studentsLoading,
   currentUser,
   token,
   refreshStudents,
@@ -406,7 +408,7 @@ export const StudentListPanel: React.FC<StudentListPanelProps> = ({
           </div>
         )}
 
-        <EmptyStudents students={visibleStudents} />
+        <EmptyStudents students={visibleStudents} loading={studentsLoading} />
       </div>
     </div>
   );

--- a/frontend/src/components/panels/StudentProfilePanel.tsx
+++ b/frontend/src/components/panels/StudentProfilePanel.tsx
@@ -10,12 +10,13 @@ import { Users, BookOpen, Calendar, Award, BarChart3, FileText, Search, ChevronD
 
 export const StudentProfilePanel: React.FC<{
   students: Student[];
+  studentsLoading?: boolean;
   schools: School[];
   reportsList: EvaluationReport[];
   currentUser: User;
   token: string;
   updateStudentLocally: (studentId: string, patch: Partial<Student>) => void;
-}> = ({ students, schools, reportsList, currentUser, token, updateStudentLocally }) => {
+}> = ({ students, studentsLoading, schools, reportsList, currentUser, token, updateStudentLocally }) => {
   const [sel, setSel] = useState('');
   const [profileTab, setProfileTab] = useState<'overview' | 'academic' | 'personal' | 'activity'>('overview');
   const [editingProfile, setEditingProfile] = useState(false);
@@ -33,6 +34,29 @@ export const StudentProfilePanel: React.FC<{
       setSel(students[0].id);
     }
   }, [students, sel]);
+
+  // Issue #292: `students[0]` used to always exist because a hardcoded
+  // demo-student fallback guaranteed a non-empty list. With that fallback
+  // removed, a teacher who genuinely has zero students yet — a brand-new
+  // account, the exact case this bug was found on — would otherwise hit
+  // `s.schoolId`, `s.levelHistory[0]`, etc. on `undefined` below and crash.
+  if (studentsLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-slate-400 dark:text-slate-500">
+        <div className="w-6 h-6 border-2 border-indigo-600 border-t-transparent rounded-full animate-spin mb-3" />
+        <p className="text-xs font-mono">Loading student records...</p>
+      </div>
+    );
+  }
+  if (students.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center text-slate-400 dark:text-slate-500">
+        <Users className="h-8 w-8 mb-3" />
+        <p className="text-sm font-semibold text-slate-600 dark:text-slate-300">No students registered yet.</p>
+        <p className="text-xs mt-1">Register a student from the Students section to see their profile here.</p>
+      </div>
+    );
+  }
 
     const s = students.find(x => x.id === sel) || students[0];
 

--- a/frontend/src/components/panels/usePanelData.ts
+++ b/frontend/src/components/panels/usePanelData.ts
@@ -16,16 +16,6 @@ import { DISTRICT_NAMES, BLOCK_NAMES } from '../../constants';
 // screens that don't display any student data.
 const STUDENTS_NOT_NEEDED_PANELS = new Set(['users', 'worksheet_templates', 'content', 'system_settings']);
 
-const STUDENTS_FALLBACK: Student[] = [
-  { id: 's1', name: 'Amanpreet Singh', age: 8, classGroup: 'Class 2', section: 'A', schoolId: 'gps-mt-001', currentLevel: 12, currentSubLevel: 0, targetLevel: 13, aadharMasked: 'XXXX-XXXX-1234', levelHistory: [{ level: 12, subLevel: 0, date: '2026-03-15', reason: 'Diagnostic' }], streak: 3 },
-  { id: 's2', name: 'Jasmine Kaur', age: 7, classGroup: 'Class 2', section: 'A', schoolId: 'gps-mt-001', currentLevel: 8, currentSubLevel: 1, targetLevel: 12, aadharMasked: 'XXXX-XXXX-5678', levelHistory: [{ level: 8, subLevel: 1, date: '2026-02-20', reason: 'Mid-year' }], streak: 1 },
-  { id: 's3', name: 'Rohit Kumar', age: 9, classGroup: 'Class 3', section: 'A', schoolId: 'gps-mt-001', currentLevel: 36, currentSubLevel: 0, targetLevel: 37, aadharMasked: 'XXXX-XXXX-9012', levelHistory: [{ level: 36, date: '2026-01-10', reason: 'Baseline' }], streak: 5 },
-  { id: 's4', name: 'Priya Sharma', age: 8, classGroup: 'Class 2', section: 'A', schoolId: 'gps-mt-001', currentLevel: 10, currentSubLevel: 2, targetLevel: 14, aadharMasked: 'XXXX-XXXX-3456', levelHistory: [], streak: 0 },
-  { id: 's5', name: 'Arjun Verma', age: 7, classGroup: 'Class 2', section: 'A', schoolId: 'gps-mt-001', currentLevel: 6, currentSubLevel: 0, targetLevel: 11, aadharMasked: 'XXXX-XXXX-7890', levelHistory: [{ level: 6, date: '2026-04-01', reason: 'Diagnostic' }], streak: 2 },
-  { id: 's6', name: 'Neha Gupta', age: 8, classGroup: 'Class 3', section: 'A', schoolId: 'gps-mt-001', currentLevel: 38, currentSubLevel: 1, targetLevel: 40, aadharMasked: 'XXXX-XXXX-2345', levelHistory: [{ level: 38, date: '2026-03-01', reason: 'Mid-year' }], streak: 4 },
-  { id: 's7', name: 'Simran Kaur', age: 6, classGroup: 'Class 1', section: 'A', schoolId: 'gps-mt-001', currentLevel: 4, currentSubLevel: 0, targetLevel: 8, aadharMasked: 'XXXX-XXXX-6789', levelHistory: [], streak: 0 },
-];
-
 const TEACHERS_MOCK = [
   { id: 't1', name: 'Ritu Sharma', email: 'gps-mt-001.t01@fln.org', schoolId: 'gps-mt-001', classes: ['Class 2-A', 'Class 3-A'], studentsCount: 42, delayedAttempts: 0, status: 'Active' },
   { id: 't2', name: 'Amit Kumar', email: 'gps-mt-001.t02@fln.org', schoolId: 'gps-mt-001', classes: ['Class 1-A'], studentsCount: 28, delayedAttempts: 1, status: 'Active' },
@@ -64,6 +54,13 @@ const USERS_FALLBACK = [
 
 export function usePanelData(token: string, currentUser: User, activePanel: string) {
   const [apiStudents, setApiStudents] = useState<Student[]>([]);
+  // Distinct from apiStudents.length === 0 — issue #292: that condition is
+  // true both "fetch hasn't resolved yet" and "fetch succeeded, roster is
+  // genuinely empty" (a brand-new teacher account), and code that can't
+  // tell those apart was previously substituting hardcoded demo students
+  // for the second case too. studentsLoading lets consumers show a real
+  // empty state instead.
+  const [studentsLoading, setStudentsLoading] = useState(true);
   const [apiSchools, setApiSchools] = useState<School[]>([]);
   const [apiUsers, setApiUsers] = useState<any[]>([]);
   const [apiReports, setApiReports] = useState<EvaluationReport[]>([]);
@@ -87,12 +84,17 @@ export function usePanelData(token: string, currentUser: User, activePanel: stri
   // (verified by grepping for the identifier in each branch below).
   useEffect(() => {
     if (apiStudents.length > 0) return;
-    if (STUDENTS_NOT_NEEDED_PANELS.has(activePanel)) return;
+    if (STUDENTS_NOT_NEEDED_PANELS.has(activePanel)) { setStudentsLoading(false); return; }
+    setStudentsLoading(true);
     const headers = { 'Authorization': `Bearer ${token}` };
-    apiFetch('/api/students', { headers }).then(r => r.json()).then(d => { if (Array.isArray(d)) setApiStudents(d); }).catch(() => { });
+    apiFetch('/api/students', { headers })
+      .then(r => r.json())
+      .then(d => { if (Array.isArray(d)) setApiStudents(d); })
+      .catch(() => { })
+      .finally(() => setStudentsLoading(false));
   }, [token, activePanel, apiStudents.length]);
 
-  const students = apiStudents.length > 0 ? apiStudents : STUDENTS_FALLBACK;
+  const students = apiStudents;
   const schools = apiSchools.length > 0 ? apiSchools : SCHOOLS_FALLBACK;
   const usersList = apiUsers.length > 0 ? apiUsers : USERS_FALLBACK;
   // No mock fallback here (unlike students/schools/users): a fake report's
@@ -154,7 +156,7 @@ export function usePanelData(token: string, currentUser: User, activePanel: stri
   };
 
   return {
-    students, schools, usersList, reportsList, worksheetsList, teachersList,
+    students, studentsLoading, schools, usersList, reportsList, worksheetsList, teachersList,
     getDistrictStats, getBlockStats, updateStudentLocally, refreshStudents,
   };
 }


### PR DESCRIPTION
Closes #292

## Problem

`frontend/src/components/panels/usePanelData.ts` substituted 7 hardcoded demo students (Amanpreet Singh, Jasmine Kaur, Rohit Kumar, etc.) whenever the real `GET /api/students` call returned an empty array — true for any brand-new teacher account. The code couldn't distinguish "still loading" from "genuinely empty roster."

## Fix

- Removed `STUDENTS_FALLBACK` entirely.
- Added a real `studentsLoading` boolean (set on fetch start/finish), distinct from `apiStudents.length`, threaded through `PanelViews.tsx` into `StudentListPanel` and `StudentProfilePanel`.
- **`StudentListPanel`**: wired `loading`/`emptyMessage` into `EmptyStudents` → `Table.tsx` (which already supports both props — same ones used for PR #288's pagination fix). Shows a spinner while loading, "No students registered yet." when genuinely empty.
- **`StudentProfilePanel`**: found and fixed a **real crash** the fallback had been masking. `students.find(...) || students[0]` assumed `students[0]` always exists; with zero real students that's `undefined`, and every downstream line (`s.schoolId`, `s.levelHistory[0]`, `s.name.charAt(0)`, ...) would throw. Added explicit loading/empty states before that logic runs.

## Testing

- `tsc --noEmit` and `vite build` both clean.
- Verified live against a local isolated MongoDB (not production): the same fresh zero-student teacher account from PR #296 (#291's fix) returns `[]` from `/api/students`, confirming no fallback substitution happens anywhere in the chain.
- Not yet click-tested in browser for the visual empty state / crash prevention specifically — recommend a quick pass on Student List + Student Profile with a zero-student account before merge.