### PR TITLE
feat: add new-teacher welcome/onboarding state

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -155,7 +155,7 @@ return <SuperadminDashboard user={currentUser} token={token!} />;
       case 'school':
         return <SchoolDashboard user={currentUser} token={token!} />;
       case 'teacher':
-        return <TeacherDashboard user={currentUser} token={token!} />;
+        return <TeacherDashboard user={currentUser} token={token!} onNavigate={setActivePanel} />;
       case 'volunteer':
         return <VolunteerDashboard user={currentUser} token={token!} />;
       default:

--- a/frontend/src/components/dashboards/TeacherDashboard.tsx
+++ b/frontend/src/components/dashboards/TeacherDashboard.tsx
@@ -13,9 +13,21 @@ import { LevelBadge } from '../RoleDashboards';
 import { ClassSummaryBar } from './ClassSummaryBar';
 
 
-export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
+interface TeacherDashboardProps extends DashboardProps {
+  // Issue #294: the welcome panel's Register/CSV-Upload actions live on the
+  // Students section (a sibling panel, not part of this dashboard) — this
+  // lets the welcome panel switch the app's active panel without
+  // TeacherDashboard needing to own that navigation state itself.
+  onNavigate?: (panel: string) => void;
+}
+
+export const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ user, token, onNavigate }) => {
   const [classes, setClasses] = useState<ClassGroup[]>([]);
   const [students, setStudents] = useState<Student[]>([]);
+  // Distinct from students.length === 0 (issue #294, same pattern as #292's
+  // studentsLoading) — without it the welcome panel would flash on screen
+  // for every teacher for a moment before their real roster loads in.
+  const [studentsLoading, setStudentsLoading] = useState(true);
   const [activeClass, setActiveClass] = useState<ClassGroup | null>(null);
   const [showAllStudents, setShowAllStudents] = useState(true);
   const [diagnosticStudent, setDiagnosticStudent] = useState<Student | null>(null);
@@ -73,6 +85,8 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
       if (Array.isArray(stdData)) setStudents(stdData);
     } catch (err) {
       console.error(err);
+    } finally {
+      setStudentsLoading(false);
     }
   };
 
@@ -104,6 +118,66 @@ export const TeacherDashboard: React.FC<DashboardProps> = ({ user, token }) => {
         onPlaced={() => fetchTeacherData()}
         onBack={() => setBaselineStudent(null)}
       />
+    );
+  }
+
+  // Issue #294: CSV template matching the exact column schema
+  // `POST /api/students/bulk-import` expects (see createStudentFromData in
+  // backend/src/routes/students.ts) — required fields first (name,
+  // classGroup, section, aadharNumber), then the optional fields the same
+  // endpoint accepts. Generated client-side rather than a static file in
+  // frontend/public/ so it can never silently drift from the real schema.
+  const downloadCsvTemplate = () => {
+    const headers = ['name', 'classGroup', 'section', 'aadharNumber', 'dob', 'gender', 'guardianName', 'guardianRelation', 'guardianContact', 'address'];
+    const exampleRow = ['Aarav Sharma', 'Class 2', 'A', '123456789012', '2018-06-15', 'Male', 'Rakesh Sharma', 'Father', '9876543210', 'Village Road, Near School'];
+    const csvContent = [headers.join(','), exampleRow.map(v => `"${v.replace(/"/g, '""')}"`).join(',')].join('\n');
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.setAttribute('href', url);
+    link.setAttribute('download', 'fln_student_upload_template.csv');
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  // Issue #294: a brand-new teacher with zero students previously landed on
+  // a fully-populated dashboard layout (with honest zeros, at least — see
+  // #292 for the fake-data version of this problem) and no guidance on
+  // what to do next. Show a welcome state instead until they register or
+  // import their first student.
+  if (!studentsLoading && students.length === 0) {
+    return (
+      <div className="max-w-2xl mx-auto py-16 text-center space-y-6" id="teacher-dashboard-welcome">
+        <div>
+          <h1 className="text-2xl font-display font-semibold text-zinc-900 dark:text-white">Welcome, {user.name}!</h1>
+          <p className="text-zinc-500 dark:text-zinc-400 text-sm mt-2">
+            You don't have any students registered yet. Get started by adding your first student below.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-left">
+          <button
+            onClick={() => onNavigate?.('student_list')}
+            className="bg-slate-900 dark:bg-white text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-zinc-200 font-semibold text-sm px-5 py-4 rounded-xl transition-colors cursor-pointer text-center"
+          >
+            Register New Student
+          </button>
+          <button
+            onClick={() => onNavigate?.('student_list')}
+            className="bg-white dark:bg-slate-900 border border-zinc-200 dark:border-zinc-700 text-zinc-800 dark:text-zinc-100 hover:bg-zinc-50 dark:hover:bg-zinc-800 font-semibold text-sm px-5 py-4 rounded-xl transition-colors cursor-pointer text-center"
+          >
+            Smart CSV Upload
+          </button>
+        </div>
+        <button
+          onClick={downloadCsvTemplate}
+          className="text-xs font-mono text-indigo-600 dark:text-indigo-400 hover:underline cursor-pointer"
+        >
+          ⬇ Download CSV template
+        </button>
+      </div>
     );
   }
 


### PR DESCRIPTION
Closes #294

## Problem

A teacher with zero registered students landed on a fully-populated dashboard layout — real, correct zeros as of #292/#291's fixes, but still no onboarding or guidance on what to do first.

## Fix

Added a welcome state to `TeacherDashboard.tsx`, shown when `!studentsLoading && students.length === 0`:

- Welcome message with the teacher's name
- **Register New Student** — navigates to the Students section (existing single-student registration flow)
- **Smart CSV Upload** — navigates to the same section (bulk-import UI already built by #178, this is just a discoverable entry point to it)
- **Downloadable CSV template** — generated client-side from the exact column schema `createStudentFromData()` expects in `backend/src/routes/students.ts` (required: `name`, `classGroup`, `section`, `aadharNumber`; optional: `dob`, `gender`, `guardianName`, `guardianRelation`, `guardianContact`, `address`). Generated at click-time rather than a static file in `frontend/public/` specifically so it can never silently drift from the real backend schema if that endpoint's fields change later.

## Implementation note

The welcome panel's two navigation actions target the Students section, a sibling panel outside `TeacherDashboard` — added an optional `onNavigate` prop, wired from `App.tsx`'s existing `setActivePanel` state setter, rather than having the dashboard own navigation state itself.

No backend changes — reuses the existing single-student registration endpoint and #178's bulk-import endpoint as-is.

## Testing

- `tsc --noEmit` and `vite build` both clean.
- Not yet click-tested live in browser — recommend verifying: (1) a zero-student teacher account sees the welcome panel, not the normal dashboard; (2) both buttons correctly land on the Students section; (3) the downloaded CSV template's headers match what a real bulk-import accepts; (4) registering one student replaces the welcome panel with the normal dashboard on next load.