### PR TITLE
Fix #234: tell Cloud OCR the expected question count, flag mismatches

### DIFF
--- a/backend/src/routes/evaluation.ts
+++ b/backend/src/routes/evaluation.ts
@@ -94,7 +94,8 @@ export function registerEvaluationRoutes(app: express.Express) {
   const runCloudOcrOnImage = async (
     dataUrl: string,
     provider: string,
-    apiKey: string
+    apiKey: string,
+    expectedCount?: number
   ): Promise<{ status: number; body: any }> => {
     if (!dataUrl || typeof dataUrl !== 'string' ||
       (dataUrl.indexOf('data:image/') !== 0 && dataUrl.indexOf('data:application/') !== 0)) {
@@ -412,6 +413,24 @@ export function registerEvaluationRoutes(app: express.Express) {
           mimeUsed = mimeUsedIn;
         }
 
+        const expectedCountLines = (typeof expectedCount === 'number' && expectedCount > 0)
+          ? [
+              '',
+              '════════════════════════════════════',
+              'EXPECTED ROW COUNT',
+              '════════════════════════════════════',
+              `This answer sheet has EXACTLY ${expectedCount} questions in total, across all pages.`,
+              `Your output MUST contain EXACTLY row_1 through row_${expectedCount} — no more, no fewer.`,
+              'If you count more or fewer candidate rows than this while reading the page, re-check your',
+              'row segmentation (a merged multi-part question is still ONE row; do not split a single',
+              'question into two rows just to make the count match, and do not merge two distinct',
+              `questions into one row either). The count of ${expectedCount} is ground truth from the`,
+              'answer key this sheet was generated from — trust it over your own row count if they conflict,',
+              'and re-scan the page for a row you may have skipped or merged before giving up.',
+              '',
+            ]
+          : [];
+
         const ocrPrompt = [
           'You are an answer-sheet extraction assistant for a primary-school FLN assessment (Grades 2–5).',
           'You will receive ONE OR MORE scanned page images belonging to a SINGLE student\'s answer sheet.',
@@ -420,6 +439,7 @@ export function registerEvaluationRoutes(app: express.Express) {
           'Process ALL pages together, top to bottom, page by page.',
           'Your final output must be ONE unified JSON object with rows numbered continuously ',
           'across all pages (row 1 on page 1, row 6 on page 2, etc. — never restart at 1).',
+          ...expectedCountLines,
           '',
           '════════════════════════════════════',
           'MULTI-PAGE INSTRUCTIONS',
@@ -646,6 +666,14 @@ export function registerEvaluationRoutes(app: express.Express) {
                     // try to parse it client-side as a fallback.
                     structured: flatAnswers != null,
                     structuredError: parseError,
+                    // Issue #234: surface a row-count mismatch explicitly instead of
+                    // letting the frontend silently pad/truncate. expectedCount is
+                    // only present when the caller (frontend) already knew the real
+                    // question count for this student's paper.
+                    expectedCount: expectedCount ?? null,
+                    countMismatch: (typeof expectedCount === 'number' && expectedCount > 0 && flatAnswers != null)
+                      ? flatAnswers.length !== expectedCount
+                      : null,
                     processingTimeMs: Date.now() - t0,
                   }
                 };
@@ -676,7 +704,7 @@ export function registerEvaluationRoutes(app: express.Express) {
     const user = getAuthUser(req);
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
-    const { imageDataUrl, fileBase64, provider } = req.body || {};
+    const { imageDataUrl, fileBase64, provider, expectedCount } = req.body || {};
     const singleDataUrl = imageDataUrl || fileBase64;
     if (!singleDataUrl || typeof singleDataUrl !== 'string') {
       return res.status(400).json({ error: 'imageDataUrl or fileBase64 is required (data URL).' });
@@ -684,6 +712,14 @@ export function registerEvaluationRoutes(app: express.Express) {
     if (provider !== 'ollama-gemma4') {
       return res.status(400).json({ error: 'provider must be "ollama-gemma4".' });
     }
+    // Optional (issue #234): the caller may already know the real question
+    // count for this student's paper (from the diagnostic answer key). When
+    // present, it's used to tell the model exactly how many rows to expect
+    // and to flag a mismatch explicitly rather than silently padding/
+    // truncating downstream.
+    const expectedCountNum = (typeof expectedCount === 'number' && Number.isFinite(expectedCount) && expectedCount > 0)
+      ? Math.floor(expectedCount)
+      : undefined;
 
     const apiKey = await getCloudKey(provider);
     if (!apiKey) {
@@ -692,7 +728,7 @@ export function registerEvaluationRoutes(app: express.Express) {
       });
     }
 
-    const r = await runCloudOcrOnImage(singleDataUrl, provider, apiKey);
+    const r = await runCloudOcrOnImage(singleDataUrl, provider, apiKey, expectedCountNum);
     return res.status(r.status).json(r.body);
   });
 

--- a/frontend/src/components/IcrScanner.tsx
+++ b/frontend/src/components/IcrScanner.tsx
@@ -149,6 +149,11 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
   const [students, setStudents] = useState<Student[]>([]);
   const [selectedClassId, setSelectedClassId] = useState('');
   const [selectedStudentId, setSelectedStudentId] = useState('');
+  // Issue #234: the real question count for the selected student/class's
+  // paper, resolved ahead of the scan so the cloud OCR call can tell the
+  // model exactly how many rows to expect. null until resolved (or if no
+  // class/student is selected yet, or no answer key is found).
+  const [expectedQuestionCount, setExpectedQuestionCount] = useState<number | null>(null);
 
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [bulkResults, setBulkResults] = useState<BulkResultItem[] | null>(null);
@@ -313,6 +318,64 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
     fetchData();
   }, [token]);
 
+  // Issue #234: resolve the real question count for whatever class/student
+  // is currently selected, ahead of running OCR, so the scan call can tell
+  // the model exactly how many rows to expect and a mismatch can be flagged
+  // explicitly. Mirrors the same per-student → per-class fallback used in
+  // handleTwoStageResult once OCR completes; kept separate since this one
+  // needs to run on selection change, not on scan completion.
+  useEffect(() => {
+    let cancelled = false;
+    if (!selectedClassId) {
+      setExpectedQuestionCount(null);
+      return;
+    }
+    (async () => {
+      try {
+        const cls = classes.find(c => c.id === selectedClassId);
+        const targetStudentId = selectedStudentId && selectedStudentId !== 'ALL_STUDENTS'
+          ? selectedStudentId
+          : students.find(s => cls && (s.classGroup === cls.className || (s.classGroup || '').includes(cls.className)))?.id;
+
+        if (targetStudentId) {
+          const res = await apiFetch(
+            `/api/diagnostic/student/${encodeURIComponent(targetStudentId)}/answer-key`,
+            { headers: { 'Authorization': `Bearer ${token}` } }
+          );
+          if (!cancelled && res.ok) {
+            const ak = (await res.json())?.answerKey || [];
+            if (Array.isArray(ak) && ak.length > 0) {
+              setExpectedQuestionCount(ak.length);
+              return;
+            }
+          }
+        }
+        // Fallback: class-level answer key, same convention as the
+        // post-scan resolver.
+        const classNumberFromName = cls?.className ? parseInt(cls.className.match(/\d+/)?.[0] || '', 10) : 0;
+        if (!cancelled && Number.isFinite(classNumberFromName) && classNumberFromName > 0) {
+          const res = await apiFetch(
+            `/api/diagnostic/class/${encodeURIComponent(String(classNumberFromName))}/answer-key`,
+            { headers: { 'Authorization': `Bearer ${token}` } }
+          );
+          if (!cancelled && res.ok) {
+            const ak = (await res.json())?.answerKey || [];
+            if (Array.isArray(ak) && ak.length > 0) {
+              setExpectedQuestionCount(ak.length);
+              return;
+            }
+          }
+        }
+        if (!cancelled) setExpectedQuestionCount(null);
+      } catch {
+        // Non-fatal — the scan just proceeds without a known expected
+        // count, same as before this fix existed.
+        if (!cancelled) setExpectedQuestionCount(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [selectedClassId, selectedStudentId, classes, students, token]);
+
   const selectedStudent = students.find(s => s.id === selectedStudentId);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -429,6 +492,8 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
     debug?: { image_size?: [number, number]; blue_pixel_ratio?: number };
     processingTimeMs?: number;
     ocrAnalysis?: { ocrEngine?: string };
+    countMismatch?: boolean | null;
+    expectedCount?: number | null;
   }) => {
     console.log('[OCR Result] received from two-stage scan:', data);
     if (!data.success || !data.answers) {
@@ -522,6 +587,18 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
     const matched = ocrValues.filter(v => v && v.trim()).length;
     const total = loadedQuestions.length;
     const pct = Math.round((matched / Math.max(1, total)) * 100);
+    // Issue #234: don't silently pad/truncate a row-count mismatch — flag
+    // it plainly so a teacher knows to check the mapping row-by-row before
+    // trusting/submitting it, rather than assuming a positional match held.
+    // Prefer the backend's countMismatch (it knows expectedCount even if
+    // this resolver's answer key differs slightly); fall back to comparing
+    // locally when the backend didn't have an expected count to check against.
+    const countMismatched = data.countMismatch != null
+      ? data.countMismatch
+      : ocrValues.length !== loadedQuestions.length;
+    const mismatchNote = countMismatched
+      ? ` ⚠️ COUNT MISMATCH: the scan returned ${ocrValues.length} answer(s) but this paper has ${loadedQuestions.length} question(s) — check every row against the question text below before submitting, positions past the mismatch may be shifted.`
+      : '';
     // Use whichever engine/provider actually produced this result (set by
     // IcrTwoStageScan — 'Ollama Gemma 4' for the cloud OCR path.
     // No local OCR model is supported anymore; the local PaddleOCR/EasyOCR
@@ -566,13 +643,22 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
         'Shapes': firstRes.percentage >= 60 ? 'Strong' : 'Needs Practice',
         'Operations': firstRes.percentage >= 50 ? 'Strong' : 'Needs Practice',
       },
-      narrative: `Two-stage scan complete. ${sourceLabel}. Score: ${firstRes.score}/${firstRes.totalQuestions} (${firstRes.percentage}%).`,
+      narrative: `Two-stage scan complete. ${sourceLabel}. Score: ${firstRes.score}/${firstRes.totalQuestions} (${firstRes.percentage}%).${mismatchNote}`,
       recommendedLevel: firstRes.newLevel,
       recommendedSubLevel: firstRes.subLevel,
       timestamp: new Date().toISOString(),
     });
     setStep('verify');
-    setSuccess(`Two-stage scan complete — ${sourceLabel} (${firstRes.score}/${firstRes.totalQuestions} matched, ${firstRes.percentage}%).`);
+    if (countMismatched) {
+      // Use the error banner (not success) for a mismatch — it needs the
+      // teacher's attention before they trust the row mapping below, not a
+      // routine confirmation.
+      setError(`⚠️ Scan returned ${ocrValues.length} answer(s) but this paper has ${loadedQuestions.length} question(s) — a row was likely skipped or merged. Check every answer against its question text before submitting.`);
+      setSuccess('');
+    } else {
+      setError('');
+      setSuccess(`Two-stage scan complete — ${sourceLabel} (${firstRes.score}/${firstRes.totalQuestions} matched, ${firstRes.percentage}%).`);
+    }
   };
 
   const handleAnswerChange = (qId: string, value: string) => {
@@ -802,6 +888,7 @@ export const IcrScanner: React.FC<IcrScannerProps> = ({ token, user, onBack }) =
               token={token}
               uploadedFile={uploadedFile}
               onOcrSuccess={handleTwoStageResult}
+              expectedCount={expectedQuestionCount}
             />
           </div>
         </div>

--- a/frontend/src/components/IcrTwoStageScan.tsx
+++ b/frontend/src/components/IcrTwoStageScan.tsx
@@ -35,6 +35,11 @@ interface ScanResponse {
   };
   processingTimeMs?: number;
   error?: string;
+  // Issue #234: present when the caller told the backend how many
+  // questions this sheet should have (expectedCount below). true means
+  // the model's row count didn't match — the parent surfaces a warning.
+  countMismatch?: boolean | null;
+  expectedCount?: number | null;
 }
 
 interface IcrTwoStageScanProps {
@@ -44,6 +49,12 @@ interface IcrTwoStageScanProps {
   // Called when OCR succeeds so the parent scanner can switch its UI
   // to the Verify step. Parent owns the result state.
   onOcrSuccess: (data: ScanResponse) => void;
+  // Issue #234: the real question count for the selected student/class's
+  // paper, when known ahead of the scan (resolved by the parent from the
+  // diagnostic answer key). Passed to the backend so it can tell the OCR
+  // model exactly how many rows to expect, and so a count mismatch can be
+  // flagged explicitly instead of silently padding/truncating the mapping.
+  expectedCount?: number | null;
 }
 
 type OcrState = 'idle' | 'running' | 'done' | 'error';
@@ -60,6 +71,7 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
   token,
   uploadedFile,
   onOcrSuccess,
+  expectedCount,
 }) => {
   // Cloud OCR state — the only OCR state we keep.
   const [cloudOcrState, setCloudOcrState] = useState<OcrState>('idle');
@@ -158,6 +170,10 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
         body: JSON.stringify({
           provider: 'ollama-gemma4',
           imageDataUrl: dataUrl,
+          // Issue #234: tell the backend how many questions this paper
+          // actually has, when known, so the model is told an explicit
+          // target row count instead of guessing from the image alone.
+          ...(typeof expectedCount === 'number' && expectedCount > 0 ? { expectedCount } : {}),
         }),
       });
       const clientMs = Math.round(performance.now() - t0);
@@ -214,6 +230,8 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
           ocrEngine: data.ocrEngine || (data.model ? `Ollama Gemma 4 (${data.model})` : 'Ollama Gemma 4'),
         },
         processingTimeMs: data.processingTimeMs ?? clientMs,
