### PR TITLE
Raise Cloud OCR upload cap from stale 8MB to 18MB

### DIFF
--- a/frontend/src/components/IcrTwoStageScan.tsx
+++ b/frontend/src/components/IcrTwoStageScan.tsx
@@ -64,8 +64,14 @@ function formatMs(ms: number): string {
   return `${(ms / 1000).toFixed(2)} s`;
 }
 
-const MAX_UPLOAD_BYTES = 8 * 1024 * 1024; // matches backend's 8MB cap
-const MAX_UPLOAD_LABEL = '8 MB';
+// The old 8MB figure was a leftover from a since-deleted code path (the
+// removed /api/icr/filter + local-EasyOCR flow). The current backend
+// rasterizes PDFs itself (evaluation.ts) and only rejects a PDF above
+// MAX_TOTAL_BASE64 = 24MB base64 (~18MB binary); nginx's /fln location caps
+// request bodies at 25MB. 18MB raw stays safely under both once base64
+// inflation (~1.33x) is accounted for.
+const MAX_UPLOAD_BYTES = 18 * 1024 * 1024;
+const MAX_UPLOAD_LABEL = '18 MB';
 
 export const IcrTwoStageScan: React.FC<IcrTwoStageScanProps> = ({
   token,


### PR DESCRIPTION
## Summary
- Follow-up to #318, which fixed oversized *images* via client-side JPEG compression but missed that PDFs bypass that path entirely (`compressImageIfNeeded` only touches `image/*` MIME types).
- Root cause found live: a user's 11.1MB PDF scan (e.g. an Adobe Scan export) was still rejected by the frontend's hardcoded 8MB check after #318 shipped — that number was a stale leftover from the deleted `/api/icr/filter` + local-EasyOCR flow.
- Confirmed the current backend handles much larger PDFs fine: it rasterizes PDFs itself (`backend/src/routes/evaluation.ts`) and only rejects above `MAX_TOTAL_BASE64 = 24MB` base64 (~18MB binary, line 387); nginx's `/fln` location already allows 25MB request bodies; Express's body limit is 100MB. The 8MB frontend gate had no basis in any real remaining server-side constraint.
- Raised `MAX_UPLOAD_BYTES` to 18MB, matching the backend's own real PDF ceiling with margin under nginx's 25MB cap once base64 inflation (~1.33x) is accounted for.

## Test plan
- [x] `tsc --noEmit` passes on the changed file
- [ ] Manually verify: upload the same 11.1MB PDF that failed before and confirm it now succeeds
- [ ] Confirm a PDF genuinely over ~18MB still gets a clear "too large" message (not a raw 413 from nginx/Express)