### PR TITLE
Rasterize Cloud OCR PDF pages as JPEG@200dpi, not lossless PNG@300dpi

### DIFF
--- a/ai-services/scripts/pdf_rasterize.py
+++ b/ai-services/scripts/pdf_rasterize.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 """
-Rasterize a PDF to PNG using PyMuPDF.
+Rasterize a PDF to JPEG using PyMuPDF.
 
-Used by the /api/icr/filter endpoint to accept PDFs (the blue-ink filter
-only operates on raster pixels). Renders at 300 DPI so downstream OCR
-sees enough detail to read student handwriting.
+Used by the Cloud OCR path (/api/icr/evaluate-cloud) to accept PDFs —
+Ollama's vision API only takes image MIME types. Renders at 200 DPI
+(down from 300 — plenty for handwriting legibility; the extra 300 DPI
+detail is thrown away by the vision model's own internal downsampling
+anyway) and saves as JPEG at quality 85 instead of lossless PNG. A real
+22-page phone-photo scan measured ~4.8 MB/page as 300-DPI PNG (lossless
+deflate compresses photo-like scanned paper poorly) vs. a small fraction
+of that as 200-DPI JPEG — this is what actually made large multi-page
+scans fit under the pipeline's size caps, not just raising the caps
+themselves (see backend/src/routes/evaluation.ts MAX_TOTAL_BASE64).
 
 Stdout format (single JSON line):
   Single-page mode: {"success": true, "output_path": "...", "page_size": [w, h]}
@@ -12,7 +19,7 @@ Stdout format (single JSON line):
 
 Usage:
   python pdf_rasterize.py <input_pdf> <output_path>              # single page (page 1) — backward compatible
-  python pdf_rasterize.py <input_pdf> <output_dir> --all-pages   # all pages, one PNG per page in output_dir
+  python pdf_rasterize.py <input_pdf> <output_dir> --all-pages   # all pages, one JPEG per page in output_dir
   python pdf_rasterize.py <input_pdf> <output_path> --page <n>   # specific page (1-based)
 """
 
@@ -63,29 +70,57 @@ def main():
             }))
             sys.exit(1)
 
-        # 300 DPI render matrix (fitz base = 72 DPI).
-        matrix = fitz.Matrix(300 / 72, 300 / 72)
+        # 200 DPI render matrix (fitz base = 72 DPI).
+        DPI = 200
+        JPEG_QUALITY = 85
+        # Guard against a stray poster/A0-sized page blowing up memory and
+        # output size at a flat 200 DPI (e.g. a wrongly-uploaded non-worksheet
+        # PDF) — cap the longer raster side, scaling the matrix down for that
+        # one page rather than for the whole document.
+        MAX_RASTER_DIM = 3500
+
+        def matrix_for(page) -> "fitz.Matrix":
+            scale = DPI / 72
+            longer_pt = max(page.rect.width, page.rect.height)
+            if longer_pt * scale > MAX_RASTER_DIM:
+                scale = MAX_RASTER_DIM / longer_pt
+            return fitz.Matrix(scale, scale)
 
         if args.all_pages:
             output.mkdir(parents=True, exist_ok=True)
             pages_info = []
+            page_errors = []
             for i in range(doc.page_count):
-                page = doc.load_page(i)
-                pix = page.get_pixmap(matrix=matrix, alpha=False)
-                out_path = output / f"page_{i + 1}.png"
-                pix.save(out_path)
-                page_w, page_h = page.rect.width, page.rect.height
-                pages_info.append({
-                    "page_number": i + 1,
-                    "output_path": str(out_path),
-                    "page_size": [page_w, page_h],
-                    "raster_size": [pix.width, pix.height],
-                })
+                # One malformed/corrupt page (rare but real with scanned/
+                # re-exported PDFs) shouldn't fail the whole multi-page scan —
+                # skip it and let the caller OCR the pages that did render.
+                try:
+                    page = doc.load_page(i)
+                    pix = page.get_pixmap(matrix=matrix_for(page), alpha=False)
+                    out_path = output / f"page_{i + 1}.jpg"
+                    pix.save(out_path, jpg_quality=JPEG_QUALITY)
+                    page_w, page_h = page.rect.width, page.rect.height
+                    pages_info.append({
+                        "page_number": i + 1,
+                        "output_path": str(out_path),
+                        "page_size": [page_w, page_h],
+                        "raster_size": [pix.width, pix.height],
+                    })
+                except Exception as page_err:
+                    page_errors.append({"page_number": i + 1, "error": str(page_err)})
             doc.close()
+            if not pages_info:
+                print(json.dumps({
+                    "success": False,
+                    "error": f"All {doc.page_count} page(s) failed to rasterize.",
+                    "page_errors": page_errors,
+                }))
+                sys.exit(1)
             print(json.dumps({
                 "success": True,
                 "page_count": len(pages_info),
                 "pages": pages_info,
+                **({"page_errors": page_errors} if page_errors else {}),
             }))
             return
 
@@ -99,9 +134,10 @@ def main():
             }))
             sys.exit(1)
         page = doc.load_page(page_index)
