### PR TITLE
fix: stop showing fake Adaptive Test metrics

### DIFF
--- a/frontend/src/components/panels/AdaptiveTestPanel.tsx
+++ b/frontend/src/components/panels/AdaptiveTestPanel.tsx
@@ -1,25 +1,34 @@
 // Extracted from frontend/src/components/PanelViews.tsx (issue #144, PR 2).
+//
+// Issue #293: this panel used to show hardcoded fake metrics ("3 Active
+// Sessions", "72% Avg Score", "85% Completion Rate") regardless of who was
+// logged in or how many real sessions existed. Investigating the fix
+// surfaced that there is no backend concept of an "adaptive session"
+// anywhere in this codebase at all — no route, no collection, nothing to
+// wire these numbers up to. The "Start New Adaptive Test" / "View Session
+// Logs" buttons below had no onClick handlers either; they were dead
+// ends, not just visually unwired.
+//
+// Building real adaptive-session tracking (start/stop a session, persist
+// per-question difficulty adjustment, compute a real average score and
+// completion rate) is a new backend feature, not a data-wiring fix — out
+// of scope to invent under pilot time pressure. This panel is now honest
+// about that instead of showing fabricated activity: it states the
+// feature isn't available yet rather than lying with numbers.
 import React from 'react';
 import { PageHeader } from './PanelShared';
-import { MetricCard } from '../Card';
-import { SlidersHorizontal, Users, BarChart3, CheckCircle2 } from 'lucide-react';
+import { SlidersHorizontal } from 'lucide-react';
 
 export const AdaptiveTestPanel: React.FC = () => {
   return (
       <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm space-y-6">
         <PageHeader title="Adaptive Assessment" desc="Computer-adaptive testing that adjusts to student ability" icon={<SlidersHorizontal className="h-5 w-5" />} />
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <MetricCard title="Active Sessions" value="3" subtext="Students currently testing" icon={Users} />
-          <MetricCard title="Avg Adaptive Score" value="72%" subtext="Across all levels" icon={BarChart3} />
-          <MetricCard title="Completion Rate" value="85%" subtext="Tests finished on time" icon={CheckCircle2} />
-        </div>
-        <div className="border border-slate-200 dark:border-slate-700 rounded-lg p-5 bg-slate-50 dark:bg-slate-800 space-y-3">
-          <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-100">How Adaptive Testing Works</h4>
-          <p className="text-xs text-slate-600 dark:text-slate-300 leading-relaxed">The system selects questions dynamically based on the student's previous answers. Correct answers lead to harder questions; incorrect answers adjust to easier ones. This pinpoints the exact FLN level.</p>
-          <div className="flex gap-4 pt-2">
-            <button className="bg-slate-900 text-white text-xs font-medium px-4 py-2 rounded-lg hover:bg-slate-800 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200">Start New Adaptive Test</button>
-            <button className="border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 text-xs font-medium px-4 py-2 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-700">View Session Logs</button>
-          </div>
+        <div className="border border-dashed border-slate-300 dark:border-slate-600 rounded-lg p-6 bg-slate-50 dark:bg-slate-800 text-center space-y-2">
+          <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">Adaptive testing isn't available yet</p>
+          <p className="text-xs text-slate-500 dark:text-slate-400 max-w-md mx-auto leading-relaxed">
+            This will let the system pick harder or easier questions in real time based on a student's answers, to pinpoint their exact FLN level.
+            For now, use the Diagnostic Test tab to assess students.
+          </p>
         </div>
       </div>
   );


### PR DESCRIPTION
Closes #293

## Problem

`AdaptiveTestPanel.tsx` hardcoded 3 fake metrics ("3 Active Sessions", "72% Avg Adaptive Score", "85% Completion Rate") with no props and no API call — shown to every teacher regardless of real activity. Reported live on a teacher account with zero students/sessions.

## What I found investigating the fix

There is **no backend concept of an "adaptive session" anywhere in this codebase** — no route, no MongoDB collection, nothing real to wire these numbers to. The "Start New Adaptive Test" / "View Session Logs" buttons on the same panel had no `onClick` handlers either — they were dead ends, not just visually unwired.

## Scope decision

The issue's suggested fix was to build a real endpoint if one doesn't exist. Building genuine adaptive-session tracking (persist a session, adjust question difficulty per answer, compute a real average score and completion rate) is a **new backend feature**, not a data-wiring bug fix — I don't think it's appropriate to invent that under pilot-deadline time pressure without a design discussion first.

Instead, this PR makes the panel honest: it now clearly states the feature isn't available yet and points teachers to Diagnostic Test instead, rather than showing fabricated numbers that look like real activity.

**Flagging for review rather than assuming:** happy to scope out a real adaptive-testing feature as a separate, properly-designed issue if that's wanted — this PR just stops the panel from lying in the meantime.

## Testing

- `tsc --noEmit` and `vite build` both clean.