### PR TITLE
fix: scope /api/diagnostic/bulk's fallback student fetch to caller's own school

### DIFF
--- a/backend/src/routes/diagnosticBulk.ts
+++ b/backend/src/routes/diagnosticBulk.ts
@@ -44,8 +44,33 @@ export function registerDiagnosticBulkRoutes(app: express.Express) {
       paperStudents = reqStudents;
       paperCount = reqStudents.length;
     } else {
-      // Automatically fetch real enrolled students for this class from MongoDB
-      const allDbStudents = await dbStore.getStudents();
+      // Automatically fetch real enrolled students for this class — scoped
+      // to the requesting user's own school(s), same as every other
+      // role-scoped route in this app. The real frontend
+      // (BulkDiagnosticWorkflow.tsx) always sends an explicit `students`
+      // array pre-fetched from the scoped /api/students, so this branch is
+      // only reachable via a direct API call that omits it — caught while
+      // testing #304's fix, where an unscoped fetch here returned every
+      // Class-N student nationwide (28,813 for one real class number)
+      // instead of the caller's own roster. A 5000-set ceiling downstream
+      // stopped it from actually generating anything, but the query itself
+      // had no business reading outside the caller's scope in the first
+      // place — not otherwise reachable by a real user today, but
+      // defense-in-depth against a future caller of this branch.
+      let scopedSchoolIds: string[] | undefined;
+      if (user.role === UserRole.TEACHER || user.role === UserRole.SCHOOL) {
+        scopedSchoolIds = user.schoolId ? [user.schoolId] : [];
+      } else if (user.role === UserRole.VOLUNTEER) {
+        scopedSchoolIds = user.assignedSchools || [];
+      } else if (user.role === UserRole.BLOCK_ADMIN) {
+        const schools = await dbStore.getSchools();
+        scopedSchoolIds = schools.filter(s => s.blockCode === user.blockCode).map(s => s.id);
+      }
+      // SUPERADMIN/ADMIN/DISTRICT_ADMIN: no scope restriction here — they
+      // already receive unrestricted authorization below (line ~93-ish),
+      // same as the rest of this route's role tiering.
+
+      const allDbStudents = await dbStore.getStudents(scopedSchoolIds ? { schoolId: scopedSchoolIds } : undefined);
       const targetClassName = `Class ${classNumber}`;
       const enrolled = allDbStudents.filter(s => {
         const cg = (s.classGroup || '').toLowerCase().trim();


### PR DESCRIPTION
## Problem

Found while verifying #304's fix live: a request to `POST /api/diagnostic/bulk` that omits the `students` array falls back to `dbStore.getStudents()` with **no scoping** — every student matching the target class name, nationwide, not just the caller's own roster. A test call for one real class number returned `totalStudents: 28813` instead of the teacher's actual 9 enrolled students.

## Is this actually reachable by a real user?

No. The real frontend (`BulkDiagnosticWorkflow.tsx`) always sends an explicit `students` array, pre-fetched from the already-scoped `/api/students` — this fallback branch only runs on a direct API call that omits that field, which only a malformed manual request (mine, while testing) triggers. A hard 5000-set ceiling downstream also caught the test before anything was actually generated.

Fixing anyway as defense-in-depth — the unscoped query had no business reading outside the caller's role-appropriate schools regardless of whether today's frontend happens to avoid triggering it.

## Fix

Scopes the fallback fetch by role, mirroring this same route's own existing authorization tiering a few lines below it:
- `TEACHER`/`SCHOOL` → own `schoolId`
- `VOLUNTEER` → `assignedSchools`
- `BLOCK_ADMIN` → schools in their block
- `SUPERADMIN`/`ADMIN` → unrestricted (matches their existing unrestricted authorization)

## Testing

- `node --check` on the built backend passed.
- Verified live against a local isolated MongoDB (not production): the same malformed (students-array-omitted) request now returns `totalStudents` matching only the caller's own enrolled students in that class, not every student nationwide.