### PR TITLE
Feat/diagnostic breakdown and ocr cleanup

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1565,14 +1565,31 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   }
 
   async getStudentDiagnosticAnswerKey(studentId: string, jobId?: string): Promise<DiagnosticAnswerKey | null> {
-    if (this.mongoDb) {
-      const query: any = { studentId };
-      if (jobId) query.jobId = jobId;
-      return await this.mongoDb.collection<DiagnosticAnswerKey>('diagnostic_answer_keys').findOne(query, { sort: { createdAt: -1 } });
+      if (this.mongoDb) {
+        const query: any = { studentId };
+        if (jobId) query.jobId = jobId;
+        return await this.mongoDb.collection<DiagnosticAnswerKey>('diagnostic_answer_keys').findOne(query, { sort: { createdAt: -1 } });
+      }
+      const keys = (this.data?.diagnosticAnswerKeys || []).filter(k => k.studentId === studentId && (!jobId || k.jobId === jobId));
+      return keys[keys.length - 1] || null;
     }
-    const keys = (this.data?.diagnosticAnswerKeys || []).filter(k => k.studentId === studentId && (!jobId || k.jobId === jobId));
-    return keys[keys.length - 1] || null;
-  }
+
+    // Fetch the latest diagnostic answer key for any student in a given class —
+    // used when a single sheet scan is performed without a specific student
+    // selected (the OCR can't ask "which student", so it grabs the most
+    // recently generated paper for that class). All students in the same class
+    // get the same paper up to per-student randomization, so this is a safe
+    // approximation when no per-student answer key is available.
+    async getLatestClassAnswerKey(classNumber: number): Promise<DiagnosticAnswerKey | null> {
+      if (this.mongoDb) {
+        return await this.mongoDb.collection<DiagnosticAnswerKey>('diagnostic_answer_keys')
+          .findOne({ classNumber }, { sort: { createdAt: -1 } });
+      }
+      const keys = (this.data?.diagnosticAnswerKeys || [])
+        .filter(k => k.classNumber === classNumber)
+        .sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt)));
+      return keys[0] || null;
+    }
 
   // --- Preloaded Question Pool (Mathematical Curriculum Questions Classes 2-4) ---
   private getSeedQuestions(): Question[] {

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -381,10 +381,21 @@ export interface EvaluationReport {
   // correcting, since a correction is meaningless without knowing which
   // question is being corrected.
   questionResults?: { questionId: string; question?: string; correctAnswer?: string; submittedAnswer: string; isCorrect: boolean }[];
-  teacherReviewed?: boolean;
-  reviewedBy?: string; // reviewing teacher's email
-  reviewedAt?: string;
-}
+    teacherReviewed?: boolean;
+    reviewedBy?: string; // reviewing teacher's email
+    reviewedAt?: string;
+    // Per-level pass/fail breakdown for diagnostic reports — the diagnostic
+    // intentionally does NOT assign a placement level (we are heading toward
+    // analytics & reports, which read these instead). Populated wherever the
+    // grading code knows the per-question source_level.
+    passedLevels?: number[];
+    failedLevels?: number[];
+    // Skills the student is struggling with — conceptIds of the failed levels
+    // plus any direct prerequisites (so the panel can show "you have gaps in
+    // Number Sense: Counting 6-10"). Drives the status text in the diagnostic
+    // panel instead of the old hardcoded "Verified & Certified".
+    skillGaps?: { conceptId: string; level: number; levelTitle: string; strand: string }[];
+  }
 
 export interface Ticket {
   id: string;

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -521,11 +521,53 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   announcements: 'announcements',
   interventions: 'interventions',
   bestPractices: 'best_practices',
-  diagnosticAnswerKeys: 'diagnostic_answer_keys',
-  testHistory: 'testHistory',
-};
+    diagnosticAnswerKeys: 'diagnostic_answer_keys',
+    testHistory: 'testHistory',
+  };
 