-        pix = page.get_pixmap(matrix=matrix, alpha=False)
+        pix = page.get_pixmap(matrix=matrix_for(page), alpha=False)
+        output = output.with_suffix('.jpg')
         output.parent.mkdir(parents=True, exist_ok=True)
-        pix.save(output)
+        pix.save(output, jpg_quality=JPEG_QUALITY)
         page_w, page_h = page.rect.width, page.rect.height
         doc.close()
 

--- a/backend/src/routes/evaluation.ts
+++ b/backend/src/routes/evaluation.ts
@@ -378,13 +378,17 @@ export function registerEvaluationRoutes(app: express.Express) {
                 }
               };
             }
-            // Read each page PNG as base64 and concatenate. Each page is
-            // 300 DPI ~1-3 MB on disk → ~1.5-4 MB base64.
+            // Read each page JPEG as base64 and concatenate. pdf_rasterize.py
+            // renders at 200 DPI / JPEG q85 (not 300 DPI lossless PNG — a real
+            // 22-page photo-like scan measured ~4.8 MB/page as PNG vs. a small
+            // fraction of that as JPEG), so real-world pages should land well
+            // under this cap; it remains as a backstop against pathological
+            // inputs, not the primary size control.
             imageBase64s = pagePaths.map((p: string) => fs.readFileSync(p).toString('base64'));
             // Safety cap on cumulative base64 size — Ollama's /api/chat
             // accepts large request bodies but we shouldn't push 50+ MB.
             const totalBase64Bytes = imageBase64s.reduce((n, s) => n + s.length, 0);
-            const MAX_TOTAL_BASE64 = 60 * 1024 * 1024; // ~60 MB base64 ≈ 45 MB binary — sized for MAX_PAGES=25 at up to ~2.4MB base64/page avg
+            const MAX_TOTAL_BASE64 = 60 * 1024 * 1024; // ~60 MB base64 ≈ 45 MB binary — backstop, not the primary size control post-JPEG switch
             if (totalBase64Bytes > MAX_TOTAL_BASE64) {
               try { fs.rmSync(pdfPath, { force: true }); } catch { /* noop */ }
               try { fs.rmSync(pagesDir, { recursive: true, force: true }); } catch { /* noop */ }
@@ -394,8 +398,8 @@ export function registerEvaluationRoutes(app: express.Express) {
                 }
               };
             }
-            mimeUsed = 'image/png';
-            // Cleanup the per-page PNGs and the source PDF now that we
+            mimeUsed = 'image/jpeg';
+            // Cleanup the per-page JPEGs and the source PDF now that we
             // have them in memory. Done before the Ollama POST so we
             // don't leak disk if the request hangs.
             try { fs.rmSync(pdfPath, { force: true }); } catch { /* noop */ }


### PR DESCRIPTION
## Summary
Root cause fix for the recurring size errors on real multi-page Cloud OCR scans (follow-up to #319, #320). Live testing kept surfacing the same underlying problem in different forms:

1. #319 raised the frontend upload cap 8MB → 18MB (fixed oversized single-file uploads)
2. #320 raised `MAX_PAGES` 10 → 25 and `MAX_TOTAL_BASE64` 24MB → 60MB (fixed the page-count rejection)
3. The very next real test — the same 22-page PDF — still failed: **141.1 MB base64 across 22 pages**, far above even the raised 60MB cap

Investigated `ai-services/scripts/pdf_rasterize.py`: it renders every page at **300 DPI** and saves as **lossless PNG**. PNG's deflate compression handles photo-like scanned paper (texture, shadows, uneven lighting) far worse than JPEG — this fully explains the ~4.8 MB/page real-world measurement vs. the ~1-3 MB/page assumption the original caps were tuned against. Bumping caps was chasing the symptom; this fixes the cause.

**Change:** render at 200 DPI (still well above what's needed for handwriting legibility — the extra 300 DPI detail is discarded by the vision model's own downsampling anyway) and save as JPEG at quality 85 instead of PNG. `backend/src/routes/evaluation.ts`'s `mimeUsed` updated from `image/png` to `image/jpeg` to match.

**Also hardened two edge cases** found while in this file:
- A single malformed/corrupt page no longer fails the whole multi-page batch — it's skipped and reported in a `page_errors` array, OCR proceeds on the pages that did render.
- A stray poster/A0-sized page no longer rasterizes at an uncapped resolution (which could blow up memory/output size at 200 DPI) — longer raster side clamped to 3500px per-page.

## Test plan
- [x] `python3 -m py_compile` passes
- [x] `tsc --noEmit` passes on the changed backend file
- [x] Smoke-tested locally against a synthetic 3-page PDF (rasterized cleanly to ~55KB JPEGs at correct 1653x2339 @ 200dpi)
- [x] Smoke-tested poster-size clamp (9370x13242 → correctly capped to 2475x3500)
- [x] Smoke-tested missing-file and corrupt-file inputs (clean JSON error, no crash)
- [ ] Manually verify: re-upload the same 22-page real scan that measured 141MB and confirm it now succeeds end-to-end
- [ ] Spot-check OCR accuracy on a real scan at 200 DPI/JPEG vs. the prior 300 DPI/PNG output to confirm no meaningful legibility regression