### PR TITLE
Raise Cloud OCR page/size caps to support 22-25 page scans

### DIFF
--- a/backend/src/routes/evaluation.ts
+++ b/backend/src/routes/evaluation.ts
@@ -368,7 +368,7 @@ export function registerEvaluationRoutes(app: express.Express) {
             }
             const pagePaths: string[] = pdfJson.pages.map((p: any) => p.output_path).filter(Boolean);
             // Safety caps: refuse to OCR absurdly long PDFs.
-            const MAX_PAGES = 10;
+            const MAX_PAGES = 25;
             if (pagePaths.length > MAX_PAGES) {
               try { fs.rmSync(pdfPath, { force: true }); } catch { /* noop */ }
               try { fs.rmSync(pagesDir, { recursive: true, force: true }); } catch { /* noop */ }
@@ -384,7 +384,7 @@ export function registerEvaluationRoutes(app: express.Express) {
             // Safety cap on cumulative base64 size — Ollama's /api/chat
             // accepts large request bodies but we shouldn't push 50+ MB.
             const totalBase64Bytes = imageBase64s.reduce((n, s) => n + s.length, 0);
-            const MAX_TOTAL_BASE64 = 24 * 1024 * 1024; // ~24 MB base64 ≈ 18 MB binary
+            const MAX_TOTAL_BASE64 = 60 * 1024 * 1024; // ~60 MB base64 ≈ 45 MB binary — sized for MAX_PAGES=25 at up to ~2.4MB base64/page avg
             if (totalBase64Bytes > MAX_TOTAL_BASE64) {
               try { fs.rmSync(pdfPath, { force: true }); } catch { /* noop */ }
               try { fs.rmSync(pagesDir, { recursive: true, force: true }); } catch { /* noop */ }


### PR DESCRIPTION
## Summary
- Live user hit "PDF has 22 pages; max is 10" on a real scan through the Cloud OCR panel (`/api/icr/evaluate-cloud`), right after #319 fixed the unrelated file-size gate.
- Raised `MAX_PAGES` (backend/src/routes/evaluation.ts:371) from 10 to 25.
- Raised `MAX_TOTAL_BASE64` (line 387) from 24MB to 60MB alongside it — at the documented ~1.5-4MB base64/page rasterization estimate, 25 pages could reach 37-100MB, so raising only the page count would just trade one rejection for another on the same file.

## Deploy note
This requires a **manual nginx config change** on the production server (not part of this repo): the `/fln` location's `client_max_body_size` is currently 25MB and needs raising to accommodate the larger request body (recommend ~65MB) before this takes effect end-to-end. Will be done as part of the redeploy, not in this PR.

## Test plan
- [x] `tsc --noEmit` passes on the changed file
- [ ] Manually verify: re-upload the same 22-page PDF that failed before and confirm it now succeeds end-to-end (through nginx, not just backend)
- [ ] Confirm a PDF genuinely over 25 pages still gets a clear message, not a raw timeout/502