### PR TITLE
Fix #280 (asks 1+2): wire the L↔S level-notation crosswalk into code

### DIFF
--- a/frontend/src/data/skillProgressionMap.ts
+++ b/frontend/src/data/skillProgressionMap.ts
@@ -329,6 +329,17 @@ export const CORE_SKILLS: CoreSkill[] = [
 export interface LevelSkillMapping {
   levelId: string;
   levelNumber: number;
+  /**
+   * The same level's identifier in the research docs' S-notation
+   * (`Research/fln_level_networks.md`, `Research/fln_proposed_levels.md`),
+   * e.g. "S3.5". Derived, not hand-maintained — see sCodeFor() below.
+   * Issue #280: this is the "make the mapping available to the code" ask.
+   * Which notation is canonical long-term is a separate, deliberate naming
+   * decision (issue #280 ask #3) that hasn't been made — both IDs coexist
+   * here so nothing has to be renamed (and no student-response history
+   * orphaned) before that decision happens.
+   */
+  sCode: string;
   capability: string;
   stage: 'Pre-school 1' | 'Pre-school 2' | 'Pre-school 3'
        | 'Class 1' | 'Class 2' | 'Class 3' | 'Class 4';
@@ -340,14 +351,35 @@ export interface LevelSkillMapping {
   evidence: string[];
 }
 
+// Cumulative level counts per S-notation stage (S1..S7): 7, 10, 10, 15, 19,
+// 14, 18 — sums to 93. Both stageFor() and sCodeFor() derive from this same
+// array so the two notations can't drift relative to each other by
+// construction. Verified to reproduce all 93 rows of
+// Research/fln_L_to_S_crosswalk.json exactly — see
+// scripts/check-level-notation-drift.ts.
+const STAGE_CUMULATIVE_BOUNDARIES = [7, 17, 27, 42, 61, 75, 93] as const;
+
+function stageIndexFor(n: number): number {
+  for (let i = 0; i < STAGE_CUMULATIVE_BOUNDARIES.length; i++) {
+    if (n <= STAGE_CUMULATIVE_BOUNDARIES[i]) return i + 1; // 1-indexed: S1..S7
+  }
+  throw new Error(`Level ${n} is outside the 93-level range (1-93).`);
+}
+
+/** The n-th S-code in stage-then-index order, e.g. sCodeFor(28) === "S4.1". */
+function sCodeFor(n: number): string {
+  const stageIdx = stageIndexFor(n);
+  const prevBoundary = stageIdx === 1 ? 0 : STAGE_CUMULATIVE_BOUNDARIES[stageIdx - 2];
+  const withinStageIdx = n - prevBoundary;
+  return `S${stageIdx}.${withinStageIdx}`;
+}
+
 function stageFor(n: number): LevelSkillMapping['stage'] {
-  if (n <= 7)  return 'Pre-school 1';
-  if (n <= 17) return 'Pre-school 2';
-  if (n <= 27) return 'Pre-school 3';
-  if (n <= 42) return 'Class 1';
-  if (n <= 61) return 'Class 2';
-  if (n <= 75) return 'Class 3';
-  return 'Class 4';
+  const names: LevelSkillMapping['stage'][] = [
+    'Pre-school 1', 'Pre-school 2', 'Pre-school 3',
+    'Class 1', 'Class 2', 'Class 3', 'Class 4',
+  ];
+  return names[stageIndexFor(n) - 1];
 }
 
 // Format helpers for evidence/question types — kept inline so we don't drift
@@ -371,6 +403,7 @@ function makeLevel(n: number, capability: string, primary: string[], supporting:
   return {
     levelId: `L${n}`,
     levelNumber: n,
+    sCode: sCodeFor(n),
     capability,
     stage: stageFor(n),
     primarySkills: primary,
@@ -616,6 +649,7 @@ export const LEVEL_SKILL_MAP: LevelSkillMapping[] = [
 
 const SKILL_BY_ID: Record<string, CoreSkill> = Object.fromEntries(CORE_SKILLS.map(s => [s.id, s]));
 const LEVEL_BY_ID: Record<string, LevelSkillMapping> = Object.fromEntries(LEVEL_SKILL_MAP.map(l => [l.levelId, l]));
+const LEVEL_BY_SCODE: Record<string, LevelSkillMapping> = Object.fromEntries(LEVEL_SKILL_MAP.map(l => [l.sCode, l]));
 
 (function sanity(): void {
   for (const lvl of LEVEL_SKILL_MAP) {
@@ -636,11 +670,20 @@ const LEVEL_BY_ID: Record<string, LevelSkillMapping> = Object.fromEntries(LEVEL_
   if (Object.keys(SKILL_BY_ID).length !== 24) {
     throw new Error(`Expected 24 core skills, got ${Object.keys(SKILL_BY_ID).length}`);
   }
+  if (Object.keys(LEVEL_BY_SCODE).length !== 93) {
+    throw new Error(`Expected 93 unique sCode values, got ${Object.keys(LEVEL_BY_SCODE).length} — a level's sCode collided with another's.`);
+  }
 })();
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Derived aggregates
 // ─────────────────────────────────────────────────────────────────────────────
+
+/** Look up a level by its S-notation code (e.g. "S4.1") instead of its
+ * L-number. See LevelSkillMapping.sCode and issue #280. */
+export function getLevelBySCode(sCode: string): LevelSkillMapping | undefined {
+  return LEVEL_BY_SCODE[sCode];
+}
 
 export function getSkillsForLevel(levelId: string): CoreSkill[] {
   const lvl = LEVEL_BY_ID[levelId];

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build:backend": "npm run build --workspace @fln/backend",
     "start": "npm run start --workspace @fln/backend",
     "lint": "npm run lint --workspaces --if-present",
-    "seed:question-bank": "npm run seed:question-bank --workspace @fln/backend"
+    "seed:question-bank": "npm run seed:question-bank --workspace @fln/backend",
+    "check:level-notation-drift": "tsx scripts/check-level-notation-drift.ts"
   },
   "dependencies": {
     "mongodb": "^7.5.0",

--- a/scripts/check-level-notation-drift.ts
+++ b/scripts/check-level-notation-drift.ts
@@ -1,0 +1,76 @@
+// Issue #280 ask #2: fails when the two level-numbering systems disagree.
+//
+// The project has two graphs of the same 93 levels:
+//   - S-notation (S1.1-S7.18)  — Research/fln_level_networks.md, Research/fln_proposed_levels.md
+//   - L-notation (L1-L93)      — frontend/src/data/skillProgressionMap.ts
+//
+// L(n) is defined as the n-th S-code in stage-then-index order (deterministic,
+// no judgement involved) and is now computed directly in skillProgressionMap.ts
+// (see LevelSkillMapping.sCode / sCodeFor()) rather than hand-maintained. This
+// script is the automated version of the manual comparison that originally
+// surfaced the drift documented in Research/fln_L_to_S_crosswalk.md — it
+// checks that the *reference* crosswalk file (the machine-readable record of
+// what the mapping is supposed to be) and the *code's* computed mapping still
+// agree, so a future edit to either one can't silently drift from the other
+// again.
+//
+// Usage: npx tsx scripts/check-level-notation-drift.ts
+// Exit code 0 = no drift. Exit code 1 = drift found (prints every mismatch).
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+async function main() {
+  const crosswalkPath = path.join(ROOT, 'Research', 'fln_L_to_S_crosswalk.json');
+  if (!fs.existsSync(crosswalkPath)) {
+    console.error(`Reference crosswalk not found at ${crosswalkPath} — nothing to check against.`);
+    process.exit(1);
+  }
+  const crosswalk: { L_to_S: Record<string, string> } = JSON.parse(fs.readFileSync(crosswalkPath, 'utf8'));
+  const referenceMap = crosswalk.L_to_S;
+
+  const skillMapPath = path.join(ROOT, 'frontend', 'src', 'data', 'skillProgressionMap.ts');
+  const { LEVEL_SKILL_MAP } = await import(skillMapPath);
+
+  const problems: string[] = [];
+
+  // Levels present in one but not the other.
+  const referenceIds = new Set(Object.keys(referenceMap));
+  const codeIds = new Set<string>(LEVEL_SKILL_MAP.map((l: { levelId: string }) => l.levelId));
+  for (const id of referenceIds) {
+    if (!codeIds.has(id)) problems.push(`${id} is in the reference crosswalk but has no entry in LEVEL_SKILL_MAP.`);
+  }
+  for (const id of codeIds) {
+    if (!referenceIds.has(id)) problems.push(`${id} is in LEVEL_SKILL_MAP but has no entry in the reference crosswalk.`);
+  }
+
+  // Same level, disagreeing sCode.
+  for (const lvl of LEVEL_SKILL_MAP as Array<{ levelId: string; sCode: string }>) {
+    const expected = referenceMap[lvl.levelId];
+    if (expected && expected !== lvl.sCode) {
+      problems.push(`${lvl.levelId}: code computes sCode "${lvl.sCode}" but the reference crosswalk says "${expected}".`);
+    }
+  }
+
+  if (problems.length > 0) {
+    console.error(`Level-notation drift found (${problems.length} problem(s)):\n`);
+    for (const p of problems) console.error('  - ' + p);
+    console.error(
+      '\nEither the reference crosswalk (Research/fln_L_to_S_crosswalk.json) or the ' +
+      'sCode computation in frontend/src/data/skillProgressionMap.ts has drifted from ' +
+      'the other. Fix whichever one is wrong before merging.'
+    );
+    process.exit(1);
+  }
+
+  console.log(`OK — all ${LEVEL_SKILL_MAP.length} levels' sCode values match the reference crosswalk exactly.`);
+}
+
+main().catch(err => {
+  console.error('check-level-notation-drift.ts failed to run:', err);
+  process.exit(1);
+});

--- a/scripts/repo-health-check.js
+++ b/scripts/repo-health-check.js
@@ -30,6 +30,24 @@ if (!lintOk) {
   notes.push('```\n' + lintOutput.split('\n').slice(0, 40).join('\n') + '\n```');
 }
 
+// --- Level-notation drift check (issue #280) ---
+// The L-notation (L1-L93, frontend/src/data/skillProgressionMap.ts) and
+// S-notation (S1.1-S7.18, Research/ docs) level-numbering systems drifted
+// apart once already without anyone noticing. This re-runs that comparison
+// daily so it can't happen silently again.
+let driftOk = true;
+let driftOutput = '';
+try {
+  execSync('npm run check:level-notation-drift --silent', { encoding: 'utf8', stdio: 'pipe' });
+} catch (err) {
+  driftOk = false;
+  driftOutput = (err.stdout || '') + (err.stderr || '');
+}
+if (!driftOk) {
+  problems.push('**The L-notation and S-notation level mappings have drifted apart again** (`npm run check:level-notation-drift`).');
+  notes.push('```\n' + driftOutput.split('\n').slice(0, 40).join('\n') + '\n```');
+}
+
 // --- CHANGELOG staleness check ---
 const changelogPath = path.join(__dirname, '..', 'CHANGELOG.md');
 const changelog = fs.readFileSync(changelogPath, 'utf8');


### PR DESCRIPTION
Closes the mechanical parts of #280 — asks 1 and 2. Ask 3 (deciding which notation survives long-term) is explicitly **not** addressed here; see below.

## Ask 1 — make the mapping available to the code

- Added `sCode` to `LevelSkillMapping` (`frontend/src/data/skillProgressionMap.ts`), computed by a new `sCodeFor()` using the same stage-then-index logic the issue describes as deterministic — not a hand-maintained table, so it can't independently drift from its own definition. Verified programmatically to reproduce all 93 rows of `Research/fln_L_to_S_crosswalk.json` exactly.
- `stageFor()` was refactored to share the same underlying stage-boundary array as `sCodeFor()`, so the two can't disagree with each other either.
- Added `getLevelBySCode()` so a level can be looked up by either ID, and an `sCode`-uniqueness check to the file's existing startup sanity check.

## Ask 2 — add a drift check

- New `scripts/check-level-notation-drift.ts`: loads the code's computed L→S mapping and diffs it against the reference `Research/fln_L_to_S_crosswalk.json` — levels present in one but not the other, and same-level entries that disagree. Non-zero exit on any mismatch.
- Wired into the existing `scripts/repo-health-check.js` (the daily CI health-check workflow already covers lint + CHANGELOG staleness — this is now a third check in the same report), so this can't drift silently a second time.
- `npm run check:level-notation-drift` to run it standalone.

**Actually tested that it catches drift**, not just that it passes: temporarily changed one entry in the reference crosswalk, confirmed the script reported the exact mismatch and exited 1, then reverted (`git status` confirms the crosswalk file is untouched in this PR).

Note: this PR only checks *level identity* (does L28 mean S4.1 in both places), not edge/prerequisite agreement between the two graphs — that's the substance of #277/#278/#279 and out of scope here.

## Ask 3 — not addressed, deliberately

The issue itself calls this "not mechanical," and renaming either ID would orphan accumulated student-response history. This PR makes both IDs available additively on every level — nothing is renamed, nothing currently using `levelId` changes behavior. Which notation (if either) becomes canonical is still an open decision for the team to make deliberately.

## Verification

- `npm run lint` (tsc --noEmit, both workspaces) — clean.
- `npm run build --workspace @fln/frontend` — clean.
- `node scripts/repo-health-check.js` — runs clean end-to-end with the new check wired in (only the pre-existing, unrelated CHANGELOG-staleness warning shows).
- Drift checker verified against both a clean and a deliberately-broken crosswalk (see above).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RPePEJdjynqqFyPNWZhPCF