### PR TITLE
feat: add Cycle Comparison view and class-level worksheet print-count rollup

### DIFF
--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -64,7 +64,7 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
     );
   }
 
-  if (panel === 'student_profile') return <StudentProfilePanel students={students} studentsLoading={studentsLoading} schools={schools} reportsList={reportsList} currentUser={currentUser} token={token} updateStudentLocally={updateStudentLocally} />;
+  if (panel === 'student_profile') return <StudentProfilePanel students={students} studentsLoading={studentsLoading} schools={schools} reportsList={reportsList} worksheetsList={worksheetsList} currentUser={currentUser} token={token} updateStudentLocally={updateStudentLocally} />;
 
   if (panel === 'diagnostic_test') return <DiagnosticTestPanel students={students} currentUser={currentUser} token={token} refreshStudents={refreshStudents} />;
 

--- a/frontend/src/components/dashboards/ClassSummaryBar.tsx
+++ b/frontend/src/components/dashboards/ClassSummaryBar.tsx
@@ -1,12 +1,46 @@
 // Issue #172 + #167: a real "how is my class doing today?" summary bar for
 // the Teacher Dashboard, folding in the stats + Top Performing Students list
 // that used to live on the standalone Performance page (now removed).
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Student } from '../../types';
 import { MetricCard } from '../Card';
-import { Users, BarChart3, TrendingUp, TrendingDown } from 'lucide-react';
+import { apiFetch } from '../../services/apiClient';
+import { Users, BarChart3, TrendingUp, TrendingDown, Printer } from 'lucide-react';
 