+        countMismatch: data.countMismatch ?? null,
+        expectedCount: data.expectedCount ?? null,
       };
       setCloudOcrState('done');
       onOcrSuccess(normalized);


### PR DESCRIPTION
## What this fixes

Closes #234's first two suggested-approach items.

`/api/icr/evaluate-cloud` (Ollama Gemma 4, the sole OCR provider since the recent consolidation) returned a flat, positional `answers[]` list. The frontend zipped that list against the real answer-key questions purely by index (`extracted[loadedQuestions[i].id] = ocrValues[i]`), with **no check that the counts even matched** — a skipped or merged row on a busy multi-question page would silently shift every subsequent answer to the wrong question, with no signal to the teacher.

## What changed

- **Backend** (`evaluation.ts`): `/api/icr/evaluate-cloud` now accepts an optional `expectedCount`. When present, it's injected into the Ollama prompt as an explicit "this sheet has exactly N questions, output exactly row_1..row_N" instruction, and the response includes `expectedCount`/`countMismatch` so the caller doesn't have to re-derive it.
- **Frontend** (`IcrScanner.tsx`): resolves the real question count from the student's (or class's) diagnostic answer key *before* the scan runs — same lookup the verify step already did after the fact, just hoisted earlier — and passes it to the OCR call.
- **Frontend** (`IcrTwoStageScan.tsx`): plumbs `expectedCount` through to the request and back out in the result.
- On a mismatch, the verify screen shows an explicit warning banner instead of silently padding/truncating the mapping, so a teacher knows to check row-by-row before submitting.

Fully backward compatible — `expectedCount` is optional on both ends; omitting it (no answer key resolvable yet) preserves the exact previous behavior.

## Explicitly out of scope

True spatial/semantic answer-to-question matching (per-answer bounding boxes) isn't achievable in this fix — that data no longer exists now that the pipeline is cloud-only (the local EasyOCR + coordinate pipeline was removed in the OCR consolidation). This fix makes the remaining positional approach honest about when it might be wrong, per #234's own suggested approach, rather than attempting to rebuild spatial matching from scratch.

## Verification

- `npm run lint` (tsc --noEmit, both workspaces) — clean, no new errors.
- `npm run build --workspace @fln/frontend` — clean build.
- `npm run build:backend` — clean esbuild bundle.
- Not yet tested against a live scan (no server-side Ollama key in this sandbox) — recommend a real scan test against a known answer key before merging, given this touches the pilot-critical scan path.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RPePEJdjynqqFyPNWZhPCF