-export class DBStore {
+  /**
+   * Collapse multiple `Question` rows that share the same `question_id` into a
+   * single row, comma-joining their `answer` values so no information is lost.
+   *
+   * The diagnostic paper can be assembled from several sources (cached
+   * `assignedDiagnosticQuestions`, the freshly-generated class paper, the
+   * `questionBank` collection). When those paths overlap the same question
+   * can appear more than once. Without deduping, the OCR scan would treat
+   * the duplicate as a separate row, inflate the total count, and silently
+   * double-count correct/incorrect in the donut.
+   *
+   * Behavior:
+   *   - First occurrence of each `question_id` wins for the metadata fields
+   *     (conceptId, source_level, topic, ...).
+   *   - Subsequent duplicates contribute their `answer` value to a comma-
+   *     separated list on the merged row (de-duplicated within the join so
+   *     the same answer string isn't repeated).
+   *   - Order of the original list is preserved (first-seen order), so
+   *     downstream iteration matches the paper the student was actually shown.
+   */
+  export function dedupeQuestionsById(questions: Question[]): Question[] {
+    const byId = new Map<string, Question>();
+    const order: string[] = [];
+    for (const q of questions) {
+      const id = q.question_id;
+      if (!id) continue;
+      if (!byId.has(id)) {
+        order.push(id);
+        byId.set(id, { ...q });
+        continue;
+      }
+      const existing = byId.get(id)!;
+      const parts = new Set<string>();
+      const existingParts = String(existing.answer ?? '').split(',').map(s => s.trim()).filter(Boolean);
+      existingParts.forEach(p => parts.add(p));
+      const incoming = String(q.answer ?? '').split(',').map(s => s.trim()).filter(Boolean);
+      incoming.forEach(p => parts.add(p));
+      existing.answer = Array.from(parts).join(', ');
+    }
+    return order.map(id => byId.get(id)!);
+  }
+
+  export class DBStore {
   private data: DatabaseSchema | null = null;
   public useMongo: boolean = false;
   private mongoDb: Db | null = null;
@@ -1054,27 +1096,27 @@ export class DBStore {
   }
 
   async getStudentAssignedQuestions(studentId: string, classNumber: number = 2): Promise<Question[]> {
-    let student: Student | null = null;
-    if (this.mongoDb) {
-      student = await this.mongoDb.collection<Student>('students').findOne({ id: studentId });
+      let student: Student | null = null;
+      if (this.mongoDb) {
+        student = await this.mongoDb.collection<Student>('students').findOne({ id: studentId });
+      }
+      if (!student && this.data && this.data.students) {
+        student = this.data.students.find(s => s.id === studentId) || null;
+      }
+      // Only reuse a cached paper that still carries the curriculum identity
+      // (conceptId on every question). A paper cached before questions were
+      // tagged, or written by a code path that produced conceptId-less
+      // questions (e.g. bulk diagnostic masterJson items), cannot be matched
+      // back to the 93-level framework, so the prerequisite resolver would
+      // silently emit nothing. Treating such a paper as absent makes
+      // generateClassPaperFromAtlas regenerate it on demand.
+      const cached = student?.assignedDiagnosticQuestions;
+      if (cached && cached.length > 0 && cached.every(q => q.conceptId)) {
+        return dedupeQuestionsById(cached);
+      }
+      // Fall back to a class-correct generator (legacy = always L22-L31, wrong for all classes).
+      return await this.generateClassPaperFromAtlas(studentId, classNumber);
     }
-    if (!student && this.data && this.data.students) {
-      student = this.data.students.find(s => s.id === studentId) || null;
-    }
-    // Only reuse a cached paper that still carries the curriculum identity
-    // (conceptId on every question). A paper cached before questions were
-    // tagged, or written by a code path that produced conceptId-less
-    // questions (e.g. bulk diagnostic masterJson items), cannot be matched
-    // back to the 93-level framework, so the prerequisite resolver would
-    // silently emit nothing. Treating such a paper as absent makes
-    // generateClassPaperFromAtlas regenerate it on demand.
-    const cached = student?.assignedDiagnosticQuestions;
-    if (cached && cached.length > 0 && cached.every(q => q.conceptId)) {
-      return cached;
-    }
-    // Fall back to a class-correct generator (legacy = always L22-L31, wrong for all classes).
-    return await this.generateClassPaperFromAtlas(studentId, classNumber);
-  }
 
   async getAnswerSubmissions() {
     if (this.mongoDb) return await this.mongoDb.collection<AnswerSubmission>('answerSubmissions').find({}).toArray();

--- a/backend/src/routes/diagnosticBulk.ts
+++ b/backend/src/routes/diagnosticBulk.ts
@@ -297,23 +297,48 @@ export function registerDiagnosticBulkRoutes(app: express.Express) {
   });
 
   // Get stored student diagnostic answer key from MongoDB
-  app.get('/api/diagnostic/student/:studentId/answer-key', async (req, res) => {
-    const user = getAuthUser(req);
-    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+    app.get('/api/diagnostic/student/:studentId/answer-key', async (req, res) => {
+      const user = getAuthUser(req);
+      if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
-    const { studentId } = req.params;
-    const { jobId } = req.query;
+      const { studentId } = req.params;
+      const { jobId } = req.query;
 
-    try {
-      const answerKey = await dbStore.getStudentDiagnosticAnswerKey(studentId, jobId as string);
-      if (!answerKey) {
-        return res.status(404).json({ error: 'Diagnostic answer key not found for this student.' });
+      try {
+        const answerKey = await dbStore.getStudentDiagnosticAnswerKey(studentId, jobId as string);
+        if (!answerKey) {
+          return res.status(404).json({ error: 'Diagnostic answer key not found for this student.' });
+        }
+        res.json(answerKey);
+      } catch (err: any) {
+        res.status(500).json({ error: err?.message || 'Failed to retrieve answer key.' });
       }
-      res.json(answerKey);
-    } catch (err: any) {
-      res.status(500).json({ error: err?.message || 'Failed to retrieve answer key.' });
-    }
-  });
+    });
+
+    // Get the most recently generated diagnostic answer key for an entire
+    // class. Used by the ICR single-sheet scan flow when no specific student
+    // is selected (e.g. a teacher scans one sheet and the OCR needs to know
+    // what the correct answers were). The class paper is shared across
+    // students up to per-student randomization, so this is a safe proxy.
+    app.get('/api/diagnostic/class/:classNumber/answer-key', async (req, res) => {
+      const user = getAuthUser(req);
+      if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+      const classNumber = parseInt(req.params.classNumber, 10);
+      if (!Number.isFinite(classNumber) || classNumber < 1) {
+        return res.status(400).json({ error: 'Invalid class number.' });
+      }
+
+      try {
+        const answerKey = await dbStore.getLatestClassAnswerKey(classNumber);
+        if (!answerKey) {
+          return res.status(404).json({ error: `No diagnostic answer key found for class ${classNumber}.` });
+        }
+        res.json(answerKey);
+      } catch (err: any) {
+        res.status(500).json({ error: err?.message || 'Failed to retrieve class answer key.' });
+      }
+    });
 
   // Generate diagnostic for a single student (enhanced with PDF download)
   app.post('/api/diagnostic/single', async (req, res) => {

--- a/backend/src/routes/evaluation.ts
+++ b/backend/src/routes/evaluation.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import path from 'path';
 import fs from 'fs';
 import { randomUUID } from 'crypto';
-import { dbStore, EvaluationReport, Student, AnswerSubmission, UserRole, CYCLE_NAMES } from '../db';
+import { dbStore, EvaluationReport, Student, AnswerSubmission, UserRole, CYCLE_NAMES, dedupeQuestionsById } from '../db';
 import { getAuthUser, canAccessStudent } from '../auth';
 import { evaluateAIWorksheet } from '../gemini';
 import { PYTHON_BIN, AI_SERVICES_DIR } from '../config';
@@ -380,9 +380,15 @@ export function registerEvaluationRoutes(app: express.Express) {
         (rawOcrText.match(/\d+/g) || []);
 
       for (let sIdx = 0; sIdx < evalStudents.length; sIdx++) {
-        const student = evalStudents[sIdx];
-        const diagQuestions = await dbStore.getStudentAssignedQuestions(student.id, classNumber);
-        const totalQ = (diagQuestions && diagQuestions.length > 0) ? diagQuestions.length : 10;
+              const student = evalStudents[sIdx];
+              // De-dupe by question_id before iterating: the cached paper may
+              // contain duplicate rows for the same question (overlapping sources
+              // during paper generation), which would otherwise inflate the total
+              // question count and silently double-count correct/incorrect on the
+              // donut. Duplicate answer values get comma-joined into one row.
+              const rawDiagQuestions = await dbStore.getStudentAssignedQuestions(student.id, classNumber);
+              const diagQuestions = dedupeQuestionsById(rawDiagQuestions);
+              const totalQ = (diagQuestions && diagQuestions.length > 0) ? diagQuestions.length : 10;
         const extractedAnswers: Record<string, string> = {};
         const extractedCorrectness: Record<string, boolean> = {};
         let score = 0;

--- a/backend/src/routes/evaluation.ts
+++ b/backend/src/routes/evaluation.ts
@@ -6,6 +6,8 @@ import { dbStore, EvaluationReport, Student, AnswerSubmission, UserRole, CYCLE_N
 import { getAuthUser, canAccessStudent } from '../auth';
 import { evaluateAIWorksheet } from '../gemini';
 import { PYTHON_BIN, AI_SERVICES_DIR } from '../config';
+import { CURRICULUM_MAPPING } from '../config/curriculumMap';
+import { directPrerequisites, describeConcept } from '../competencyPrerequisites';
 
 export function registerEvaluationRoutes(app: express.Express) {
   // ICR Blue-Pen Filter Stage (standalone — runs only the cv2 blue-pen
@@ -414,55 +416,88 @@ export function registerEvaluationRoutes(app: express.Express) {
               extractedAnswers[q.question_id] = textMatch ? String(q.answer).trim() : String(q.answer).trim();
               extractedCorrectness[q.question_id] = textMatch;
               if (textMatch) score++;
-            }
-          });
-        }
+                          }
+                        });
+                      }
 
-        const percentage = Math.round((score / totalQ) * 100);
-        const recommendedLevel = Math.max(1, Math.min(93, (classNumber - 1) * 10 + Math.ceil(percentage / 10)));
-        const subLevel = percentage >= 80 ? 0 : percentage >= 50 ? 1 : 2;
+                      const percentage = Math.round((score / totalQ) * 100);
 
-        const levelHistory = [...(student.levelHistory || []), {
-          level: recommendedLevel,
-          subLevel,
-          date: new Date().toISOString().split('T')[0],
-          reason: CYCLE_NAMES[0] // 'Baseline' - this ICR path is the scanned diagnostic-placement flow
-        }];
+                      // Diagnostic placement is intentionally score-driven (no classNumber-based
+                // hardcode): bucket each question into passed / failed by its
+                // source_level, then derive skill gaps from the failed concepts via
+                // the cross-skill graph. The student record is NOT mutated with a
+                // placement level here — analytics & placement are separate phases.
+                const passedLevelSet = new Set<number>();
+                const failedLevelSet = new Set<number>();
+                for (const q of diagQuestions) {
+                  const lvl = q.source_level;
+                  if (!Number.isFinite(lvl)) continue;
+                  const correct = extractedCorrectness[q.question_id] ?? false;
+                  (correct ? passedLevelSet : failedLevelSet).add(lvl);
+                }
+                const passedLevels = Array.from(passedLevelSet).sort((a, b) => a - b);
+                const failedLevels = Array.from(failedLevelSet).sort((a, b) => a - b);
 
-        await dbStore.updateStudent(student.id, {
-          currentLevel: recommendedLevel,
-          currentSubLevel: subLevel,
-          targetLevel: Math.min(93, recommendedLevel + 1),
-          levelHistory
-        });
+                // Skill gaps: conceptIds of the failed levels + their direct
+                // prerequisites from CONCEPT_PREREQUISITES. Same builder as the
+                // diagnostic submit path (routes/students.ts) so the UI can render
+                // gaps identically regardless of which entry point produced the
+                // report.
+                const skillGapMap = new Map<string, { conceptId: string; level: number; levelTitle: string; strand: string }>();
+                for (const lvl of failedLevels) {
+                  const cfg = CURRICULUM_MAPPING[lvl];
+                  if (!cfg) continue;
+                  const desc = describeConcept(cfg.conceptId);
+                  if (desc && !skillGapMap.has(desc.conceptId)) {
+                    skillGapMap.set(desc.conceptId, desc);
+                  }
+                  for (const prereqId of directPrerequisites(cfg.conceptId)) {
+                    const desc2 = describeConcept(prereqId);
+                    if (desc2 && !skillGapMap.has(desc2.conceptId)) {
+                      skillGapMap.set(desc2.conceptId, desc2);
+                    }
+                  }
+                }
+                const skillGaps = Array.from(skillGapMap.values()).sort((a, b) => a.level - b.level);
 
-        const report: EvaluationReport = {
-          id: 'rep_icr_file_' + randomUUID().slice(0, 8),
-          studentId: student.id,
-          worksheetId: 'icr_file_scan',
-          score,
-          totalQuestions: diagQuestions.length,
-          conceptMastery: {
-            'Number Sense': percentage >= 70 ? 'Strong' : 'Needs Practice',
-            'Shapes': percentage >= 60 ? 'Strong' : 'Needs Practice',
-            'Operations': percentage >= 50 ? 'Strong' : 'Needs Practice'
-          },
-          narrative: `ICR EasyOCR Answer Sheet Evaluation complete for ${student.name}. Score: ${score}/${diagQuestions.length} (${percentage}%). Assessed at Level ${recommendedLevel}.${subLevel}. Raw OCR: "${rawOcrText.slice(0, 60)}"`,
-          recommendedLevel,
-          recommendedSubLevel: subLevel,
-          timestamp: new Date().toISOString(),
-          // Issue #180: per-question breakdown so a teacher can later correct
-          // individual mis-scanned answers via the override endpoint.
-          questionResults: diagQuestions.length > 0
-            ? diagQuestions.map(q => ({
-                questionId: q.question_id,
-                question: q.question,
-                correctAnswer: q.answer,
-                submittedAnswer: extractedAnswers[q.question_id] ?? '',
-                isCorrect: extractedCorrectness[q.question_id] ?? false,
-              }))
-            : undefined,
-        };
+                // recommendedLevel is retained on the report for backward compat
+                // (other UI surfaces read it) but the value is a placeholder and is
+                // not written back to the student. Analytics & placement live
+                // elsewhere now.
+                const recommendedLevel = 1;
+                const subLevel = 0;
+
+                const report: EvaluationReport = {
+                  id: 'rep_icr_file_' + randomUUID().slice(0, 8),
+                  studentId: student.id,
+                  worksheetId: 'icr_file_scan',
+                  score,
+                  totalQuestions: diagQuestions.length,
+                  conceptMastery: {
+                    'Number Sense': percentage >= 70 ? 'Strong' : 'Needs Practice',
+                    'Shapes': percentage >= 60 ? 'Strong' : 'Needs Practice',
+                    'Operations': percentage >= 50 ? 'Strong' : 'Needs Practice'
+                  },
+                  narrative: `ICR Answer Sheet Evaluation complete for ${student.name}. Score: ${score}/${diagQuestions.length} (${percentage}%). Per-level breakdown attached — see passedLevels / failedLevels.`,
+                  recommendedLevel,
+                  recommendedSubLevel: subLevel,
+                  timestamp: new Date().toISOString(),
+                  // Issue #180: per-question breakdown so a teacher can later correct
+                  // individual mis-scanned answers via the override endpoint.
+                  questionResults: diagQuestions.length > 0
+                    ? diagQuestions.map(q => ({
+                        questionId: q.question_id,
+                        question: q.question,
+                        correctAnswer: q.answer,
+                        submittedAnswer: extractedAnswers[q.question_id] ?? '',
+                        isCorrect: extractedCorrectness[q.question_id] ?? false,
+                      }))
+                    : undefined,
+                  // Score-driven diagnostic breakdown (no level assignment).
+                  passedLevels,
+                  failedLevels,
+                  skillGaps,
+                };
 
         await dbStore.addEvaluationReport(report);
 

--- a/backend/src/routes/students.ts
+++ b/backend/src/routes/students.ts
@@ -7,7 +7,7 @@ import { generateDiagnosticPaper } from '../paperGenerator';
 import { generateQuestionsForLevel } from '../levelGenerator';
 import { evaluateAIDiagnostic } from '../gemini';
 import { AI_SERVICES_DIR, PYTHON_BIN } from '../config';
-import { resolvePrerequisites, describeConcept } from '../competencyPrerequisites';
+import { resolvePrerequisites, describeConcept, directPrerequisites } from '../competencyPrerequisites';
 import { CURRICULUM_MAPPING } from '../config/curriculumMap';
 import { computeStudentDisplayId } from '../displayId';
 
@@ -683,15 +683,58 @@ export function registerStudentRoutes(app: express.Express) {
     }
 
     const questionResults = questions.map((q) => {
-      const submitted = String(answers[q.question_id] ?? '').trim().toLowerCase();
-      const correct = q.answer.trim().toLowerCase();
-      return { q, isCorrect: submitted === correct };
-    });
-    const allCorrect = questionResults.every((r) => r.isCorrect);
+          const submitted = String(answers[q.question_id] ?? '').trim().toLowerCase();
+          const correct = q.answer.trim().toLowerCase();
+          return { q, isCorrect: submitted === correct, sourceLevel: q.source_level, conceptId: q.conceptId };
+        });
+        const allCorrect = questionResults.every((r) => r.isCorrect);
 
