### PR TITLE
Auto-compress oversized scans before Cloud OCR upload

### DIFF
--- a/frontend/src/components/IcrTwoStageScan.tsx
+++ b/frontend/src/components/IcrTwoStageScan.tsx
@@ -143,9 +143,10 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
 
   const runCloudOcr = async () => {
     if (!uploadedFile) return;
-    if (uploadedFile.size > MAX_UPLOAD_BYTES) {
+    const fileToUse = await compressImageIfNeeded(uploadedFile, MAX_UPLOAD_BYTES);
+    if (fileToUse.size > MAX_UPLOAD_BYTES) {
       setCloudError(
-        `File too large: ${(uploadedFile.size / 1024 / 1024).toFixed(1)} MB (max ${MAX_UPLOAD_LABEL}). ` +
+        `File too large: ${(fileToUse.size / 1024 / 1024).toFixed(1)} MB (max ${MAX_UPLOAD_LABEL}). ` +
         `Try compressing the image, or use a smaller scan resolution.`
       );
       return;
@@ -160,7 +161,7 @@ export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
       // data URL; the backend rasterizes PDFs to PNG before posting to
       // Ollama (Ollama's vision API only accepts image MIME types).
       // NO apiKey is ever sent from the frontend.
-      const dataUrl = await fileToDataUrl(uploadedFile);
+      const dataUrl = await fileToDataUrl(fileToUse);
       const res = await apiFetch('/api/icr/evaluate-cloud', {
         method: 'POST',
         headers: {
@@ -295,6 +296,48 @@ function fileToDataUrl(file: File): Promise<string> {
     reader.onerror = () => reject(reader.error || new Error('FileReader failed'));
     reader.readAsDataURL(file);
   });
+}
+
+// Phone-camera scans routinely land north of the 8MB cap at full resolution.
+// Rather than just rejecting them, downscale + re-encode as JPEG (quality
+// step-down, then dimension step-down) until it fits. PDFs and files already
+// under the cap pass through untouched. Bails out and returns the original
+// file if canvas encoding fails for any reason — the existing size check
+// downstream will then produce the normal "too large" error.
+async function compressImageIfNeeded(file: File, maxBytes: number): Promise<File> {
+  if (file.size <= maxBytes || !file.type.startsWith('image/')) return file;
+
+  const dataUrl = await fileToDataUrl(file);
+  const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const el = new Image();
+    el.onload = () => resolve(el);
+    el.onerror = () => reject(new Error('Could not decode image for compression'));
+    el.src = dataUrl;
+  });
+
+  let scale = 1;
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round(img.width * scale));
+    canvas.height = Math.max(1, Math.round(img.height * scale));
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return file;
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+    const quality = attempt < 3 ? [0.9, 0.75, 0.6][attempt] : 0.6;
+    const blob: Blob | null = await new Promise((resolve) =>
+      canvas.toBlob(resolve, 'image/jpeg', quality)
+    );
+    if (blob && blob.size <= maxBytes) {
+      return new File([blob], file.name.replace(/\.\w+$/, '') + '.jpg', {
+        type: 'image/jpeg',
+        lastModified: file.lastModified,
+      });
+    }
+    // Quality alone didn't get us there — shrink dimensions and retry.
+    scale *= 0.7;
+  }
+  return file;
 }
 
 // --- Reusable building blocks ----------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes the "File too large: X MB (max 8 MB)" dead-end error on `Run OCR with Ollama Gemma 4` — phone-camera scans routinely land above the 8MB cap at full resolution, and the only prior mitigation was a message telling the user to manually compress the image themselves.
- Adds `compressImageIfNeeded()` in `IcrTwoStageScan.tsx`: downscales + re-encodes oversized images as JPEG client-side (quality step-down 0.9→0.75→0.6, then dimension step-down ×0.7 per attempt, up to 6 tries) before the existing size check runs. PDFs and already-small files pass through untouched; if canvas encoding fails for any reason, it falls back to the original file so the existing "too large" error still fires as a safety net.

## Test plan
- [x] `tsc --noEmit` passes on the changed file (pre-existing unrelated `i18next` type errors on `main` are untouched)
- [ ] Manually verify in the browser: upload an ~11MB phone photo to the Cloud OCR panel and confirm it now compresses and submits successfully instead of erroring
- [ ] Confirm a normal-size scan (<8MB) is unaffected (passes through without re-encoding)