-export const ClassSummaryBar: React.FC<{ students: Student[] }> = ({ students }) => {
+// Issue #200: class-level worksheet print-count rollup, piggybacking on
+// #182's Test History log (GET /api/teachers/:id/test-history) rather than
+// a separate tracking mechanism — each entry there is one bulk-generation
+// request, and studentCount is the number of worksheets that request
+// printed. Summed per class, that's exactly the "how many worksheets has
+// this class had printed" KPI the issue asks for.
+interface TestHistoryEntry {
+  studentCount: number;
+  classId?: string;
+  className?: string;
+}
+
+export const ClassSummaryBar: React.FC<{ students: Student[]; token?: string; teacherId?: string }> = ({ students, token, teacherId }) => {
+  const [printCounts, setPrintCounts] = useState<{ classId: string; className: string; count: number }[]>([]);
+
+  useEffect(() => {
+    if (!token || !teacherId) return;
+    let cancelled = false;
+    apiFetch(`/api/teachers/${teacherId}/test-history`, { headers: { Authorization: `Bearer ${token}` } })
+      .then(r => r.json())
+      .then((history: TestHistoryEntry[]) => {
+        if (cancelled || !Array.isArray(history)) return;
+        const byClass = new Map<string, { classId: string; className: string; count: number }>();
+        history.forEach(h => {
+          if (!h.classId) return;
+          const existing = byClass.get(h.classId);
+          if (existing) existing.count += h.studentCount;
+          else byClass.set(h.classId, { classId: h.classId, className: h.className || h.classId, count: h.studentCount });
+        });
+        setPrintCounts(Array.from(byClass.values()).sort((a, b) => b.count - a.count));
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [token, teacherId]);
   const total = students.length;
   const assessed = students.filter(s => s.levelHistory.length > 0).length;
   const pending = total - assessed;
@@ -40,6 +74,21 @@ export const ClassSummaryBar: React.FC<{ students: Student[] }> = ({ students })
         <MetricCard title="On Track" value={`${onTrackPercent}%`} subtext="Mastery at current level" icon={TrendingUp} />
         <MetricCard title="Regressed" value={regressed} subtext="Level dropped since last cycle" icon={TrendingDown} />
       </div>
+      {printCounts.length > 0 && (
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
+          <h4 className="text-xs font-mono font-bold text-slate-500 dark:text-slate-400 uppercase mb-3 flex items-center gap-1.5">
+            <Printer className="h-3.5 w-3.5" /> Worksheets Printed by Class
+          </h4>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {printCounts.map(pc => (
+              <div key={pc.classId} className="border border-slate-100 dark:border-slate-700 rounded-lg p-3 text-center">
+                <div className="text-lg font-bold text-slate-900 dark:text-white">{pc.count}</div>
+                <div className="text-[10px] text-slate-500 dark:text-slate-400 truncate" title={pc.className}>{pc.className}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
       {topStudents.length > 0 && (
         <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-sm">
           <h4 className="text-xs font-mono font-bold text-slate-500 dark:text-slate-400 uppercase mb-3">Top Performing Students</h4>

--- a/frontend/src/components/dashboards/TeacherDashboard.tsx
+++ b/frontend/src/components/dashboards/TeacherDashboard.tsx
@@ -218,7 +218,7 @@ export const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ user, token,
       {/* Issue #172: real "how is my class doing today?" summary + #167's
           Top Performing Students, now that the standalone Performance page
           is gone. */}
-      <ClassSummaryBar students={students} />
+      <ClassSummaryBar students={students} token={token} teacherId={user.id} />
 
       {/* Class picker tabs */}
       <div className="flex gap-2 border-b border-zinc-200 dark:border-zinc-700 pb-px">

--- a/frontend/src/components/panels/StudentProfilePanel.tsx
+++ b/frontend/src/components/panels/StudentProfilePanel.tsx
@@ -4,19 +4,25 @@
 // updateStudentLocally mutator (built in PR 1 for exactly this purpose).
 import { apiFetch } from '../../services/apiClient';
 import React, { useState, useEffect } from 'react';
-import { User, UserRole, Student, School, EvaluationReport } from '../../types';
+import { User, UserRole, Student, School, EvaluationReport, Worksheet } from '../../types';
 import { handleDownloadPDF } from './pdfReportGenerator';
-import { Users, BookOpen, Calendar, Award, BarChart3, FileText, Search, ChevronDown } from 'lucide-react';
+import { Users, BookOpen, Calendar, Award, BarChart3, FileText, Search, ChevronDown, GitCompareArrows } from 'lucide-react';
+
+// Issue #200: canonical cycle order for the comparison view — matches
+// db.ts's CYCLE_NAMES (Worksheet.cycle already uses these exact strings
+// since #179/#191's standardization).
+const CYCLE_ORDER = ['Baseline', 'Mid-year', 'End-of-year'] as const;
 
 export const StudentProfilePanel: React.FC<{
   students: Student[];
   studentsLoading?: boolean;
   schools: School[];
   reportsList: EvaluationReport[];
+  worksheetsList: Worksheet[];
   currentUser: User;
   token: string;
   updateStudentLocally: (studentId: string, patch: Partial<Student>) => void;
-}> = ({ students, studentsLoading, schools, reportsList, currentUser, token, updateStudentLocally }) => {
+}> = ({ students, studentsLoading, schools, reportsList, worksheetsList, currentUser, token, updateStudentLocally }) => {
   const [sel, setSel] = useState('');
   const [profileTab, setProfileTab] = useState<'overview' | 'academic' | 'personal' | 'activity'>('overview');
   const [editingProfile, setEditingProfile] = useState(false);
@@ -66,6 +72,27 @@ export const StudentProfilePanel: React.FC<{
     );
 
     const reports = reportsList.filter(r => r.studentId === s.id);
+
+    // Issue #200: Baseline / Mid-year / End-of-year side by side, so a
+    // teacher can see this student's trajectory across the 3-cycle model
+    // in one place instead of scrolling through the activity log. A
+    // report doesn't carry its own cycle — it's looked up via its
+    // worksheetId (Worksheet.cycle, standardized by #179/#191). If a
+    // cycle has more than one report, the most recent one represents it.
+    const worksheetCycleById = new Map(worksheetsList.map(w => [w.id, w.cycle]));
+    const cycleComparison = CYCLE_ORDER.map(cycle => {
+      const cycleReports = reports
+        .filter(r => worksheetCycleById.get(r.worksheetId) === cycle)
+        .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+      const report = cycleReports[0] ?? null;
+      return {
+        cycle,
+        report,
+        scorePercent: report ? Math.round((report.score / report.totalQuestions) * 100) : null,
+      };
+    });
+    const hasCycleData = cycleComparison.some(c => c.report !== null);
+
     const studentSchool = schools.find(sch => sch.id === s.schoolId);
     // No attendance data model exists on the backend yet (no dedicated
     // collection or endpoint) - showing `null` here surfaces the existing
@@ -291,6 +318,41 @@ export const StudentProfilePanel: React.FC<{
                         <span>Last: <strong>{Math.round((reports[reports.length - 1].score / reports[reports.length - 1].totalQuestions) * 100)}%</strong></span>
                       </div>
                     )}
+                  </div>
+                </div>
+              )}
+
+              {/* Issue #200: Baseline / Mid-year / End-of-year side by side —
+                  distinct from Score Trend above, which is every report in
+                  chronological order regardless of cycle. This is
+                  specifically the 3-cycle model the assessment design is
+                  built around. */}
+              {hasCycleData && (
+                <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 shadow-sm">
+                  <h3 className="text-xs font-mono font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-4 flex items-center gap-1.5">
+                    <GitCompareArrows className="h-3.5 w-3.5" /> Cycle Comparison
+                  </h3>
+                  <div className="grid grid-cols-3 gap-4">
+                    {cycleComparison.map(({ cycle, report, scorePercent }) => (
+                      <div key={cycle} className="text-center space-y-2">
+                        <div className="text-[10px] font-mono font-bold text-slate-500 dark:text-slate-400 uppercase">{cycle}</div>
+                        {report ? (
+                          <>
+                            <div className="h-24 flex items-end justify-center">
+                              <div
+                                className={`w-10 rounded-t-lg ${scorePercent! >= 80 ? 'bg-emerald-500' : scorePercent! >= 60 ? 'bg-amber-500' : 'bg-red-500'}`}
+                                style={{ height: `${Math.max(scorePercent! * 0.9, 8)}px` }}
+                              />
+                            </div>
+                            <div className="font-mono font-bold text-sm text-slate-900 dark:text-white">{scorePercent}%</div>
+                            <div className="text-[10px] text-slate-500 dark:text-slate-400">L{report.recommendedLevel}.{report.recommendedSubLevel ?? 0}</div>
+                            <div className="text-[9px] text-slate-400 dark:text-slate-500">{new Date(report.timestamp).toLocaleDateString('en-IN', { day: 'numeric', month: 'short', year: 'numeric' })}</div>
+                          </>
+                        ) : (
+                          <div className="h-24 flex items-center justify-center text-[10px] text-slate-300 dark:text-slate-600 font-mono">Not yet taken</div>
+                        )}
+                      </div>
+                    ))}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
Closes #200

## 1. Cycle Comparison (Student Profile, Overview tab)

Baseline / Mid-year / End-of-year shown side by side for the selected student — distinct from the existing Score Trend chart, which shows every report in chronological order regardless of cycle. A report's cycle is looked up via its `worksheetId` against `Worksheet.cycle` (standardized by #179/#191); the most recent report represents a cycle if more than one exists for it.

Added `worksheetsList` as a new `StudentProfilePanel` prop, threaded from `PanelViews.tsx` — it was already available from `usePanelData`, just wasn't being passed down to this panel before.

## 2. Worksheets Printed by Class (Class Summary Bar, Teacher Dashboard)

Piggybacks on #182's Test History log (`GET /api/teachers/:id/test-history`) rather than building a new tracking mechanism, per the issue's own suggested approach. Each log entry is one bulk-generation request; `studentCount` is how many worksheets that request printed. Summed per `classId`, that's the print-count rollup. **No backend changes needed.**

## Testing

- `tsc --noEmit` and `vite build` both clean.
- **Honest disclosure:** attempted a full live end-to-end check locally (trigger a real bulk generation, confirm it shows up in the class rollup), but the local sandbox doesn't have headless Chrome installed for the PDF step, so the generation request failed before it reached the point of being logged to test-history. This is an environment limitation of my local setup, not something this change introduces — recommend verifying the print-count rollup against a real deploy where Chrome/Puppeteer is already configured (per the existing deployment notes in the repo).
- The Cycle Comparison view was verified by code review against real report/worksheet data shapes, not click-tested live for the same reason (needs at least one real evaluation report tied to a cycle-tagged worksheet, which the failed generation above would have produced).