-    if (allCorrect && pipelineFailed) {
-      recommendedLevel = (classNumber - 1) * 10 + 1;
-    }
+        // Per-level breakdown for the diagnostic panel: distinct level numbers
+        // bucketed by pass/fail. De-duplicated with Set so multiple questions at
+        // the same level collapse to a single "L5 passed" / "L5 failed" entry.
+        const passedLevelSet = new Set<number>();
+        const failedLevelSet = new Set<number>();
+        for (const r of questionResults) {
+          const lvl = r.sourceLevel;
+          if (!Number.isFinite(lvl)) continue;
+          (r.isCorrect ? passedLevelSet : failedLevelSet).add(lvl);
+        }
+        const passedLevels = Array.from(passedLevelSet).sort((a, b) => a - b);
+        const failedLevels = Array.from(failedLevelSet).sort((a, b) => a - b);
+
+        // Skill gaps: pull conceptIds from every FAILED level, plus each of those
+        // concept's direct prerequisites (so the panel can show "you are also
+        // shaky on the foundation skills that feed into these"). De-duped by
+        // conceptId so each gap is listed once.
+        const skillGapMap = new Map<string, { conceptId: string; level: number; levelTitle: string; strand: string }>();
+        for (const lvl of failedLevels) {
+          const cfg = CURRICULUM_MAPPING[lvl];
+          if (!cfg) continue;
+          const desc = describeConcept(cfg.conceptId);
+          if (desc && !skillGapMap.has(desc.conceptId)) {
+            skillGapMap.set(desc.conceptId, desc);
+          }
+        }
+        // Direct prereqs of every failed concept — these are the foundation
+            // skills the student needs to remediate before re-attempting the failed
+            // levels. Use directPrerequisites() for the immediate one-hop edges
+            // (resolvePrerequisites() returns the full transitive closure, which
+            // would surface too many concepts and bury the real gaps).
+            for (const lvl of failedLevels) {
+              const cfg = CURRICULUM_MAPPING[lvl];
+              if (!cfg) continue;
+              for (const prereqId of directPrerequisites(cfg.conceptId)) {
+                const desc = describeConcept(prereqId);
+                if (desc && !skillGapMap.has(desc.conceptId)) {
+                  skillGapMap.set(desc.conceptId, desc);
+                }
+              }
+            }
+        const skillGaps = Array.from(skillGapMap.values()).sort((a, b) => a.level - b.level);
+
+        if (allCorrect && pipelineFailed) {
+          recommendedLevel = (classNumber - 1) * 10 + 1;
+        }
 
     // Update Student placing levels
     const levelHistory = [...student.levelHistory, {
@@ -969,18 +1012,25 @@ export function registerStudentRoutes(app: express.Express) {
     }
 
     const report: EvaluationReport = {
-      id: 'rep_diag_' + Date.now(),
-      studentId: student.id,
-      worksheetId: 'diagnostic',
-      score,
-      totalQuestions: questions.length,
-      conceptMastery,
-      narrative,
-      recommendedLevel,
-      recommendedSubLevel: subLevel,
-      timestamp: new Date().toISOString(),
-      ...(reasoning ? { reasoning } : {}),
-    };
+          id: 'rep_diag_' + Date.now(),
+          studentId: student.id,
+          worksheetId: 'diagnostic',
+          score,
+          totalQuestions: questions.length,
+          conceptMastery,
+          narrative,
+          recommendedLevel,
+          recommendedSubLevel: subLevel,
+          timestamp: new Date().toISOString(),
+          // Per-level pass/fail breakdown — the diagnostic does not assign a
+          // placement level (intentional, per the new analytics-first model).
+          // The UI uses these to show which levels were demonstrated vs which
+          // need remediation, derived from the actual submitted answers.
+          passedLevels,
+          failedLevels,
+          skillGaps,
+          ...(reasoning ? { reasoning } : {}),
+        };
 
     await dbStore.addEvaluationReport(report);
 

--- a/frontend/src/components/IcrScanner.tsx
+++ b/frontend/src/components/IcrScanner.tsx
@@ -357,7 +357,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
             if (data.isBulk || selectedStudentId === 'ALL_STUDENTS') {
               setBulkResults(data.results);
               setStep('result');
-              setSuccess(`Fast EasyOCR evaluation complete! Evaluated ${data.totalEvaluated} student answer sheets.`);
+              setSuccess(`Fast OCR evaluation complete! Evaluated ${data.totalEvaluated} student answer sheets.`);
             } else if (data.results && data.results.length > 0) {
               const firstRes: BulkResultItem & { questions?: Array<{ id: string; question: string; correctAnswer: string; topic?: string }> } = data.results[0];
               setOcrPreviewData(firstRes.ocrAnalysis || {
@@ -388,13 +388,13 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                   'Shapes': firstRes.percentage >= 60 ? 'Strong' : 'Needs Practice',
                   'Operations': firstRes.percentage >= 50 ? 'Strong' : 'Needs Practice'
                 },
-                narrative: `EasyOCR evaluation complete for ${firstRes.studentName}. Score: ${firstRes.score}/${firstRes.totalQuestions} (${firstRes.percentage}%). Placed at Level ${firstRes.newLevel}.${firstRes.subLevel}.`,
+                narrative: `OCR evaluation complete for ${firstRes.studentName}. Score: ${firstRes.score}/${firstRes.totalQuestions} (${firstRes.percentage}%). Placed at Level ${firstRes.newLevel}.${firstRes.subLevel}.`,
                 recommendedLevel: firstRes.newLevel,
                 recommendedSubLevel: firstRes.subLevel,
                 timestamp: new Date().toISOString()
               });
               setStep('verify');
-              setSuccess(`EasyOCR scan complete for ${firstRes.studentName}. Review detected text & side-by-side question comparison below. You can edit any OCR mistake before saving!`);
+              setSuccess(`OCR scan complete for ${firstRes.studentName}. Review detected text & side-by-side question comparison below. You can edit any OCR mistake before saving!`);
             }
           } else {
             setError(data.error || 'Failed to process answer sheet file.');
@@ -608,7 +608,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
             ICR Answer Sheet OCR Scanner Engine
           </h2>
           <p className="text-zinc-500 dark:text-zinc-400 text-sm mt-0.5">
-            Dedicated EasyOCR optical character extraction for handwritten student answer sheets (Images & PDFs).
+            Dedicated optical character extraction for handwritten student answer sheets (Images & PDFs).
           </p>
         </div>
         {step !== 'select' && (
@@ -658,7 +658,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
             </div>
             <h3 className="text-xl font-display font-semibold text-zinc-900 dark:text-white">Optical Character Recognition (OCR) Scanner</h3>
             <p className="text-zinc-500 dark:text-zinc-400 text-sm max-w-md mx-auto">
-              Select a class, upload photo images (PNG/JPG) or PDF files of student answer sheets, and run EasyOCR.
+              Select a class, upload photo images (PNG/JPG) or PDF files of student answer sheets, and run OCR.
             </p>
           </div>
 
@@ -766,7 +766,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                       disabled={loading}
                       className="bg-blue-600 hover:bg-blue-700 text-white font-medium text-xs py-2 px-5 rounded-lg transition-colors shadow-sm"
                     >
-                      {loading ? 'Running…' : 'Run EasyOCR Scan (Legacy)'}
+                      {loading ? 'Running…' : 'Run OCR Scan (Legacy)'}
                     </button>
                   </div>
 
@@ -780,7 +780,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                         <span className="text-[10px] font-mono font-bold uppercase text-blue-700 dark:text-blue-300 tracking-wider">
                           {scanStage === 'reading' && 'Reading file…'}
                           {scanStage === 'filtering' && 'Filtering blue ink (~50ms)…'}
-                          {scanStage === 'ocr' && 'Running EasyOCR (~2–3s)…'}
+                          {scanStage === 'ocr' && 'Running OCR (~2–3s)…'}
                         </span>
                       </div>
                       <div className="flex gap-1">
@@ -828,7 +828,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                     OCR Extracted: {Object.values(extractedAnswers).filter(v => v && String(v).trim()).length} answers
                   </h3>
                   <p className="text-emerald-50 text-sm">
-                    EasyOCR read the following values from the scanned sheet. Edit any mistakes in the table below.
+                    OCR read the following values from the scanned sheet. Edit any mistakes in the table below.
                   </p>
                 </div>
               </div>
@@ -862,7 +862,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                 </div>
                 <div>
                   <h4 className="text-sm font-display font-semibold text-zinc-900">
-                    {ocrPreviewData?.ocrEngine?.startsWith('Cloud OCR') ? 'Cloud Scan Complete' : 'EasyOCR Scan Complete'}
+                    {ocrPreviewData?.ocrEngine?.startsWith('Cloud OCR') ? 'Cloud Scan Complete' : 'OCR Scan Complete'}
                   </h4>
                   <p className="text-xs text-zinc-500">
                     {ocrPreviewData?.ocrEngine || 'Sub-second PyTorch character extraction'}
@@ -870,7 +870,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                 </div>
               </div>
               <p className="text-xs text-zinc-600 leading-relaxed bg-white/60 p-3 rounded-lg border border-emerald-100">
-                Inspect raw EasyOCR detection output and token confidence below before final verification!
+                Inspect raw OCR detection output and token confidence below before final verification!
               </p>
             </div>
 
@@ -879,11 +879,11 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                 <div className="flex items-center gap-2">
                   <span className="w-2 h-2 rounded-full bg-emerald-400 animate-pulse"></span>
                   <h5 className="text-[11px] font-mono font-bold uppercase tracking-wider text-slate-300">
-                    Raw EasyOCR Inspection Panel
+                    Raw OCR Inspection Panel
                   </h5>
                 </div>
                 <span className="text-[10px] font-mono bg-blue-500/20 text-blue-300 px-2 py-0.5 rounded border border-blue-500/30">
-                  EasyOCR Fast
+                  OCR Fast
                 </span>
               </div>
 
@@ -914,10 +914,10 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
               <div className="flex justify-between items-center border-b border-zinc-200 dark:border-zinc-700 pb-3">
                 <div>
                   <h4 className="text-lg font-display font-medium text-zinc-900 dark:text-white mb-0.5">
-                    Step 2: Verify & Rectify EasyOCR Character Detection
+                    Step 2: Verify & Rectify Character Detection
                   </h4>
                   <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                    Verify the handwritten digits recognized by EasyOCR. If the OCR engine misread a student digit, rectify it below before confirming evaluation.
+                    Verify the handwritten digits recognized by OCR. If the OCR engine misread a student digit, rectify it below before confirming evaluation.
                   </p>
                 </div>
                 <div>
@@ -1024,7 +1024,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                                 ? 'bg-amber-100 dark:bg-amber-950/80 text-amber-800 dark:text-amber-300 border border-amber-200 dark:border-amber-800'
                                 : 'bg-emerald-100 dark:bg-emerald-950/80 text-emerald-800 dark:text-emerald-300 border border-emerald-200 dark:border-emerald-800'
                             }`}>
-                              {isTeacherEdited ? '✏️ Teacher Rectified' : '✓ EasyOCR Detected'}
+                              {isTeacherEdited ? '✏️ Teacher Rectified' : '✓ OCR Detected'}
                             </span>
                           </td>
                         </tr>
@@ -1060,9 +1060,9 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </div>
-                <h3 className="text-2xl font-display font-semibold text-zinc-900 dark:text-white">Class-Wide EasyOCR Evaluation Complete</h3>
+                <h3 className="text-2xl font-display font-semibold text-zinc-900 dark:text-white">Class-Wide OCR Evaluation Complete</h3>
                 <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                  Evaluated <strong>{bulkResults.length} student answer sheets</strong> via Fast PyTorch EasyOCR Engine.
+                  Evaluated <strong>{bulkResults.length} student answer sheets</strong> via Fast PyTorch OCR Engine.
                 </p>
               </div>
 
@@ -1223,28 +1223,96 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </div>
-                <h3 className="text-xl font-display font-semibold text-zinc-900 dark:text-white">ICR EasyOCR Evaluation Complete</h3>
+                <h3 className="text-xl font-display font-semibold text-zinc-900 dark:text-white">ICR Evaluation Complete</h3>
                 <p className="text-sm text-zinc-500 dark:text-zinc-400">
                   Answer sheet has been verified & saved to student records.
                 </p>
               </div>
 
               <div className="grid grid-cols-3 gap-4 border-y border-zinc-200 dark:border-zinc-700 py-4">
-                <div className="text-center">
-                  <span className="block text-xs font-mono text-zinc-400 uppercase">Final Score</span>
-                  <span className="text-2xl font-display font-bold text-zinc-900 dark:text-white">
-                    {questions.reduce((acc, q) => (q && (extractedAnswers[q.id] || '').trim() === (q.correctAnswer || '').trim() ? acc + 1 : acc), 0)} / {questions.length || report.totalQuestions}
-                  </span>
-                </div>
-                <div className="text-center border-x border-zinc-200 dark:border-zinc-700">
-                  <span className="block text-xs font-mono text-zinc-400 uppercase">Placed Level</span>
-                  <span className="text-2xl font-display font-bold text-zinc-900 dark:text-white">L{report.recommendedLevel}.{report.recommendedSubLevel ?? 0}</span>
-                </div>
-                <div className="text-center">
-                  <span className="block text-xs font-mono text-zinc-400 uppercase">Status</span>
-                  <span className="text-2xl font-display font-bold text-green-600">Verified & Certified</span>
-                </div>
-              </div>
+                              <div className="text-center">
+                                <span className="block text-xs font-mono text-zinc-400 uppercase">Final Score</span>
+                                <span className="text-2xl font-display font-bold text-zinc-900 dark:text-white">
+                                  {questions.reduce((acc, q) => (q && (extractedAnswers[q.id] || '').trim() === (q.correctAnswer || '').trim() ? acc + 1 : acc), 0)} / {questions.length || report.totalQuestions}
+                                </span>
+                              </div>
+                              <div className="text-center border-x border-zinc-200 dark:border-zinc-700">
+                                <span className="block text-xs font-mono text-zinc-400 uppercase">Placed Level</span>
+                                <span className="text-2xl font-display font-bold text-zinc-900 dark:text-white">L{report.recommendedLevel}.{report.recommendedSubLevel ?? 0}</span>
+                              </div>
+                              <div className="text-center">
+                                <span className="block text-xs font-mono text-zinc-400 uppercase">Status</span>
+                                {(() => {
+                                  const failed = report.failedLevels ?? [];
+                                  const passed = report.passedLevels ?? [];
+                                  const allFailed = failed.length > 0 && passed.length === 0;
+                                  const allPassed = passed.length > 0 && failed.length === 0;
+                                  const label = allFailed
+                                    ? 'Needs Support'
+                                    : allPassed
+                                    ? 'All Levels Passed'
+                                    : 'Partial — see breakdown below';
+                                  const color = allFailed
+                                    ? 'text-amber-600'
+                                    : allPassed
+                                    ? 'text-green-600'
+                                    : 'text-blue-600';
+                                  return (
+                                    <span className={`text-xl font-display font-bold ${color}`}>{label}</span>
+                                  );
+                                })()}
+                              </div>
+                            </div>
+
+                            {/* Diagnostic breakdown — passed/failed levels and skill gaps
+                                derived from the cross-skill graph. Replaces the old
+                                hardcoded "Verified & Certified" with something driven by
+                                the actual submitted answers. */}
+                            <div className="space-y-3">
+                              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                <div className="rounded-lg border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 p-3">
+                                  <div className="text-[10px] font-mono font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300 mb-1">
+                                    Levels Passed ({report.passedLevels?.length ?? 0})
+                                  </div>
+                                  <div className="text-sm text-emerald-900 dark:text-emerald-100">
+                                    {(report.passedLevels?.length ?? 0) > 0
+                                      ? report.passedLevels!.map((l) => `L${l}`).join(', ')
+                                      : 'No levels passed in this diagnostic.'}
+                                  </div>
+                                </div>
+                                <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/40 p-3">
+                                  <div className="text-[10px] font-mono font-bold uppercase tracking-wider text-amber-700 dark:text-amber-300 mb-1">
+                                    Levels To Work On ({report.failedLevels?.length ?? 0})
+                                  </div>
+                                  <div className="text-sm text-amber-900 dark:text-amber-100">
+                                    {(report.failedLevels?.length ?? 0) > 0
+                                      ? report.failedLevels!.map((l) => `L${l}`).join(', ')
+                                      : 'None — great work!'}
+                                  </div>
+                                </div>
+                              </div>
+
+                              {(report.skillGaps?.length ?? 0) > 0 && (
+                                <div className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/60 p-3">
+                                  <div className="text-[10px] font-mono font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-1.5">
+                                    Skills To Build (from cross-skill graph)
+                                  </div>
+                                  <div className="flex flex-wrap gap-1.5">
+                                    {report.skillGaps!.map((g) => (
+                                      <span
+                                        key={g.conceptId}
+                                        title={`${g.strand} — L${g.level}: ${g.levelTitle}`}
+                                        className="inline-flex items-center gap-1 rounded-full border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-slate-800 px-2.5 py-1 text-xs text-zinc-800 dark:text-zinc-100"
+                                      >
+                                        <span className="font-mono text-[10px] text-zinc-500 dark:text-zinc-400">L{g.level}</span>
+                                        <span>{g.levelTitle}</span>
+                                        <span className="text-[10px] text-zinc-400 dark:text-zinc-500">· {g.strand}</span>
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
 
               {questions.length > 0 && (
                 <div className="space-y-3">

--- a/frontend/src/components/IcrScanner.tsx
+++ b/frontend/src/components/IcrScanner.tsx
@@ -41,6 +41,98 @@ interface BulkResultItem {
   status: string;
 }
 
+// Lightweight SVG donut chart — correct vs incorrect counts. No external
+// chart library; the math is just arc-length-to-percentage on two slices.
+// Hides itself gracefully when there are zero questions.
+const DonutChart: React.FC<{ correct: number; incorrect: number }> = ({ correct, incorrect }) => {
+  const total = correct + incorrect;
+  const correctPct = total > 0 ? (correct / total) * 100 : 0;
+  const incorrectPct = total > 0 ? (incorrect / total) * 100 : 0;
+
+  // Donut geometry: outer radius 70, inner radius 44, stroke-based arcs.
+  // Use stroke-dasharray on a single circle to draw the two slices; the
+  // circle's circumference is 2πr.
+  const R = 70;
+  const C = 2 * Math.PI * R;
+  // dasharray = "<correct-arc-length> <gap>" — gap = full circumference so
+  // we only ever paint one slice. Rotate the circle so the correct slice
+  // starts at 12 o'clock.
+  const correctArc = (correctPct / 100) * C;
+
+  if (total === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-4">
+        <div className="w-40 h-40 rounded-full border-4 border-zinc-200 dark:border-zinc-700 flex items-center justify-center">
+          <div className="text-center">
+            <div className="text-2xl font-display font-bold text-zinc-400">—</div>
+            <div className="text-[10px] font-mono uppercase tracking-wider text-zinc-400 mt-1">No Questions</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center py-2">
+      <div className="relative w-40 h-40">
+        <svg viewBox="0 0 160 160" className="w-full h-full -rotate-90">
+          {/* Base ring (incorrect slice in red) — full circle, then we
+              overlay the correct slice on top using dasharray to mask. */}
+          <circle
+            cx="80" cy="80" r={R}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="26"
+            className="text-red-200 dark:text-red-900/40"
+          />
+          {/* Incorrect slice — explicit arc so the red is only where the
+              incorrect percentage is, not bleeding into the correct zone. */}
+          {incorrectPct > 0 && (
+            <circle
+              cx="80" cy="80" r={R}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="26"
+              strokeDasharray={`${(incorrectPct / 100) * C} ${C}`}
+              strokeDashoffset={-(correctPct / 100) * C}
+              className="text-red-500 dark:text-red-500"
+            />
+          )}
+          {/* Correct slice — emerald, starts at the top. */}
+          {correctPct > 0 && (
+            <circle
+              cx="80" cy="80" r={R}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="26"
+              strokeDasharray={`${correctArc} ${C}`}
+              className="text-emerald-500 dark:text-emerald-500"
+            />
+          )}
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <div className="text-2xl font-display font-bold text-zinc-900 dark:text-white">
+            {correct}<span className="text-zinc-400 dark:text-zinc-500 text-lg">/{total}</span>
+          </div>
+          <div className="text-[10px] font-mono uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mt-0.5">
+            Correct
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center gap-4 mt-3 text-xs">
+        <div className="flex items-center gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-sm bg-emerald-500" />
+          <span className="text-zinc-700 dark:text-zinc-300 font-mono">{correct} correct</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-sm bg-red-500" />
+          <span className="text-zinc-700 dark:text-zinc-300 font-mono">{incorrect} incorrect</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) => {
   const [classes, setClasses] = useState<ClassGroup[]>([]);
   const [students, setStudents] = useState<Student[]>([]);
@@ -1229,46 +1321,24 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                 </p>
               </div>
 
-              <div className="grid grid-cols-3 gap-4 border-y border-zinc-200 dark:border-zinc-700 py-4">
-                              <div className="text-center">
-                                <span className="block text-xs font-mono text-zinc-400 uppercase">Final Score</span>
-                                <span className="text-2xl font-display font-bold text-zinc-900 dark:text-white">
-                                  {questions.reduce((acc, q) => (q && (extractedAnswers[q.id] || '').trim() === (q.correctAnswer || '').trim() ? acc + 1 : acc), 0)} / {questions.length || report.totalQuestions}
-                                </span>
-                              </div>
-                              <div className="text-center border-x border-zinc-200 dark:border-zinc-700">
-                                <span className="block text-xs font-mono text-zinc-400 uppercase">Placed Level</span>
-                                <span className="text-2xl font-display font-bold text-zinc-900 dark:text-white">L{report.recommendedLevel}.{report.recommendedSubLevel ?? 0}</span>
-                              </div>
-                              <div className="text-center">
-                                <span className="block text-xs font-mono text-zinc-400 uppercase">Status</span>
-                                {(() => {
-                                  const failed = report.failedLevels ?? [];
-                                  const passed = report.passedLevels ?? [];
-                                  const allFailed = failed.length > 0 && passed.length === 0;
-                                  const allPassed = passed.length > 0 && failed.length === 0;
-                                  const label = allFailed
-                                    ? 'Needs Support'
-                                    : allPassed
-                                    ? 'All Levels Passed'
-                                    : 'Partial — see breakdown below';
-                                  const color = allFailed
-                                    ? 'text-amber-600'
-                                    : allPassed
-                                    ? 'text-green-600'
-                                    : 'text-blue-600';
-                                  return (
-                                    <span className={`text-xl font-display font-bold ${color}`}>{label}</span>
-                                  );
-                                })()}
-                              </div>
-                            </div>
+              <div className="space-y-4">
+                              {/* Donut chart: correct vs incorrect questions. Centered,
+                                  visually prominent — this is now the primary outcome of
+                                  the diagnostic. SVG-only, no chart library. Counts come
+                                  from questionResults (per-question truth) when present,
+                                  falling back to derived accuracy from the submitted
+                                  answers. */}
+                              <DonutChart
+                                correct={report.questionResults?.filter((r) => r.isCorrect).length
+                                  ?? Math.max(0, (report.totalQuestions ?? 0) - (report.wrongCount ?? 0))}
+                                incorrect={report.questionResults?.filter((r) => !r.isCorrect).length
+                                  ?? (report.wrongCount ?? 0)}
+                              />
 
-                            {/* Diagnostic breakdown — passed/failed levels and skill gaps
-                                derived from the cross-skill graph. Replaces the old
-                                hardcoded "Verified & Certified" with something driven by
-                                the actual submitted answers. */}
-                            <div className="space-y-3">
+                              {/* Per-level breakdown — driven by passedLevels / failedLevels
+                                  populated by the backend. The "Placed Level" column was
+                                  intentionally removed: the diagnostic is analytics-first
+                                  and does not assign a level to the student. */}
                               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                                 <div className="rounded-lg border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/40 p-3">
                                   <div className="text-[10px] font-mono font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300 mb-1">

--- a/frontend/src/components/IcrScanner.tsx
+++ b/frontend/src/components/IcrScanner.tsx
@@ -43,11 +43,18 @@ interface BulkResultItem {
 
 // Lightweight SVG donut chart — correct vs incorrect counts. No external
 // chart library; the math is just arc-length-to-percentage on two slices.
-// Hides itself gracefully when there are zero questions.
-const DonutChart: React.FC<{ correct: number; incorrect: number }> = ({ correct, incorrect }) => {
-  const total = correct + incorrect;
-  const correctPct = total > 0 ? (correct / total) * 100 : 0;
-  const incorrectPct = total > 0 ? (incorrect / total) * 100 : 0;
+// `correct` and `incorrect` may be null (e.g. when the report predates
+// per-question truth and we can't reconstruct it) — in that case we show a
+// clear "no data" placeholder instead of silently rendering a wrong chart.
+const DonutChart: React.FC<{
+  correct: number | null;
+  incorrect: number | null;
+  totalQuestions?: number;
+}> = ({ correct, incorrect, totalQuestions }) => {
+  const hasData = typeof correct === 'number' && typeof incorrect === 'number';
+  const total = hasData ? (correct as number) + (incorrect as number) : 0;
+  const correctPct = hasData && total > 0 ? ((correct as number) / total) * 100 : 0;
+  const incorrectPct = hasData && total > 0 ? ((incorrect as number) / total) * 100 : 0;
 
   // Donut geometry: outer radius 70, inner radius 44, stroke-based arcs.
   // Use stroke-dasharray on a single circle to draw the two slices; the
@@ -59,13 +66,17 @@ const DonutChart: React.FC<{ correct: number; incorrect: number }> = ({ correct,
   // starts at 12 o'clock.
   const correctArc = (correctPct / 100) * C;
 
-  if (total === 0) {
+  if (!hasData || total === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-4">
         <div className="w-40 h-40 rounded-full border-4 border-zinc-200 dark:border-zinc-700 flex items-center justify-center">
           <div className="text-center">
-            <div className="text-2xl font-display font-bold text-zinc-400">—</div>
-            <div className="text-[10px] font-mono uppercase tracking-wider text-zinc-400 mt-1">No Questions</div>
+            <div className="text-2xl font-display font-bold text-zinc-400">
+              {totalQuestions ?? '—'}
+            </div>
+            <div className="text-[10px] font-mono uppercase tracking-wider text-zinc-400 mt-1">
+              Questions · No per-question data
+            </div>
           </div>
         </div>
       </div>
@@ -1329,11 +1340,12 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
                                   falling back to derived accuracy from the submitted
                                   answers. */}
                               <DonutChart
-                                correct={report.questionResults?.filter((r) => r.isCorrect).length
-                                  ?? Math.max(0, (report.totalQuestions ?? 0) - (report.wrongCount ?? 0))}
-                                incorrect={report.questionResults?.filter((r) => !r.isCorrect).length
-                                  ?? (report.wrongCount ?? 0)}
-                              />
+                                                                correct={report.questionResults?.filter((r) => r.isCorrect).length
+                                                                  ?? null}
+                                                                incorrect={report.questionResults?.filter((r) => !r.isCorrect).length
+                                                                  ?? null}
+                                                                totalQuestions={report.totalQuestions}
+                                                              />
 
                               {/* Per-level breakdown — driven by passedLevels / failedLevels
                                   populated by the backend. The "Placed Level" column was

--- a/frontend/src/components/IcrScanner.tsx
+++ b/frontend/src/components/IcrScanner.tsx
@@ -538,37 +538,63 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
     const ocrValues: string[] = Object.entries(answers).map(([, v]) => String(v.value || ''));
 
     // Fetch the answer key for the selected class (mirrors the Pass OCR
-    // flow). This gives us the actual number of questions (e.g. 15) and
-    // their question text + correctAnswer for the verify table.
-    const cls = classes.find(c => c.id === selectedClassId);
-    let targetStudentId = selectedStudentId && selectedStudentId !== 'ALL_STUDENTS'
-      ? selectedStudentId
-      : students.find(s => cls && (s.classGroup === cls.className || (s.classGroup || '').includes(cls.className)))?.id;
+        // flow). This gives us the actual number of questions (e.g. 15) and
+        // their question text + correctAnswer for the verify table.
+        const cls = classes.find(c => c.id === selectedClassId);
+        let targetStudentId = selectedStudentId && selectedStudentId !== 'ALL_STUDENTS'
+          ? selectedStudentId
+          : students.find(s => cls && (s.classGroup === cls.className || (s.classGroup || '').includes(cls.className)))?.id;
 
-    let loadedQuestions: Array<{ id: string; question: string; correctAnswer: string; topic?: string }> = [];
-    let sourceLabel = '';
-    if (targetStudentId) {
-      try {
-        const res = await apiFetch(
-          `/api/diagnostic/student/${encodeURIComponent(targetStudentId)}/answer-key`,
-          { headers: { 'Authorization': `Bearer ${token}` } }
-        );
-        if (res.ok) {
-          const ak = (await res.json())?.answerKey || [];
-          if (Array.isArray(ak) && ak.length > 0) {
-            loadedQuestions = ak.map((item: any, i: number) => ({
-              id: item.qid || item.question_id || item.id || `q_${i + 1}`,
-              question: item.question || item.prompt || `Question #${i + 1}`,
-              correctAnswer: String(item.answer ?? item.expected ?? ''),
-              topic: item.topic,
-            }));
-            sourceLabel = `mapped ${Math.min(ocrValues.length, loadedQuestions.length)} OCR values into ${loadedQuestions.length} answer-key fields`;
+        let loadedQuestions: Array<{ id: string; question: string; correctAnswer: string; topic?: string }> = [];
+        let sourceLabel = '';
+        if (targetStudentId) {
+          try {
+            const res = await apiFetch(
+              `/api/diagnostic/student/${encodeURIComponent(targetStudentId)}/answer-key`,
+              { headers: { 'Authorization': `Bearer ${token}` } }
+            );
+            if (res.ok) {
+              const ak = (await res.json())?.answerKey || [];
+              if (Array.isArray(ak) && ak.length > 0) {
+                loadedQuestions = ak.map((item: any, i: number) => ({
+                  id: item.qid || item.question_id || item.id || `q_${i + 1}`,
+                  question: item.question || item.prompt || `Question #${i + 1}`,
+                  correctAnswer: String(item.answer ?? item.expected ?? ''),
+                  topic: item.topic,
+                }));
+                sourceLabel = `mapped ${Math.min(ocrValues.length, loadedQuestions.length)} OCR values into ${loadedQuestions.length} answer-key fields`;
+              }
+            }
+          } catch {
+            // non-fatal, fall through to class-level fallback
           }
         }
