### PR TITLE
Fix #277: move relationshipType from the level onto each prerequisite

### DIFF
--- a/frontend/src/components/SkillGraphPanel.tsx
+++ b/frontend/src/components/SkillGraphPanel.tsx
@@ -594,14 +594,19 @@ const LevelDetailView: React.FC<{
       )}
 
       {level.prerequisites.length > 0 && (
-        <Section title={`Prerequisites (${RELATIONSHIP_GLYPH[level.relationshipType]})`}>
+        // Issue #277: each prerequisite carries its own relationship type
+        // now (a level's prereqs can genuinely differ in strength from each
+        // other), so the glyph/color moved from the section title onto each
+        // chip individually instead of assuming one type for the whole list.
+        <Section title="Prerequisites">
           <div className="flex flex-wrap gap-1">
             {level.prerequisites.map(pre => (
               <span
-                key={pre}
-                className={`text-[10px] font-mono px-2 py-0.5 rounded border ${RELATIONSHIP_COLOR[level.relationshipType]} text-zinc-700 dark:text-zinc-300`}
+                key={pre.levelId}
+                title={pre.rationale ?? undefined}
+                className={`text-[10px] font-mono px-2 py-0.5 rounded border ${RELATIONSHIP_COLOR[pre.relationshipType]} text-zinc-700 dark:text-zinc-300`}
               >
-                {pre}
+                {RELATIONSHIP_GLYPH[pre.relationshipType]} {pre.levelId}
               </span>
             ))}
           </div>

--- a/frontend/src/data/skillProgressionMap.ts
+++ b/frontend/src/data/skillProgressionMap.ts
@@ -345,10 +345,26 @@ export interface LevelSkillMapping {
        | 'Class 1' | 'Class 2' | 'Class 3' | 'Class 4';
   primarySkills: string[];     // SK IDs
   supportingSkills: string[];  // SK IDs
-  prerequisites: string[];     // levelIds (conservative — only set when required_for_procedure)
-  relationshipType: RelationshipType;
+  prerequisites: Prerequisite[];
   questionTypes: string[];
   evidence: string[];
+}
+
+/**
+ * Issue #277: a level's prerequisites can genuinely differ in strength from
+ * each other (e.g. L53 depends on L36 more loosely than it depends on L37) —
+ * the relationship type lives on the edge, not on the whole level, so mixed
+ * strength can actually be expressed. `rationale` gives somewhere to record
+ * *why* an edge is typed the way it is; per the issue, an edge with no
+ * stated rationale shouldn't be typed as a hard prerequisite
+ * (`required_for_procedure`) — the diagnostic paper's apex-selection
+ * inference only holds across genuinely hard edges, so an unjustified one
+ * silently over-claims what testing the apex level actually proves.
+ */
+export interface Prerequisite {
+  levelId: string;
+  relationshipType: RelationshipType;
+  rationale?: string;
 }
 
 // Cumulative level counts per S-notation stage (S1..S7): 7, 10, 10, 15, 19,
@@ -394,8 +410,26 @@ function qtL(l: number): string[] {
 // (Earlier hand-written L1-L27 mapping has been replaced by spec §4. The shape
 // and the dashboard button location are preserved.)
 
+// Issue #277: every existing call site below sets `prerequisites` as a plain
+// levelId array plus one shared `relationshipType` — because until now that
+// was the only way to say it. That shape stays valid as a shorthand (most
+// levels genuinely do have uniform-strength prerequisites and there's no
+// reason to force verbosity where it isn't needed) but is normalized here
+// into real per-edge Prerequisite objects, so the *data* is per-edge even
+// where the *authoring* isn't. A call site that does need mixed strength
+// (e.g. applying #278's corrections) can pass `Prerequisite[]` directly
+// instead, per-edge, bypassing the shorthand for just that level.
+function normalizePrerequisites(
+  prereqs: (string | Prerequisite)[] | undefined,
+  defaultType: RelationshipType
+): Prerequisite[] {
+  return (prereqs ?? []).map(p =>
+    typeof p === 'string' ? { levelId: p, relationshipType: defaultType } : p
+  );
+}
+
 function makeLevel(n: number, capability: string, primary: string[], supporting: string[], opts: {
-  prerequisites?: string[];
+  prerequisites?: (string | Prerequisite)[];
   relationshipType?: RelationshipType;
   questionTypes?: string[];
   evidence?: string[];
@@ -408,8 +442,7 @@ function makeLevel(n: number, capability: string, primary: string[], supporting:
     stage: stageFor(n),
     primarySkills: primary,
     supportingSkills: supporting,
-    prerequisites: opts.prerequisites ?? [],
-    relationshipType: opts.relationshipType ?? 'often_precedes',
+    prerequisites: normalizePrerequisites(opts.prerequisites, opts.relationshipType ?? 'often_precedes'),
     questionTypes: opts.questionTypes ?? qtL(n),
     evidence: opts.evidence ?? [],
   };
@@ -659,8 +692,8 @@ const LEVEL_BY_SCODE: Record<string, LevelSkillMapping> = Object.fromEntries(LEV
       }
     }
     for (const pre of lvl.prerequisites) {
-      if (!LEVEL_BY_ID[pre]) {
-        throw new Error(`Level ${lvl.levelId} references unknown prereq level ${pre}`);
+      if (!LEVEL_BY_ID[pre.levelId]) {
+        throw new Error(`Level ${lvl.levelId} references unknown prereq level ${pre.levelId}`);
       }
     }
   }
@@ -713,7 +746,7 @@ export function getPrerequisiteEdges(): Array<{ from: string; to: string; type: 
   const edges: Array<{ from: string; to: string; type: RelationshipType }> = [];
   for (const lvl of LEVEL_SKILL_MAP) {
     for (const pre of lvl.prerequisites) {
-      edges.push({ from: pre, to: lvl.levelId, type: lvl.relationshipType });
+      edges.push({ from: pre.levelId, to: lvl.levelId, type: pre.relationshipType });
     }
   }
   return edges;


### PR DESCRIPTION
Closes #277 — enables the per-edge corrections that #278 is blocked on.

## Problem

`LevelSkillMapping` stored one `relationshipType` per level, applied to every entry in that level's `prerequisites` array — a level with two prerequisites of genuinely different strength (e.g. L53's `['L36','L37']`) couldn't express that difference. This matters because the diagnostic paper is built by apex-selection inference, which is only valid across a genuinely hard (`required_for_procedure`) edge — so the single-field limitation directly affected what gets printed and what can be safely inferred from a child's answers.

## What changed

- New `Prerequisite { levelId, relationshipType, rationale? }`, replacing the level-level `relationshipType` field.
- `rationale` gives somewhere to record why an edge is typed the way it is. Per the issue, an edge with no stated rationale shouldn't be typed as a hard prerequisite — **not enforced in this PR** (no edge currently has a rationale to check against; enforcing it now would break every existing `required_for_procedure` edge). Left as a natural follow-up once #279's adjudication pass populates real rationales.
- `makeLevel()` keeps accepting the existing `prerequisites: string[]` + `relationshipType` shorthand and normalizes it into real per-edge objects underneath — **all ~86 existing call sites are untouched**, since most levels do genuinely have uniform-strength prerequisites today. A level that needs mixed strength (like #278's corrections will) can pass `Prerequisite[]` directly instead, per-edge.
- Updated the file's own sanity check, `getPrerequisiteEdges()`, and `SkillGraphPanel.tsx`'s prerequisite chips — glyph/color now render per chip from that edge's actual type instead of assuming one type for the whole list, and a chip shows its `rationale` as a tooltip when present.

## Verification

- Spot-checked the actual normalized data: `L53.prerequisites` now has two real per-edge objects, both `relationshipType: 'supports'` — matching the original single-type data exactly, confirming nothing was silently changed.
- Total edge count via `getPrerequisiteEdges()` unchanged: 124, same before and after.
- `npm run lint` (tsc --noEmit, both workspaces) — clean, no new errors, confirming no other consumer still expects the old shape.
- `npm run build --workspace @fln/frontend` — clean.
- `npm run check:level-notation-drift` — still passes (unrelated to this change, but exercises the module's own load-time sanity check as a side effect, confirming it still runs cleanly for all 93 levels).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RPePEJdjynqqFyPNWZhPCF