### PR TITLE
feat: add 'Run Diagnostic in Bulk' button to the student roster

### DIFF
--- a/frontend/src/components/dashboards/TeacherDashboard.tsx
+++ b/frontend/src/components/dashboards/TeacherDashboard.tsx
@@ -261,6 +261,15 @@ export const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ user, token,
               <h3 className="font-display font-medium text-zinc-900 dark:text-white text-sm">
                 {showAllStudents ? `All Students — School Roster (${classStudents.length})` : `Classroom Student Roster (${classStudents.length})`}
               </h3>
+              {classStudents.some(s => s.levelHistory.length === 0) && (
+                <button
+                  onClick={() => onNavigate?.('diagnostic_test')}
+                  className="bg-amber-600 hover:bg-amber-700 text-white font-mono text-xs font-bold px-3 py-1.5 rounded-lg transition-colors cursor-pointer"
+                  title="Generate diagnostic papers for a whole class at once, instead of one student at a time"
+                >
+                  📋 Run Diagnostic in Bulk
+                </button>
+              )}
             </div>
             <div className="p-4">
               {(() => {


### PR DESCRIPTION
## Problem

Reported live via screenshot: the "All Students — School Roster" table on the Teacher Dashboard only has a per-student "Run Diagnostic" button. A teacher with a full class of pending students has to click through each one individually — no way to generate diagnostic papers for the whole class at once from this view.

## Fix

Added a "📋 Run Diagnostic in Bulk" button to the roster table header. It navigates to Assessment → Diagnostic Test via the `onNavigate` prop (already wired from #294's welcome panel), landing directly on `BulkDiagnosticWorkflow` — the real bulk-generation flow that already exists and works, rather than duplicating that logic inline on the dashboard.

Only shown when the current roster view (All Students or a single class tab) has at least one student with a pending diagnostic, so it disappears once a class is fully assessed instead of cluttering the roster permanently.

## Testing

- `tsc --noEmit` and `vite build` both clean.