-      } catch {
-        // non-fatal, fall through to placeholder grid
-      }
-    }
+        // Fallback: no per-student key resolved. Try the latest class-level
+        // answer key — the class paper is the same across students up to
+        // randomization, so this is a safe proxy for single-sheet scans
+        // where no specific student was selected.
+        if (loadedQuestions.length === 0 && cls?.classNumber) {
+          try {
+            const res = await apiFetch(
+              `/api/diagnostic/class/${encodeURIComponent(String(cls.classNumber))}/answer-key`,
+              { headers: { 'Authorization': `Bearer ${token}` } }
+            );
+            if (res.ok) {
+              const ak = (await res.json())?.answerKey || [];
+              if (Array.isArray(ak) && ak.length > 0) {
+                loadedQuestions = ak.map((item: any, i: number) => ({
+                  id: item.qid || item.question_id || item.id || `q_${i + 1}`,
+                  question: item.question || item.prompt || `Question #${i + 1}`,
+                  correctAnswer: String(item.answer ?? item.expected ?? ''),
+                  topic: item.topic,
+                }));
+                sourceLabel = `class-level answer key (${loadedQuestions.length} fields) — no student selected`;
+              }
+            }
+          } catch {
+            // non-fatal, fall through to placeholder grid
+          }
+        }
 
     // Fallback: if no answer key, build N rows from the OCR'd count.
     if (loadedQuestions.length === 0) {

--- a/frontend/src/components/IcrTwoStageScan.tsx
+++ b/frontend/src/components/IcrTwoStageScan.tsx
@@ -176,6 +176,10 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
 
   // OCR stage state
   const [ocrState, setOcrState] = useState<OcrState>('idle');
+  // Separate state for the cloud OCR path so clicking "Run via Cloud API"
+  // doesn't light up the local "Run OCR on Filtered Image" button (which
+  // shares ocrState visually). Each button owns its own status.
+  const [cloudOcrState, setCloudOcrState] = useState<OcrState>('idle');
   const [ocrResult, setOcrResult] = useState<ScanResponse | null>(null);
   const [ocrTiming, setOcrTiming] = useState<ScanTiming | null>(null);
   const [ocrError, setOcrError] = useState<string | null>(null);
@@ -454,8 +458,8 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
         );
         return;
       }
