### PR TITLE
fix: auto-create ClassGroup record when a student is registered

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1281,6 +1281,48 @@ export class DBStore {
     return student;
   }
 
+  // Only the original seed data ever populated the `classes` collection —
+  // registering a student (single or bulk-import) creates a Student record
+  // tagged with a classGroup/section, but nothing was ever creating the
+  // matching ClassGroup document those classGroup/section strings imply.
+  // Several features key off ClassGroup existing for a teacher/school (the
+  // Teacher Dashboard's class-tab bar, and — the bug this was found from —
+  // bulk diagnostic generation's authorization check), so a teacher whose
+  // whole roster was registered live (not seeded) could end up "not
+  // authorized" for a class she demonstrably has real students in.
+  // Called after every successful student creation; idempotent — does
+  // nothing if a ClassGroup already exists for this school+class+section.
+  async ensureClassExists(schoolId: string, className: string, section: string, teacherId: string) {
+    const existing = await this.getClasses();
+    if (existing.some(c => c.schoolId === schoolId && c.className === className && c.section === section)) {
+      return;
+    }
+    const newClass: ClassGroup = {
+      id: 'c_' + schoolId + '_' + className.replace(/\s+/g, '') + '_' + section,
+      schoolId,
+      className,
+      section,
+      teacherId,
+    };
+    if (this.mongoDb) {
+      // Race-safe: two near-simultaneous registrations into a brand-new
+      // class both pass the `existing.some(...)` check above before either
+      // has inserted. upsert on the same deterministic `id` means the
+      // second one updates rather than duplicate-inserts.
+      await this.mongoDb.collection('classes').updateOne(
+        { id: newClass.id },
+        { $setOnInsert: newClass },
+        { upsert: true }
+      );
+    }
+    if (this.data) {
+      if (!this.data.classes.some(c => c.id === newClass.id)) {
+        this.data.classes.push(newClass);
+      }
+      if (!this.mongoDb) await this.save();
+    }
+  }
+
   async updateStudent(studentId: string, updates: Partial<Student>) {
     await this.mongoDb!.collection('students').updateOne({ id: studentId }, { $set: updates });
     const s = await this.mongoDb!.collection<Student>('students').findOne({ id: studentId });

--- a/backend/src/routes/students.ts
+++ b/backend/src/routes/students.ts
@@ -236,6 +236,12 @@ export function registerStudentRoutes(app: express.Express) {
     }
 
     await dbStore.addStudent(newStudent);
+    // Issue: bulk diagnostic generation ("not authorized for Class N")
+    // traced back to no ClassGroup document ever being created for
+    // live-registered classes — only the seed data had one. Ensure it
+    // exists now so class-tabs, bulk-diagnostic authorization, etc. all
+    // work for this student's class going forward.
+    await dbStore.ensureClassExists(schoolId, trimmedClassGroup, trimmedSection, actingUser.id);
     // Track in-memory so bulk operations detect intra-batch duplicates too
     existingAadhars.add(rawAadhar);
     return { student: newStudent };

--- a/scripts/backfill_missing_class_records.ts
+++ b/scripts/backfill_missing_class_records.ts
@@ -1,0 +1,108 @@
+/* eslint-disable no-console */
+/**
+ * Backfill missing ClassGroup ("classes" collection) documents for
+ * students registered before dbStore.ensureClassExists() existed.
+ *
+ * Root cause: only the original seed data ever populated the `classes`
+ * collection. Registering a student (single POST /api/students or
+ * POST /api/students/bulk-import) created a Student record tagged with a
+ * classGroup/section, but nothing created the matching ClassGroup document
+ * those strings imply. Several features key off ClassGroup existing for a
+ * teacher/school -- the Teacher Dashboard's class-tab bar (issue #291), and
+ * bulk diagnostic generation's authorization check ("You are not
+ * authorized to generate diagnostic papers for Class N", reported live on
+ * a teacher whose real 9-student Class 2 roster had no ClassGroup record).
+ *
+ * This is a one-time catch-up for students that predate the fix in
+ * createStudentFromData (students.ts) that now calls ensureClassExists()
+ * on every new registration going forward. Safe to re-run -- it only
+ * inserts a ClassGroup if one doesn't already exist for that
+ * schoolId+className+section.
+ *
+ * Usage:
+ *   tsx scripts/backfill_missing_class_records.ts --dry-run   # log plan, no writes
+ *   tsx scripts/backfill_missing_class_records.ts --apply     # insert into Atlas
+ *
+ * Reads MONGODB_URI from the backend/.env file (same source as `npm run dev:backend`).
+ */
+import { MongoClient } from 'mongodb';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type Student = { id: string; name: string; schoolId: string; classGroup: string; section: string; teacherId?: string };
+type ClassGroup = { id: string; schoolId: string; className: string; section: string; teacherId: string };
+
+function loadMongoUri(): string {
+  const envPath = path.resolve(__dirname, '..', 'backend', '.env');
+  if (!fs.existsSync(envPath)) {
+    throw new Error(`backend/.env not found at ${envPath}`);
+  }
+  const text = fs.readFileSync(envPath, 'utf-8');
+  const match = text.match(/^MONGODB_URI\s*=\s*(.+)$/m);
+  if (!match) throw new Error('MONGODB_URI not set in backend/.env');
+  return match[1].trim().replace(/^["']|["']$/g, '');
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const dryRun = process.argv.includes('--dry-run') || !apply;
+
+  const uri = loadMongoUri();
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db();
+
+  const students = await db.collection<Student>('students').find({}).toArray();
+  const existingClasses = await db.collection<ClassGroup>('classes').find({}).toArray();
+  const existingKeys = new Set(existingClasses.map(c => `${c.schoolId}|${c.className}|${c.section}`));
+
+  // Group students by school+class+section so we backfill one ClassGroup
+  // per real combination, not one per student. Prefer the first teacher-
+  // owned student's teacherId if any exist in that group (matches how a
+  // real teacher's own registrations would have set it going forward);
+  // falls back to a placeholder if the group is entirely non-teacher-owned
+  // (e.g. a volunteer/admin-registered class) -- ClassGroup.teacherId is a
+  // required field but volunteer/admin authorization checks key off
+  // schoolId/assignedSchools, not teacherId, so a placeholder there is
+  // harmless for those paths.
+  const groups = new Map<string, { schoolId: string; className: string; section: string; teacherId: string }>();
+  for (const s of students) {
+    const key = `${s.schoolId}|${s.classGroup}|${s.section}`;
+    if (existingKeys.has(key)) continue;
+    if (!groups.has(key)) {
+      groups.set(key, { schoolId: s.schoolId, className: s.classGroup, section: s.section, teacherId: s.teacherId || 'unassigned' });
+    } else if (s.teacherId && groups.get(key)!.teacherId === 'unassigned') {
+      groups.get(key)!.teacherId = s.teacherId;
+    }
+  }
+
+  console.log(`Found ${students.length} students, ${existingClasses.length} existing ClassGroup records.`);
+  console.log(`${groups.size} missing ClassGroup(s) to create:`);
+  for (const g of groups.values()) {
+    console.log(`  - ${g.schoolId} / ${g.className} / ${g.section} (teacherId: ${g.teacherId})`);
+  }
+
+  if (dryRun) {
+    console.log('\nDry run only -- no writes made. Re-run with --apply to insert.');
+    await client.close();
+    return;
+  }
+
+  let inserted = 0;
+  for (const g of groups.values()) {
+    const id = 'c_' + g.schoolId + '_' + g.className.replace(/\s+/g, '') + '_' + g.section;
+    await db.collection('classes').updateOne(
+      { id },
+      { $setOnInsert: { id, ...g } },
+      { upsert: true }
+    );
+    inserted++;
+  }
+  console.log(`\nApplied: ${inserted} ClassGroup record(s) created (or already existed, safely skipped).`);
+  await client.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

Reported live via screenshot: Bulk Diagnostic Generator said **"You are not authorized to generate diagnostic papers for Class 2"** for a teacher whose 9 students in Class 2 were all real, correctly enrolled, and visible right there in the same screen ("Enrolled Students in Class 2: ... 9 Real Students").

## Root cause

Only the original seed data ever populated the `classes` collection — there was no `addClass` function anywhere in `db.ts`. Registering a student (single `POST /api/students` or `POST /api/students/bulk-import`) creates a `Student` record tagged with a `classGroup`/`section`, but nothing ever created the matching `ClassGroup` document those strings imply.

Several features key off a `ClassGroup` existing for a teacher/school:
- The Teacher Dashboard's class-tab bar — this is the actual underlying gap behind #291's "nationwide fallback" bug (that fix removed the dangerous symptom, not this root cause).
- Bulk diagnostic generation's authorization check (`diagnosticBulk.ts:80`), which looks up a matching `ClassGroup` and 403s when none exists — exactly what's reported here.

## Fix

- New `dbStore.ensureClassExists()` in `db.ts` — idempotent, upserts on a deterministic `id` so two near-simultaneous registrations into a brand-new class can't race into duplicates.
- Called from `createStudentFromData()` (`students.ts`), the single choke point both single and bulk student registration already go through, right after the student itself is created.
- One-time backfill script `scripts/backfill_missing_class_records.ts` (`--dry-run`/`--apply`, same pattern as #284's `add_class1_students.ts`) for students registered **before** this fix existed — the forward fix alone doesn't help teachers whose rosters are already live, like the one in the screenshot.

## Testing

- `node --check` on the built backend passed.
- Verified live against a local isolated MongoDB (not production): registered a new student into a class with no existing `ClassGroup`, confirmed `GET /api/classes` now returns it, and confirmed `POST /api/diagnostic/bulk` for that class succeeds (previously would have 403'd with the exact reported error).
- Ran the backfill script: dry-run found 1 real legacy gap (`gps-bth-006`/Class 2/A), applied it, re-ran dry-run and confirmed 0 remaining gaps — idempotent.

## Deploy note

**This PR alone doesn't fix the teacher in the screenshot** — after merging, the backfill script needs to run once against production Atlas (`tsx scripts/backfill_missing_class_records.ts --apply`) to catch up existing rosters. I'll run that as part of the redeploy once this is merged.