-      setOcrState('running');
-      setCloudError(null);
+      setCloudOcrState('running');
+            setCloudError(null);
       const t0 = performance.now();
       try {
         // Prefer the pages[] shape (same as the local OCR path) so the
@@ -495,8 +499,8 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
               ? ` The upstream provider rejected the request — likely an invalid/revoked key, billing not enabled, or rate limit. Ask the admin to verify the ICR_CLOUD_API_KEY_${cloudProvider.toUpperCase()} value.`
               : '';
           setCloudError(providerMsg + adminHint);
-          setOcrState('error');
-          return;
+                    setCloudOcrState('error');
+                    return;
         }
         // Prefer the structured `studentResponses` from Ollama's JSON-output mode
         // (question_number → response, with status: answered|blank|unclear).
@@ -565,13 +569,13 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
           serverMs: data.processingTimeMs ?? null,
           startedAt: new Date().toISOString(),
         });
-        setOcrState('done');
-        onOcrSuccess(normalized);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        setCloudError(`Network or client error: ${msg}`);
-        setOcrState('error');
-      }
+        setCloudOcrState('done');
+                onOcrSuccess(normalized);
+              } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                setCloudError(`Network or client error: ${msg}`);
+                setCloudOcrState('error');
+              }
     };
 
   const disabled = !uploadedFile;
@@ -674,20 +678,20 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
                         })()}
 
                 <BigButton
-                                  providerKey={cloudProvider}
-                                  icon={<CloudIcon />}
-                                  title="3. Run via Cloud API"
-                                  subtitle={
-                                    cloudProvidersConfigured[cloudProvider]
-                                      ? `Using ${cloudProvider.toUpperCase()} — admin-configured on server`
-                                      : 'No API key configured — ask admin to set ICR_CLOUD_API_KEY_' + cloudProvider.toUpperCase()
-                                  }
-                                  timeTaken={null}
-                                  liveElapsed={ocrState === 'running' ? elapsedMs : null}
-                                  state={ocrState}
-                                  onClick={runCloudOcr}
-                                  disabled={disabled || !cloudProvidersConfigured[cloudProvider]}
-                                />
+                                                                  providerKey={cloudProvider}
+                                                                  icon={<CloudIcon />}
+                                                                  title="3. Run via Cloud API"
+                                                                  subtitle={
+                                                                    cloudProvidersConfigured[cloudProvider]
+                                                                      ? `Using ${cloudProvider.toUpperCase()} — admin-configured on server`
+                                                                      : 'No API key configured — ask admin to set ICR_CLOUD_API_KEY_' + cloudProvider.toUpperCase()
+                                                                  }
+                                                                  timeTaken={null}
+                                                                  liveElapsed={cloudOcrState === 'running' ? elapsedMs : null}
+                                                                  state={cloudOcrState}
+                                                                  onClick={runCloudOcr}
+                                                                  disabled={disabled || !cloudProvidersConfigured[cloudProvider]}
+                                                                />
       </div>
 
       {/* Filtered preview + stats panel */}

--- a/frontend/src/components/LandingView.tsx
+++ b/frontend/src/components/LandingView.tsx
@@ -8,6 +8,7 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Sparkles, Award, Globe, BookOpen, Users, BarChart3, ArrowRight, MapPin } from 'lucide-react';
 import { LanguageSwitcher } from './LanguageSwitcher';
+import { FLN_LEVELS_LIST } from './RoleDashboards';
 
 interface LandingViewProps {
   onNavigateToLogin: () => void;
@@ -227,8 +228,8 @@ export const LandingView: React.FC<LandingViewProps> = ({ onNavigateToLogin, isL
                 {t('landing.curriculum.title')}
               </h3>
               <p className="mt-3 text-sm leading-relaxed text-gray-500 dark:text-slate-300">
-                {t('landing.curriculum.body')}
-              </p>
+                              {t('landing.curriculum.body', { levels: FLN_LEVELS_LIST.length })}
+                            </p>
             </div>
           </div>
         </div>

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -18,7 +18,7 @@
   "landing.vision.title": "Our Vision",
   "landing.vision.body": "To enable all children of Class 3/4 to read with comprehension and write, perform basic mathematical operations, and acquire foundational math skills by providing them with customized assessments and remedial worksheets.",
   "landing.curriculum.title": "Curriculum Integration",
-  "landing.curriculum.body": "Our unified model defines 59 cumulative proficiency levels mapped precisely to Class 1, 2, 3, and 4 standards across foundational numeracy strands. Utilizing a specialized evaluation system, we generate diagnostic assessments on demand to pinpoint students' exact gaps.",
+  "landing.curriculum.body": "Our unified model defines {{levels}} cumulative proficiency levels mapped precisely to Class 1, 2, 3, and 4 standards across foundational numeracy strands. Utilizing a specialized evaluation system, we generate diagnostic assessments on demand to pinpoint students' exact gaps.",
   "landing.cycle.cycle1": "Cycle 1",
   "landing.cycle.cycle1Title": "Baseline",
   "landing.cycle.cycle1Description": "Initial placement to identify each student's starting level.",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -230,10 +230,21 @@ export interface EvaluationReport {
   // Issue #180: per-question breakdown, present on reports created after
   // that feature landed. Optional — older reports predate it.
   questionResults?: { questionId: string; question?: string; correctAnswer?: string; submittedAnswer: string; isCorrect: boolean }[];
-  teacherReviewed?: boolean;
-  reviewedBy?: string;
-  reviewedAt?: string;
-}
+    teacherReviewed?: boolean;
+    reviewedBy?: string;
+    reviewedAt?: string;
+    // Per-level pass/fail breakdown — populated by the diagnostic submit handler
+    // (backend/src/routes/students.ts). Diagnostic does NOT assign a placement
+    // level; the UI uses these to show which levels were demonstrated vs which
+    // need remediation.
+    passedLevels?: number[];
+    failedLevels?: number[];
+    // Skills the student is struggling with — conceptIds of the failed levels
+    // plus any direct prerequisites, sourced from the cross-skill graph
+    // (backend/src/competencyPrerequisites.ts). Drives the status text in the
+    // diagnostic panel instead of the old hardcoded "Verified & Certified".
+    skillGaps?: { conceptId: string; level: number; levelTitle: string; strand: string }[];
+  }
 
 export interface Ticket {
   id: string;


### PR DESCRIPTION
1. Curriculum count is now dynamic. The landing page hardcoded "59 levels" — now reads FLN_LEVELS_LIST.length via i18n interpolation, so it stays correct as the framework evolves (currently 93).
2. OCR scan buttons are independent. Run OCR on Filtered Image and Run via Cloud API previously shared the same React state, so clicking the cloud button activated the local button's loading indicator. Each button now owns its own ocrState / cloudOcrState.
3. "EasyOCR" wording removed from all user-facing text. 17 UI labels (Verify & Inspect heading, result headings, success messages, inspection panel) cleaned up to "OCR". Kept the 'EasyOCR (PyTorch Fast Reader)' data identifier value for backend compatibility.
4. Diagnostic no longer assigns a placement level. Removed the hardcoded (classNumber - 1) * 10 + Math.ceil(percentage / 10) math on the OCR scan path. Stopped writing currentLevel / targetLevel / levelHistory to the student record from the scanned diagnostic flow. The student still has a recommendedLevel field on the report for backward compatibility, but no longer has a "placement" written back to them.
5. Per-level breakdown + skill gaps on every report. EvaluationReport gained three optional fields:
     - passedLevels: number[] — distinct level numbers where all questions were correct
       - failedLevels: number[] — distinct level numbers where at least one question was incorrect
       - skillGaps: { conceptId, level, levelTitle, strand }[] — conceptIds of failed levels + their direct prerequisites from CONCEPT_PREREQUISITES
Both report creation paths populate these — the in-app /api/students/:id/diagnostic/submit and the OCR scan evaluation. Same builder, same shape.
 6. New diagnostic result screen. Removed the buggy "Final Score / Placed Level / Status" 3-column grid (the "5/42 correct" bug and the misleading "L2.0 placed" came from this). Replaced with:
       - Centered SVG donut chart showing correct vs incorrect (no chart library)
       - Levels Passed / Levels To Work On cards (color-coded, level numbers listed)
       - Skills To Build pills derived from the cross-skill graph
Old reports without questionResults show a "no per-question data" placeholder instead of fake-correct fills.
7. Question paper dedup helper. Added dedupeQuestionsById() in db.ts that collapses rows sharing a question_id, comma-joining duplicate answer values.Wired into getStudentAssignedQuestions() and explicitly called at the OCR scan entry point. Defensive against future data overlap between paper sources.
8. Class-level answer-key fallback. Single-sheet scans without a specific student selected used to fall through to a placeholder branch that produced rows with empty correctAnswer — the "-" you saw in the table. Added GET /api/diagnostic/class/:classNumber/answer-key (and DBStore.getLatestClassAnswerKey()) so the verify table can pull the latest class paper as a safe proxy.