### PR TITLE
feat(superadmin): Question Intervention — author question logic per level

### DIFF
--- a/backend/src/config/skillLevelMap.ts
+++ b/backend/src/config/skillLevelMap.ts
@@ -1,0 +1,95 @@
+// Server-side view of the 93-level -> 24-skill -> ~179-subskill curriculum map.
+//
+// The canonical data lives in `frontend/src/data/skillProgressionMap.ts`. That
+// module cannot be imported here: `frontend` and `backend` are separate npm
+// workspaces with separate tsconfigs, and the backend ships as a single esbuild
+// bundle. So the mapping is snapshotted into `./../data/skillLevelMap.json` by
+// `scripts/generate-skill-level-map.ts`, and CI runs that script with `--check`
+// to fail the build if the snapshot drifts from the source.
+//
+// This matters because the Question Intervention API validates every
+// (level, skills, subskills) combination server-side. The client's cascading
+// dropdowns are a convenience; they are not a guard, and a malformed request
+// must not be able to file a logic against a level that cannot host it.
+
+import snapshot from '../data/skillLevelMap.json';
+
+export interface LevelInfo {
+  levelId: string;       // "L30"
+  levelNumber: number;   // 30
+  capability: string;
+  stage: string;         // "Class 1"
+  sCode: string;         // "S4.3"
+  skills: string[];      // union of primary + supporting, sorted
+}
+
+export interface SkillInfo {
+  id: string;            // "SK05"
+  name: string;
+  domain: string;
+  subskills: Array<{ id: string; name: string }>;
+}
+
+const LEVELS = snapshot.levels as Record<string, Omit<LevelInfo, 'levelId'>>;
+const SKILLS = snapshot.skills as Record<string, Omit<SkillInfo, 'id'>>;
+
+/** Total number of FLN levels. Read from the snapshot rather than hardcoded as 93. */
+export const LEVEL_COUNT: number = snapshot.levelCount;
+
+export function levelIdFor(levelNumber: number): string {
+  return `L${levelNumber}`;
+}
+
+export function getLevel(levelNumber: number): LevelInfo | undefined {
+  const id = levelIdFor(levelNumber);
+  const entry = LEVELS[id];
+  return entry ? { levelId: id, ...entry } : undefined;
+}
+
+export function getSkill(skillId: string): SkillInfo | undefined {
+  const entry = SKILLS[skillId];
+  return entry ? { id: skillId, ...entry } : undefined;
+}
+
+/** Skills validly attachable to a level (primary + supporting). Empty if the level is unknown. */
+export function getSkillsForLevel(levelNumber: number): string[] {
+  return getLevel(levelNumber)?.skills ?? [];
+}
+
+export function isSkillMappedToLevel(skillId: string, levelNumber: number): boolean {
+  return getSkillsForLevel(levelNumber).includes(skillId);
+}
+
+/** Subskill IDs under the given skills, deduped and sorted. */
+export function getSubskillsForSkills(skillIds: string[]): string[] {
+  const out = new Set<string>();
+  for (const sk of skillIds) {
+    for (const ss of SKILLS[sk]?.subskills ?? []) out.add(ss.id);
+  }
+  return Array.from(out).sort();
+}
+
+/**
+ * A subskill belongs to a skill when its dotted prefix matches — "SK05.04" is
+ * under "SK05". Checked against the snapshot rather than by string surgery
+ * alone, so a well-formed but non-existent id like "SK05.99" is still rejected.
+ */
+export function isSubskillUnderSkills(subskillId: string, skillIds: string[]): boolean {
+  const prefix = subskillId.split('.')[0];
+  if (!skillIds.includes(prefix)) return false;
+  return (SKILLS[prefix]?.subskills ?? []).some(ss => ss.id === subskillId);
+}
+
+/**
+ * The payload behind `GET /api/question-logics/level-map` — everything the
+ * authoring form needs to drive its cascading dropdowns, in one response.
+ */
+export function buildLevelMapPayload() {
+  return {
+    levelCount: LEVEL_COUNT,
+    levels: Object.entries(LEVELS)
+      .map(([levelId, l]) => ({ levelId, ...l }))
+      .sort((a, b) => a.levelNumber - b.levelNumber),
+    skills: Object.entries(SKILLS).map(([id, s]) => ({ id, ...s })),
+  };
+}

--- a/backend/src/data/skillLevelMap.json
+++ b/backend/src/data/skillLevelMap.json
@@ -1,0 +1,1843 @@
+{
+  "generatedFrom": "frontend/src/data/skillProgressionMap.ts",
+  "levelCount": 93,
+  "levels": {
+    "L1": {
+      "levelNumber": 1,
+      "capability": "One-to-One Correspondence",
+      "stage": "Pre-school 1",
+      "sCode": "S1.1",
+      "skills": [
+        "SK01",
+        "SK06"
+      ]
+    },
+    "L2": {
+      "levelNumber": 2,
+      "capability": "Classification (Single Property)",
+      "stage": "Pre-school 1",
+      "sCode": "S1.2",
+      "skills": [
+        "SK02",
+        "SK04"
+      ]
+    },
+    "L3": {
+      "levelNumber": 3,
+      "capability": "Perceptual Same/Different",
+      "stage": "Pre-school 1",
+      "sCode": "S1.3",
+      "skills": [
+        "SK02",
+        "SK04"
+      ]
+    },
+    "L4": {
+      "levelNumber": 4,
+      "capability": "Rote Verbal Counting to 10",
+      "stage": "Pre-school 1",
+      "sCode": "S1.4",
+      "skills": [
+        "SK05",
+        "SK10"
+      ]
+    },
+    "L5": {
+      "levelNumber": 5,
+      "capability": "Counting Small Sets (1-3)",
+      "stage": "Pre-school 1",
+      "sCode": "S1.5",
+      "skills": [
+        "SK01",
+        "SK05",
+        "SK06"
+      ]
+    },
+    "L6": {
+      "levelNumber": 6,
+      "capability": "Shape Matching (Perceptual)",
+      "stage": "Pre-school 1",
+      "sCode": "S1.6",
+      "skills": [
+        "SK04",
+        "SK19"
+      ]
+    },
+    "L7": {
+      "levelNumber": 7,
+      "capability": "Perceptual Subitizing",
+      "stage": "Pre-school 1",
+      "sCode": "S1.7",
+      "skills": [
+        "SK06",
+        "SK07"
+      ]
+    },
+    "L8": {
+      "levelNumber": 8,
+      "capability": "Quantity Comparison",
+      "stage": "Pre-school 2",
+      "sCode": "S2.1",
+      "skills": [
+        "SK01",
+        "SK06",
+        "SK09"
+      ]
+    },
+    "L9": {
+      "levelNumber": 9,
+      "capability": "Seriation (3 Objects)",
+      "stage": "Pre-school 2",
+      "sCode": "S2.2",
+      "skills": [
+        "SK03",
+        "SK09"
+      ]
+    },
+    "L10": {
+      "levelNumber": 10,
+      "capability": "Classification (Increasing Complexity)",
+      "stage": "Pre-school 2",
+      "sCode": "S2.3",
+      "skills": [
+        "SK02",
+        "SK04"
+      ]
+    },
+    "L11": {
+      "levelNumber": 11,
+      "capability": "Counting to 5 (Cardinality)",
+      "stage": "Pre-school 2",
+      "sCode": "S2.4",
+      "skills": [
+        "SK01",
+        "SK05",
+        "SK06"
+      ]
+    },
+    "L12": {
+      "levelNumber": 12,
+      "capability": "Counting 6-10",
+      "stage": "Pre-school 2",
+      "sCode": "S2.5",
+      "skills": [
+        "SK05",
+        "SK06"
+      ]
+    },
+    "L13": {
+      "levelNumber": 13,
+      "capability": "Shape Identification",
+      "stage": "Pre-school 2",
+      "sCode": "S2.6",
+      "skills": [
+        "SK04",
+        "SK19"
+      ]
+    },
+    "L14": {
+      "levelNumber": 14,
+      "capability": "2-Item Patterns",
+      "stage": "Pre-school 2",
+      "sCode": "S2.7",
+      "skills": [
+        "SK04",
+        "SK18"
+      ]
+    },
+    "L15": {
+      "levelNumber": 15,
+      "capability": "Comparative Vocabulary",
+      "stage": "Pre-school 2",
+      "sCode": "S2.8",
+      "skills": [
+        "SK09",
+        "SK20"
+      ]
+    },
+    "L16": {
+      "levelNumber": 16,
+      "capability": "Conceptual Subitizing",
+      "stage": "Pre-school 2",
+      "sCode": "S2.9",
+      "skills": [
+        "SK06",
+        "SK07",
+        "SK12"
+      ]
+    },
+    "L17": {
+      "levelNumber": 17,
+      "capability": "Basic Shape Composition",
+      "stage": "Pre-school 2",
+      "sCode": "S2.10",
+      "skills": [
+        "SK12",
+        "SK19"
+      ]
+    },
+    "L18": {
+      "levelNumber": 18,
+      "capability": "Numeral Recognition (1-10)",
+      "stage": "Pre-school 3",
+      "sCode": "S3.1",
+      "skills": [
+        "SK05",
+        "SK08"
+      ]
+    },
+    "L19": {
+      "levelNumber": 19,
+      "capability": "Numeral-Quantity Correspondence",
+      "stage": "Pre-school 3",
+      "sCode": "S3.2",
+      "skills": [
+        "SK05",
+        "SK06",
+        "SK08"
+      ]
+    },
+    "L20": {
+      "levelNumber": 20,
+      "capability": "Numeral Comparison (Object-Mediated)",
+      "stage": "Pre-school 3",
+      "sCode": "S3.3",
+      "skills": [
+        "SK08",
+        "SK09"
+      ]
+    },
+    "L21": {
+      "levelNumber": 21,
+      "capability": "Seriation with Transitivity",
+      "stage": "Pre-school 3",
+      "sCode": "S3.4",
+      "skills": [
+        "SK03",
+        "SK09"
+      ]
+    },
+    "L22": {
+      "levelNumber": 22,
+      "capability": "Flexible Classification",
+      "stage": "Pre-school 3",
+      "sCode": "S3.5",
+      "skills": [
+        "SK02",
+        "SK04",
+        "SK24"
+      ]
+    },
+    "L23": {
+      "levelNumber": 23,
+      "capability": "Numeral Sequencing",
+      "stage": "Pre-school 3",
+      "sCode": "S3.6",
+      "skills": [
+        "SK05",
+        "SK08",
+        "SK10"
+      ]
+    },
+    "L24": {
+      "levelNumber": 24,
+      "capability": "Comparative Vocabulary (Formalizing)",
+      "stage": "Pre-school 3",
+      "sCode": "S3.7",
+      "skills": [
+        "SK09",
+        "SK20"
+      ]
+    },
+    "L25": {
+      "levelNumber": 25,
+      "capability": "Patterns (2-Item Indep & 3-Item Intro)",
+      "stage": "Pre-school 3",
+      "sCode": "S3.8",
+      "skills": [
+        "SK04",
+        "SK18"
+      ]
+    },
+    "L26": {
+      "levelNumber": 26,
+      "capability": "Basic Shape Properties",
+      "stage": "Pre-school 3",
+      "sCode": "S3.9",
+      "skills": [
+        "SK04",
+        "SK19"
+      ]
+    },
+    "L27": {
+      "levelNumber": 27,
+      "capability": "Shape Composition & Decomposition",
+      "stage": "Pre-school 3",
+      "sCode": "S3.10",
+      "skills": [
+        "SK12",
+        "SK19"
+      ]
+    },
+    "L28": {
+      "levelNumber": 28,
+      "capability": "Abstract Numeral Comparison",
+      "stage": "Class 1",
+      "sCode": "S4.1",
+      "skills": [
+        "SK08",
+        "SK09",
+        "SK10"
+      ]
+    },
+    "L29": {
+      "levelNumber": 29,
+      "capability": "Close Numeral Comparison",
+      "stage": "Class 1",
+      "sCode": "S4.2",
+      "skills": [
+        "SK09",
+        "SK11"
+      ]
+    },
+    "L30": {
+      "levelNumber": 30,
+      "capability": "Counting Objects to 20",
+      "stage": "Class 1",
+      "sCode": "S4.3",
+      "skills": [
+        "SK01",
+        "SK05",
+        "SK06"
+      ]
+    },
+    "L31": {
+      "levelNumber": 31,
+      "capability": "Reading & Writing Numerals to 99",
+      "stage": "Class 1",
+      "sCode": "S4.4",
+      "skills": [
+        "SK05",
+        "SK08",
+        "SK11"
+      ]
+    },
+    "L32": {
+      "levelNumber": 32,
+      "capability": "Tens and Ones",
+      "stage": "Class 1",
+      "sCode": "S4.5",
+      "skills": [
+        "SK11",
+        "SK12"
+      ]
+    },
+    "L33": {
+      "levelNumber": 33,
+      "capability": "Single-Digit Addition",
+      "stage": "Class 1",
+      "sCode": "S4.6",
+      "skills": [
+        "SK05",
+        "SK06",
+        "SK12",
+        "SK13"
+      ]
+    },
+    "L34": {
+      "levelNumber": 34,
+      "capability": "Single-Digit Subtraction",
+      "stage": "Class 1",
+      "sCode": "S4.7",
+      "skills": [
+        "SK05",
+        "SK06",
+        "SK14"
+      ]
+    },
+    "L35": {
+      "levelNumber": 35,
+      "capability": "3D Shape Properties",
+      "stage": "Class 1",
+      "sCode": "S4.8",
+      "skills": [
+        "SK04",
+        "SK19"
+      ]
+    },
+    "L36": {
+      "levelNumber": 36,
+      "capability": "Non-Standard Length Estimation",
+      "stage": "Class 1",
+      "sCode": "S4.9",
+      "skills": [
+        "SK20",
+        "SK24"
+      ]
+    },
+    "L37": {
+      "levelNumber": 37,
+      "capability": "Non-Standard Capacity Estimation",
+      "stage": "Class 1",
+      "sCode": "S4.10",
+      "skills": [
+        "SK20",
+        "SK24"
+      ]
+    },
+    "L38": {
+      "levelNumber": 38,
+      "capability": "3-Item Pattern Completion",
+      "stage": "Class 1",
+      "sCode": "S4.11",
+      "skills": [
+        "SK04",
+        "SK18"
+      ]
+    },
+    "L39": {
+      "levelNumber": 39,
+      "capability": "Concept of Zero",
+      "stage": "Class 1",
+      "sCode": "S4.12",
+      "skills": [
+        "SK05",
+        "SK08",
+        "SK11"
+      ]
+    },
+    "L40": {
+      "levelNumber": 40,
+      "capability": "Ordinal Positions (1st-10th)",
+      "stage": "Class 1",
+      "sCode": "S4.13",
+      "skills": [
+        "SK05",
+        "SK10"
+      ]
+    },
+    "L41": {
+      "levelNumber": 41,
+      "capability": "Informal Number Line (0-20)",
+      "stage": "Class 1",
+      "sCode": "S4.14",
+      "skills": [
+        "SK09",
+        "SK10"
+      ]
+    },
+    "L42": {
+      "levelNumber": 42,
+      "capability": "Advanced Shape Composition",
+      "stage": "Class 1",
+      "sCode": "S4.15",
+      "skills": [
+        "SK12",
+        "SK19"
+      ]
+    },
+    "L43": {
+      "levelNumber": 43,
+      "capability": "Reading & Writing 3-Digit Numbers",
+      "stage": "Class 2",
+      "sCode": "S5.1",
+      "skills": [
+        "SK08",
+        "SK11"
+      ]
+    },
+    "L44": {
+      "levelNumber": 44,
+      "capability": "Tens as Bundles/Groups",
+      "stage": "Class 2",
+      "sCode": "S5.2",
+      "skills": [
+        "SK11",
+        "SK12"
+      ]
+    },
+    "L45": {
+      "levelNumber": 45,
+      "capability": "Flexible 2-Digit Decomposition",
+      "stage": "Class 2",
+      "sCode": "S5.3",
+      "skills": [
+        "SK11",
+        "SK12"
+      ]
+    },
+    "L46": {
+      "levelNumber": 46,
+      "capability": "2-Digit Addition with Regrouping",
+      "stage": "Class 2",
+      "sCode": "S5.4",
+      "skills": [
+        "SK11",
+        "SK12",
+        "SK13"
+      ]
+    },
+    "L47": {
+      "levelNumber": 47,
+      "capability": "2-Digit Subtraction with Regrouping",
+      "stage": "Class 2",
+      "sCode": "S5.5",
+      "skills": [
+        "SK11",
+        "SK12",
+        "SK14"
+      ]
+    },
+    "L48": {
+      "levelNumber": 48,
+      "capability": "Multiplication as Repeated Addition",
+      "stage": "Class 2",
+      "sCode": "S5.6",
+      "skills": [
+        "SK13",
+        "SK15",
+        "SK18"
+      ]
+    },
+    "L49": {
+      "levelNumber": 49,
+      "capability": "Division as Equal Sharing",
+      "stage": "Class 2",
+      "sCode": "S5.7",
+      "skills": [
+        "SK01",
+        "SK06",
+        "SK16"
+      ]
+    },
+    "L50": {
+      "levelNumber": 50,
+      "capability": "Multiplication Tables (2,3,4,5,10)",
+      "stage": "Class 2",
+      "sCode": "S5.8",
+      "skills": [
+        "SK15",
+        "SK18"
+      ]
+    },
+    "L51": {
+      "levelNumber": 51,
+      "capability": "Currency Recognition",
+      "stage": "Class 2",
+      "sCode": "S5.9",
+      "skills": [
+        "SK08",
+        "SK22"
+      ]
+    },
+    "L52": {
+      "levelNumber": 52,
+      "capability": "Informal Fractions (Folding)",
+      "stage": "Class 2",
+      "sCode": "S5.10",
+      "skills": [
+        "SK17",
+        "SK19"
+      ]
+    },
+    "L53": {
+      "levelNumber": 53,
+      "capability": "Uniform Non-Standard Measurement",
+      "stage": "Class 2",
+      "sCode": "S5.11",
+      "skills": [
+        "SK20",
+        "SK24"
+      ]
+    },
+    "L54": {
+      "levelNumber": 54,
+      "capability": "2D Shape Set Identification",
+      "stage": "Class 2",
+      "sCode": "S5.12",
+      "skills": [
+        "SK02",
+        "SK19"
+      ]
+    },
+    "L55": {
+      "levelNumber": 55,
+      "capability": "Spatial Vocabulary",
+      "stage": "Class 2",
+      "sCode": "S5.13",
+      "skills": [
+        "SK19",
+        "SK24"
+      ]
+    },
+    "L56": {
+      "levelNumber": 56,
+      "capability": "Calendar Reading",
+      "stage": "Class 2",
+      "sCode": "S5.14",
+      "skills": [
+        "SK10",
+        "SK21"
+      ]
+    },
+    "L57": {
+      "levelNumber": 57,
+      "capability": "Data Handling (Sorting & Tallies)",
+      "stage": "Class 2",
+      "sCode": "S5.15",
+      "skills": [
+        "SK02",
+        "SK05",
+        "SK23"
+      ]
+    },
+    "L58": {
+      "levelNumber": 58,
+      "capability": "Number Patterns & Sequences",
+      "stage": "Class 2",
+      "sCode": "S5.16",
+      "skills": [
+        "SK10",
+        "SK18"
+      ]
+    },
+    "L59": {
+      "levelNumber": 59,
+      "capability": "Zero as a Placeholder",
+      "stage": "Class 2",
+      "sCode": "S5.17",
+      "skills": [
+        "SK08",
+        "SK11"
+      ]
+    },
+    "L60": {
+      "levelNumber": 60,
+      "capability": "Extended Number Line (0-100)",
+      "stage": "Class 2",
+      "sCode": "S5.18",
+      "skills": [
+        "SK09",
+        "SK10",
+        "SK11"
+      ]
+    },
+    "L61": {
+      "levelNumber": 61,
+      "capability": "Skip Counting (2s, 5s, 10s)",
+      "stage": "Class 2",
+      "sCode": "S5.19",
+      "skills": [
+        "SK05",
+        "SK15",
+        "SK18"
+      ]
+    },
+    "L62": {
+      "levelNumber": 62,
+      "capability": "3-Digit Place Value & Expanded Form",
+      "stage": "Class 3",
+      "sCode": "S6.1",
+      "skills": [
+        "SK11",
+        "SK12"
+      ]
+    },
+    "L63": {
+      "levelNumber": 63,
+      "capability": "Flexible 3-Digit Decomposition",
+      "stage": "Class 3",
+      "sCode": "S6.2",
+      "skills": [
+        "SK11",
+        "SK12"
+      ]
+    },
+    "L64": {
+      "levelNumber": 64,
+      "capability": "3-Digit Comparison & Ordering",
+      "stage": "Class 3",
+      "sCode": "S6.3",
+      "skills": [
+        "SK03",
+        "SK09",
+        "SK11"
+      ]
+    },
+    "L65": {
+      "levelNumber": 65,
+      "capability": "Reading & Writing 4-Digit Numbers",
+      "stage": "Class 3",
+      "sCode": "S6.4",
+      "skills": [
+        "SK08",
+        "SK11"
+      ]
+    },
+    "L66": {
+      "levelNumber": 66,
+      "capability": "3-Digit Addition & Subtraction Problems",
+      "stage": "Class 3",
+      "sCode": "S6.5",
+      "skills": [
+        "SK11",
+        "SK12",
+        "SK13",
+        "SK14"
+      ]
+    },
+    "L67": {
+      "levelNumber": 67,
+      "capability": "Full Multiplication Tables (2-10)",
+      "stage": "Class 3",
+      "sCode": "S6.6",
+      "skills": [
+        "SK15",
+        "SK18"
+      ]
+    },
+    "L68": {
+      "levelNumber": 68,
+      "capability": "Division Facts & Inverse Relation",
+      "stage": "Class 3",
+      "sCode": "S6.7",
+      "skills": [
+        "SK15",
+        "SK16"
+      ]
+    },
+    "L69": {
+      "levelNumber": 69,
+      "capability": "Standard Measurement Units",
+      "stage": "Class 3",
+      "sCode": "S6.8",
+      "skills": [
+        "SK20",
+        "SK24"
+      ]
+    },
+    "L70": {
+      "levelNumber": 70,
+      "capability": "Relating 2D Faces to 3D Solids",
+      "stage": "Class 3",
+      "sCode": "S6.9",
+      "skills": [
+        "SK04",
+        "SK19"
+      ]
+    },
+    "L71": {
+      "levelNumber": 71,
+      "capability": "Telling Time (Hours & Half-Hours)",
+      "stage": "Class 3",
+      "sCode": "S6.10",
+      "skills": [
+        "SK10",
+        "SK21"
+      ]
+    },
+    "L72": {
+      "levelNumber": 72,
+      "capability": "Money Arithmetic",
+      "stage": "Class 3",
+      "sCode": "S6.11",
+      "skills": [
+        "SK13",
+        "SK14",
+        "SK22"
+      ]
+    },
+    "L73": {
+      "levelNumber": 73,
+      "capability": "Formal Fractions (Half/Quarter)",
+      "stage": "Class 3",
+      "sCode": "S6.12",
+      "skills": [
+        "SK12",
+        "SK17"
+      ]
+    },
+    "L74": {
+      "levelNumber": 74,
+      "capability": "Pattern Rules & Generalization",
+      "stage": "Class 3",
+      "sCode": "S6.13",
+      "skills": [
+        "SK18",
+        "SK24"
+      ]
+    },
+    "L75": {
+      "levelNumber": 75,
+      "capability": "Data Handling (Pictographs & Bar Graphs)",
+      "stage": "Class 3",
+      "sCode": "S6.14",
+      "skills": [
+        "SK05",
+        "SK09",
+        "SK23"
+      ]
+    },
+    "L76": {
+      "levelNumber": 76,
+      "capability": "4-Digit & 5-Digit Place Value",
+      "stage": "Class 4",
+      "sCode": "S7.1",
+      "skills": [
+        "SK11",
+        "SK12"
+      ]
+    },
+    "L77": {
+      "levelNumber": 77,
+      "capability": "Large Number Operations & Regrouping",
+      "stage": "Class 4",
+      "sCode": "S7.2",
+      "skills": [
+        "SK11",
+        "SK12",
+        "SK13",
+        "SK14"
+      ]
+    },
+    "L78": {
+      "levelNumber": 78,
+      "capability": "Complex Multi-Digit Word Problems",
+      "stage": "Class 4",
+      "sCode": "S7.3",
+      "skills": [
+        "SK11",
+        "SK12",
+        "SK13",
+        "SK14",
+        "SK24"
+      ]
+    },
+    "L79": {
+      "levelNumber": 79,
+      "capability": "Extended Multiplication",
+      "stage": "Class 4",
+      "sCode": "S7.4",
+      "skills": [
+        "SK11",
+        "SK12",
+        "SK15"
+      ]
+    },
+    "L80": {
+      "levelNumber": 80,
+      "capability": "Formal Long Division",
+      "stage": "Class 4",
+      "sCode": "S7.5",
+      "skills": [
+        "SK11",
+        "SK15",
+        "SK16"
+      ]
+    },
+    "L81": {
+      "levelNumber": 81,
+      "capability": "Fractional Notation & Equivalence",
+      "stage": "Class 4",
+      "sCode": "S7.6",
+      "skills": [
+        "SK12",
+        "SK17"
+      ]
+    },
+    "L82": {
+      "levelNumber": 82,
+      "capability": "Standard Unit Conversion",
+      "stage": "Class 4",
+      "sCode": "S7.7",
+      "skills": [
+        "SK12",
+        "SK20"
+      ]
+    },
+    "L83": {
+      "levelNumber": 83,
+      "capability": "Applied Measurement Word Problems",
+      "stage": "Class 4",
+      "sCode": "S7.8",
+      "skills": [
+        "SK13",
+        "SK14",
+        "SK20",
+        "SK24"
+      ]
+    },
+    "L84": {
+      "levelNumber": 84,
+      "capability": "3D Nets & Spatial Perspective",
+      "stage": "Class 4",
+      "sCode": "S7.9",
+      "skills": [
+        "SK12",
+        "SK19",
+        "SK24"
+      ]
+    },
+    "L85": {
+      "levelNumber": 85,
+      "capability": "Advanced Time Calculation",
+      "stage": "Class 4",
+      "sCode": "S7.10",
+      "skills": [
+        "SK13",
+        "SK14",
+        "SK21"
+      ]
+    },
+    "L86": {
+      "levelNumber": 86,
+      "capability": "Complex Money Problems",
+      "stage": "Class 4",
+      "sCode": "S7.11",
+      "skills": [
+        "SK13",
+        "SK14",
+        "SK22",
+        "SK24"
+      ]
+    },
+    "L87": {
+      "levelNumber": 87,
+      "capability": "Advanced Number Patterns",
+      "stage": "Class 4",
+      "sCode": "S7.12",
+      "skills": [
+        "SK10",
+        "SK18",
+        "SK24"
+      ]
+    },
+    "L88": {
+      "levelNumber": 88,
+      "capability": "Bar Graphs & Data Interpretation",
+      "stage": "Class 4",
+      "sCode": "S7.13",
+      "skills": [
+        "SK09",
+        "SK23",
+        "SK24"
+      ]
+    },
+    "L89": {
+      "levelNumber": 89,
+      "capability": "Factors & Multiples",
+      "stage": "Class 4",
+      "sCode": "S7.14",
+      "skills": [
+        "SK15",
+        "SK16",
+        "SK18"
+      ]
+    },
+    "L90": {
+      "levelNumber": 90,
+      "capability": "Decimals (Tenths & Hundredths)",
+      "stage": "Class 4",
+      "sCode": "S7.15",
+      "skills": [
+        "SK08",
+        "SK11",
+        "SK12",
+        "SK17"
+      ]
+    },
+    "L91": {
+      "levelNumber": 91,
+      "capability": "Angles & Turn",
+      "stage": "Class 4",
+      "sCode": "S7.16",
+      "skills": [
+        "SK10",
+        "SK19"
+      ]
+    },
+    "L92": {
+      "levelNumber": 92,
+      "capability": "Symmetry & Reflection",
+      "stage": "Class 4",
+      "sCode": "S7.17",
+      "skills": [
+        "SK18",
+        "SK19"
+      ]
+    },
+    "L93": {
+      "levelNumber": 93,
+      "capability": "Perimeter & Area",
+      "stage": "Class 4",
+      "sCode": "S7.18",
+      "skills": [
+        "SK13",
+        "SK19",
+        "SK20"
+      ]
+    }
+  },
+  "skills": {
+    "SK01": {
+      "name": "One-to-One Correspondence",
+      "domain": "Pre-number",
+      "subskills": [
+        {
+          "id": "SK01.01",
+          "name": "Match one object to one object"
+        },
+        {
+          "id": "SK01.02",
+          "name": "Match objects across two groups"
+        },
+        {
+          "id": "SK01.03",
+          "name": "Maintain one-to-one correspondence while counting"
+        },
+        {
+          "id": "SK01.04",
+          "name": "Identify unmatched objects"
+        }
+      ]
+    },
+    "SK02": {
+      "name": "Classification",
+      "domain": "Pre-number",
+      "subskills": [
+        {
+          "id": "SK02.01",
+          "name": "Classify by one property"
+        },
+        {
+          "id": "SK02.02",
+          "name": "Identify common property"
+        },
+        {
+          "id": "SK02.03",
+          "name": "Identify odd object"
+        },
+        {
+          "id": "SK02.04",
+          "name": "Classify by multiple properties"
+        },
+        {
+          "id": "SK02.05",
+          "name": "Flexible reclassification"
+        }
+      ]
+    },
+    "SK03": {
+      "name": "Seriation & Ordering",
+      "domain": "Pre-number",
+      "subskills": [
+        {
+          "id": "SK03.01",
+          "name": "Arrange three objects by size"
+        },
+        {
+          "id": "SK03.02",
+          "name": "Arrange objects by length"
+        },
+        {
+          "id": "SK03.03",
+          "name": "Use comparative relationships"
+        },
+        {
+          "id": "SK03.04",
+          "name": "Apply transitivity"
+        },
+        {
+          "id": "SK03.05",
+          "name": "Order numerals"
+        },
+        {
+          "id": "SK03.06",
+          "name": "Order numbers ascending"
+        },
+        {
+          "id": "SK03.07",
+          "name": "Order numbers descending"
+        }
+      ]
+    },
+    "SK04": {
+      "name": "Same/Different & Attribute Recognition",
+      "domain": "Pre-number",
+      "subskills": [
+        {
+          "id": "SK04.01",
+          "name": "Perceptual same/different"
+        },
+        {
+          "id": "SK04.02",
+          "name": "Identify visual attributes"
+        },
+        {
+          "id": "SK04.03",
+          "name": "Identify shape attributes"
+        },
+        {
+          "id": "SK04.04",
+          "name": "Identify object differences"
+        }
+      ]
+    },
+    "SK05": {
+      "name": "Counting & Counting Sequence",
+      "domain": "Number Sense",
+      "subskills": [
+        {
+          "id": "SK05.01",
+          "name": "Rote counting to 10"
+        },
+        {
+          "id": "SK05.02",
+          "name": "Count objects 1-3"
+        },
+        {
+          "id": "SK05.03",
+          "name": "Count to 5"
+        },
+        {
+          "id": "SK05.04",
+          "name": "Count to 10"
+        },
+        {
+          "id": "SK05.05",
+          "name": "Count to 20"
+        },
+        {
+          "id": "SK05.06",
+          "name": "Count to 50"
+        },
+        {
+          "id": "SK05.07",
+          "name": "Count to 100"
+        },
+        {
+          "id": "SK05.08",
+          "name": "Count forward from a given number"
+        },
+        {
+          "id": "SK05.09",
+          "name": "Count backward"
+        }
+      ]
+    },
+    "SK06": {
+      "name": "Cardinality",
+      "domain": "Number Sense",
+      "subskills": [
+        {
+          "id": "SK06.01",
+          "name": "Understand last number counted as total"
+        },
+        {
+          "id": "SK06.02",
+          "name": "Count small sets"
+        },
+        {
+          "id": "SK06.03",
+          "name": "Count and tell how many"
+        },
+        {
+          "id": "SK06.04",
+          "name": "Relate quantity to numeral"
+        }
+      ]
+    },
+    "SK07": {
+      "name": "Subitizing",
+      "domain": "Number Sense",
+      "subskills": [
+        {
+          "id": "SK07.01",
+          "name": "Perceptual subitizing"
+        },
+        {
+          "id": "SK07.02",
+          "name": "Recognize small quantity without counting"
+        },
+        {
+          "id": "SK07.03",
+          "name": "Conceptual subitizing"
+        },
+        {
+          "id": "SK07.04",
+          "name": "Compose quantity from subgroups"
+        }
+      ]
+    },
+    "SK08": {
+      "name": "Quantity & Numeral Representation",
+      "domain": "Number Sense",
+      "subskills": [
+        {
+          "id": "SK08.01",
+          "name": "Recognize numerals 1-10"
+        },
+        {
+          "id": "SK08.02",
+          "name": "Match numeral to quantity"
+        },
+        {
+          "id": "SK08.03",
+          "name": "Represent quantity with objects"
+        },
+        {
+          "id": "SK08.04",
+          "name": "Read numerals"
+        },
+        {
+          "id": "SK08.05",
+          "name": "Write numerals"
+        },
+        {
+          "id": "SK08.06",
+          "name": "Read/write numbers to 99"
+        },
+        {
+          "id": "SK08.07",
+          "name": "Read/write three-digit numbers"
+        },
+        {
+          "id": "SK08.08",
+          "name": "Read/write four-digit numbers"
+        }
+      ]
+    },
+    "SK09": {
+      "name": "Number Comparison",
+      "domain": "Number Sense",
+      "subskills": [
+        {
+          "id": "SK09.01",
+          "name": "Compare quantities"
+        },
+        {
+          "id": "SK09.02",
+          "name": "More/less/equal"
+        },
+        {
+          "id": "SK09.03",
+          "name": "Compare numerals using objects"
+        },
+        {
+          "id": "SK09.04",
+          "name": "Abstract numeral comparison"
+        },
+        {
+          "id": "SK09.05",
+          "name": "Compare close numbers"
+        },
+        {
+          "id": "SK09.06",
+          "name": "Compare two-digit numbers"
+        },
+        {
+          "id": "SK09.07",
+          "name": "Compare three-digit numbers"
+        }
+      ]
+    },
+    "SK10": {
+      "name": "Number Sequencing & Number Line",
+      "domain": "Number Sense",
+      "subskills": [
+        {
+          "id": "SK10.01",
+          "name": "Numeral sequencing"
+        },
+        {
+          "id": "SK10.02",
+          "name": "Before"
+        },
+        {
+          "id": "SK10.03",
+          "name": "After"
+        },
+        {
+          "id": "SK10.04",
+          "name": "Between"
+        },
+        {
+          "id": "SK10.05",
+          "name": "Missing number"
+        },
+        {
+          "id": "SK10.06",
+          "name": "Ordinal position"
+        },
+        {
+          "id": "SK10.07",
+          "name": "Informal number line 0-20"
+        },
+        {
+          "id": "SK10.08",
+          "name": "Number line 0-100"
+        }
+      ]
+    },
+    "SK11": {
+      "name": "Place Value & Base-Ten Structure",
+      "domain": "Number Sense",
+      "subskills": [
+        {
+          "id": "SK11.01",
+          "name": "Understand groups of ten"
+        },
+        {
+          "id": "SK11.02",
+          "name": "Tens and ones"
+        },
+        {
+          "id": "SK11.03",
+          "name": "Tens as bundles"
+        },
+        {
+          "id": "SK11.04",
+          "name": "Zero as placeholder"
+        },
+        {
+          "id": "SK11.05",
+          "name": "Two-digit place value"
+        },
+        {
+          "id": "SK11.06",
+          "name": "Three-digit place value"
+        },
+        {
+          "id": "SK11.07",
+          "name": "Expanded form"
+        },
+        {
+          "id": "SK11.08",
+          "name": "Four-digit place value"
+        },
+        {
+          "id": "SK11.09",
+          "name": "Five-digit place value"
+        }
+      ]
+    },
+    "SK12": {
+      "name": "Number Composition & Decomposition",
+      "domain": "Number Sense",
+      "subskills": [
+        {
+          "id": "SK12.01",
+          "name": "Compose quantities"
+        },
+        {
+          "id": "SK12.02",
+          "name": "Decompose quantities"
+        },
+        {
+          "id": "SK12.03",
+          "name": "Flexible two-digit decomposition"
+        },
+        {
+          "id": "SK12.04",
+          "name": "Flexible three-digit decomposition"
+        },
+        {
+          "id": "SK12.05",
+          "name": "Expanded form (decomposition)"
+        },
+        {
+          "id": "SK12.06",
+          "name": "Regroup quantities"
+        }
+      ]
+    },
+    "SK13": {
+      "name": "Addition",
+      "domain": "Number Operations",
+      "subskills": [
+        {
+          "id": "SK13.01",
+          "name": "Combine sets"
+        },
+        {
+          "id": "SK13.02",
+          "name": "Concrete addition"
+        },
+        {
+          "id": "SK13.03",
+          "name": "Single-digit addition"
+        },
+        {
+          "id": "SK13.04",
+          "name": "Addition within 20"
+        },
+        {
+          "id": "SK13.05",
+          "name": "Addition within 30"
+        },
+        {
+          "id": "SK13.06",
+          "name": "Two-digit addition"
+        },
+        {
+          "id": "SK13.07",
+          "name": "Addition with regrouping"
+        },
+        {
+          "id": "SK13.08",
+          "name": "Three-digit addition"
+        },
+        {
+          "id": "SK13.09",
+          "name": "Multi-digit addition"
+        },
+        {
+          "id": "SK13.10",
+          "name": "Addition word problems"
+        }
+      ]
+    },
+    "SK14": {
+      "name": "Subtraction",
+      "domain": "Number Operations",
+      "subskills": [
+        {
+          "id": "SK14.01",
+          "name": "Take away"
+        },
+        {
+          "id": "SK14.02",
+          "name": "Concrete subtraction"
+        },
+        {
+          "id": "SK14.03",
+          "name": "Single-digit subtraction"
+        },
+        {
+          "id": "SK14.04",
+          "name": "Subtraction within 20"
+        },
+        {
+          "id": "SK14.05",
+          "name": "Subtraction within 30"
+        },
+        {
+          "id": "SK14.06",
+          "name": "Two-digit subtraction"
+        },
+        {
+          "id": "SK14.07",
+          "name": "Subtraction with regrouping"
+        },
+        {
+          "id": "SK14.08",
+          "name": "Three-digit subtraction"
+        },
+        {
+          "id": "SK14.09",
+          "name": "Multi-digit subtraction"
+        },
+        {
+          "id": "SK14.10",
+          "name": "Subtraction word problems"
+        }
+      ]
+    },
+    "SK15": {
+      "name": "Multiplication",
+      "domain": "Number Operations",
+      "subskills": [
+        {
+          "id": "SK15.01",
+          "name": "Equal groups"
+        },
+        {
+          "id": "SK15.02",
+          "name": "Repeated addition"
+        },
+        {
+          "id": "SK15.03",
+          "name": "Skip-count connection"
+        },
+        {
+          "id": "SK15.04",
+          "name": "Multiplication facts 2,3,4,5,10"
+        },
+        {
+          "id": "SK15.05",
+          "name": "Tables 2-10"
+        },
+        {
+          "id": "SK15.06",
+          "name": "Multi-digit multiplication"
+        },
+        {
+          "id": "SK15.07",
+          "name": "Multiplication word problems"
+        }
+      ]
+    },
+    "SK16": {
+      "name": "Division",
+      "domain": "Number Operations",
+      "subskills": [
+        {
+          "id": "SK16.01",
+          "name": "Equal sharing"
+        },
+        {
+          "id": "SK16.02",
+          "name": "Equal grouping"
+        },
+        {
+          "id": "SK16.03",
+          "name": "Division facts"
+        },
+        {
+          "id": "SK16.04",
+          "name": "Relation to multiplication"
+        },
+        {
+          "id": "SK16.05",
+          "name": "Division procedures"
+        },
+        {
+          "id": "SK16.06",
+          "name": "Long division"
+        },
+        {
+          "id": "SK16.07",
+          "name": "Division word problems"
+        }
+      ]
+    },
+    "SK17": {
+      "name": "Fractions",
+      "domain": "Fractions",
+      "subskills": [
+        {
+          "id": "SK17.01",
+          "name": "Equal parts"
+        },
+        {
+          "id": "SK17.02",
+          "name": "Half"
+        },
+        {
+          "id": "SK17.03",
+          "name": "Quarter"
+        },
+        {
+          "id": "SK17.04",
+          "name": "Fraction notation"
+        },
+        {
+          "id": "SK17.05",
+          "name": "Equivalent fractions"
+        }
+      ]
+    },
+    "SK18": {
+      "name": "Patterns & Generalization",
+      "domain": "Patterns",
+      "subskills": [
+        {
+          "id": "SK18.01",
+          "name": "Identify repeating pattern"
+        },
+        {
+          "id": "SK18.02",
+          "name": "Extend pattern"
+        },
+        {
+          "id": "SK18.03",
+          "name": "Copy pattern"
+        },
+        {
+          "id": "SK18.04",
+          "name": "Two-item pattern"
+        },
+        {
+          "id": "SK18.05",
+          "name": "Three-item pattern"
+        },
+        {
+          "id": "SK18.06",
+          "name": "Number pattern"
+        },
+        {
+          "id": "SK18.07",
+          "name": "Skip-count pattern"
+        },
+        {
+          "id": "SK18.08",
+          "name": "Identify pattern rule"
+        },
+        {
+          "id": "SK18.09",
+          "name": "Generalize pattern"
+        },
+        {
+          "id": "SK18.10",
+          "name": "Advanced number pattern"
+        }
+      ]
+    },
+    "SK19": {
+      "name": "Shapes & Spatial Reasoning",
+      "domain": "Shapes & Spatial",
+      "subskills": [
+        {
+          "id": "SK19.01",
+          "name": "Shape matching"
+        },
+        {
+          "id": "SK19.02",
+          "name": "Identify basic shapes"
+        },
+        {
+          "id": "SK19.03",
+          "name": "Identify shape properties"
+        },
+        {
+          "id": "SK19.04",
+          "name": "Compose shapes"
+        },
+        {
+          "id": "SK19.05",
+          "name": "Decompose shapes"
+        },
+        {
+          "id": "SK19.06",
+          "name": "Identify 2D shapes"
+        },
+        {
+          "id": "SK19.07",
+          "name": "Identify 3D shapes"
+        },
+        {
+          "id": "SK19.08",
+          "name": "Spatial vocabulary"
+        },
+        {
+          "id": "SK19.09",
+          "name": "Relate 2D faces to 3D solids"
+        },
+        {
+          "id": "SK19.10",
+          "name": "Nets"
+        },
+        {
+          "id": "SK19.11",
+          "name": "Perspective"
+        },
+        {
+          "id": "SK19.12",
+          "name": "Angles and turns"
+        },
+        {
+          "id": "SK19.13",
+          "name": "Symmetry"
+        },
+        {
+          "id": "SK19.14",
+          "name": "Reflection"
+        }
+      ]
+    },
+    "SK20": {
+      "name": "Measurement",
+      "domain": "Measurement",
+      "subskills": [
+        {
+          "id": "SK20.01",
+          "name": "Compare length"
+        },
+        {
+          "id": "SK20.02",
+          "name": "Compare size"
+        },
+        {
+          "id": "SK20.03",
+          "name": "Compare capacity"
+        },
+        {
+          "id": "SK20.04",
+          "name": "Estimate length"
+        },
+        {
+          "id": "SK20.05",
+          "name": "Estimate capacity"
+        },
+        {
+          "id": "SK20.06",
+          "name": "Use non-standard units"
+        },
+        {
+          "id": "SK20.07",
+          "name": "Use uniform units"
+        },
+        {
+          "id": "SK20.08",
+          "name": "Standard measurement units"
+        },
+        {
+          "id": "SK20.09",
+          "name": "Unit conversion"
+        },
+        {
+          "id": "SK20.10",
+          "name": "Applied measurement"
+        },
+        {
+          "id": "SK20.11",
+          "name": "Perimeter"
+        },
+        {
+          "id": "SK20.12",
+          "name": "Area"
+        }
+      ]
+    },
+    "SK21": {
+      "name": "Time & Calendar",
+      "domain": "Calendar & Time",
+      "subskills": [
+        {
+          "id": "SK21.01",
+          "name": "Day/night concepts"
+        },
+        {
+          "id": "SK21.02",
+          "name": "Calendar structure"
+        },
+        {
+          "id": "SK21.03",
+          "name": "Days/weeks/months"
+        },
+        {
+          "id": "SK21.04",
+          "name": "Read calendar"
+        },
+        {
+          "id": "SK21.05",
+          "name": "Tell time to hour"
+        },
+        {
+          "id": "SK21.06",
+          "name": "Tell time to half-hour"
+        },
+        {
+          "id": "SK21.07",
+          "name": "Calculate elapsed time"
+        },
+        {
+          "id": "SK21.08",
+          "name": "Advanced time problems"
+        }
+      ]
+    },
+    "SK22": {
+      "name": "Money",
+      "domain": "Money",
+      "subskills": [
+        {
+          "id": "SK22.01",
+          "name": "Recognize currency"
+        },
+        {
+          "id": "SK22.02",
+          "name": "Match currency to value"
+        },
+        {
+          "id": "SK22.03",
+          "name": "Combine amounts"
+        },
+        {
+          "id": "SK22.04",
+          "name": "Calculate total cost"
+        },
+        {
+          "id": "SK22.05",
+          "name": "Calculate change"
+        },
+        {
+          "id": "SK22.06",
+          "name": "Multi-step money problems"
+        }
+      ]
+    },
+    "SK23": {
+      "name": "Data Handling",
+      "domain": "Data",
+      "subskills": [
+        {
+          "id": "SK23.01",
+          "name": "Sort data"
+        },
+        {
+          "id": "SK23.02",
+          "name": "Classify data"
+        },
+        {
+          "id": "SK23.03",
+          "name": "Tally"
+        },
+        {
+          "id": "SK23.04",
+          "name": "Count categories"
+        },
+        {
+          "id": "SK23.05",
+          "name": "Read pictograph"
+        },
+        {
+          "id": "SK23.06",
+          "name": "Read bar graph"
+        },
+        {
+          "id": "SK23.07",
+          "name": "Compare data"
+        },
+        {
+          "id": "SK23.08",
+          "name": "Interpret data"
+        }
+      ]
+    },
+    "SK24": {
+      "name": "Mathematical Reasoning & Problem Solving",
+      "domain": "Cross-cutting",
+      "subskills": [
+        {
+          "id": "SK24.01",
+          "name": "Identify relevant information"
+        },
+        {
+          "id": "SK24.02",
+          "name": "Choose an operation"
+        },
+        {
+          "id": "SK24.03",
+          "name": "Represent a problem"
+        },
+        {
+          "id": "SK24.04",
+          "name": "Explain reasoning"
+        },
+        {
+          "id": "SK24.05",
+          "name": "Check an answer"
+        },
+        {
+          "id": "SK24.06",
+          "name": "Apply mathematics to daily life"
+        },
+        {
+          "id": "SK24.07",
+          "name": "Solve multi-step problems"
+        }
+      ]
+    }
+  }
+}

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -577,6 +577,46 @@ export interface MisconceptionCluster {
   updatedAt: string;
 }
 
+/**
+ * A Superadmin-authored instruction describing *what to ask* at a given level —
+ * not a question itself. One logic is the prompt the question-generation
+ * pipeline turns into many concrete `Question` rows across many worksheets.
+ *
+ * Deliberately a separate collection from `questions`: these have different
+ * authors (human vs. generator), different consumers (generation pipeline vs.
+ * renderer and ICR scanner), and different lifecycles (editable in place vs.
+ * immutable once a child has answered them). Folding them together would make
+ * one collection carry two incompatible lifecycles.
+ */
+export interface QuestionLogic {
+  id: string;
+  /** 1..LEVEL_COUNT, L-notation. Mutable — a logic filed under the wrong level can be re-tagged. */
+  level: number;
+  /** Denormalized for display so the list view needs no join. */
+  levelName: string;
+  /** At least one. Validated server-side against the level's primary+supporting skills. */
+  skills: string[];
+  /** Optional. Empty means "assess the skill at full granularity", which is a valid choice. */
+  subskills: string[];
+  logicText: string;
+  /**
+   * Which relationship taxonomy was in force when this was authored.
+   * The project is moving from the code's 4-type model to the research's
+   * 3-type model; pinning it per-document means both can coexist through the
+   * migration instead of forcing a schema break.
+   */
+  taxonomy: '3-type' | '4-type';
+  createdBy: string;
+  createdByEmail: string;
+  createdAt: string;
+  updatedAt: string;
+  updatedBy: string;
+  updatedByEmail: string;
+  /** Soft delete: the generation pipeline may already hold this id, so the row stays for audit. */
+  deletedAt: string | null;
+  deletedBy: string | null;
+}
+
 interface DatabaseSchema {
   users: User[];
   schools: School[];
@@ -597,6 +637,7 @@ interface DatabaseSchema {
   diagnosticAnswerKeys: DiagnosticAnswerKey[];
   misconceptionClusters: MisconceptionCluster[];
   testHistory: TestHistoryEntry[];
+  questionLogics: QuestionLogic[];
 }
 
 const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
@@ -619,6 +660,7 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   diagnosticAnswerKeys: 'diagnostic_answer_keys',
   misconceptionClusters: 'misconception_clusters',
   testHistory: 'testHistory',
+  questionLogics: 'questionLogics',
 };
 
   /**
@@ -1677,6 +1719,49 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
       if (idx !== -1) this.data.bestPractices[idx] = bp;
     }
     return bp || undefined;
+  }
+
+  // --- Question Logic Methods ---
+
+  /** Live logics only unless `includeDeleted`, since soft-deleted rows exist purely for audit. */
+  async getQuestionLogics(includeDeleted = false) {
+    const filter = includeDeleted ? {} : { deletedAt: null };
+    return await this.mongoDb!.collection<QuestionLogic>('questionLogics')
+      .find(filter).sort({ createdAt: -1 }).toArray();
+  }
+
+  async getQuestionLogicById(id: string) {
+    return (await this.mongoDb!.collection<QuestionLogic>('questionLogics').findOne({ id })) || undefined;
+  }
+
+  async addQuestionLogic(logic: QuestionLogic) {
+    await this.mongoDb!.collection('questionLogics').insertOne(logic);
+    if (this.data) this.data.questionLogics.push(logic);
+    return logic;
+  }
+
+  async updateQuestionLogic(id: string, updates: Partial<QuestionLogic>) {
+    await this.mongoDb!.collection('questionLogics').updateOne({ id }, { $set: updates });
+    const l = await this.mongoDb!.collection<QuestionLogic>('questionLogics').findOne({ id });
+    if (l && this.data) {
+      const idx = this.data.questionLogics.findIndex(x => x.id === id);
+      if (idx !== -1) this.data.questionLogics[idx] = l;
+    }
+    return l || undefined;
+  }
+
+  /**
+   * Counts for the header cards. `levelsWithLogic` is a distinct count over live
+   * rows — authoring five logics for one level still covers exactly one level.
+   */
+  async getQuestionLogicStats(totalLevels: number) {
+    const live = await this.mongoDb!.collection<QuestionLogic>('questionLogics')
+      .find({ deletedAt: null }).toArray();
+    return {
+      totalLogics: live.length,
+      totalLevels,
+      levelsWithLogic: new Set(live.map(l => l.level)).size,
+    };
   }
 
   // --- Diagnostic Answer Key Methods ---
@@ -3596,7 +3681,11 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
       bestPractices,
       diagnosticAnswerKeys: [],
       misconceptionClusters: [],
-      testHistory: []
+      testHistory: [],
+      // Seeded empty on purpose: question logics are pedagogy authored by a real
+      // Superadmin, and inventing demo ones would put fabricated curriculum
+      // intent in front of the question-generation pipeline.
+      questionLogics: []
     };
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -36,6 +36,7 @@ import { registerStudentRoutes } from './routes/students';
 import { registerWorksheetRoutes } from './routes/worksheets';
 import { registerEvaluationRoutes } from './routes/evaluation';
 import { registerAnalyticsRoutes } from './routes/analytics';
+import { registerQuestionLogicRoutes } from './routes/questionLogics';
 import { registerDiagnosticBulkRoutes } from './routes/diagnosticBulk';
 import { registerMisconceptionRoutes } from './routes/misconceptions';
 import { randomUUID } from 'crypto';
@@ -127,6 +128,7 @@ registerStatsRoutes(app);
   registerEvaluationRoutes(app);
   registerWorksheetRoutes(app);
   registerAnalyticsRoutes(app);
+  registerQuestionLogicRoutes(app);
   registerDiagnosticBulkRoutes(app);
 
   // Read-only analysis over already-graded submissions: clusters a cohort on

--- a/backend/src/routes/questionLogics.ts
+++ b/backend/src/routes/questionLogics.ts
@@ -1,0 +1,232 @@
+import express from 'express';
+import { randomUUID } from 'crypto';
+import { dbStore, UserRole, QuestionLogic } from '../db';
+import { getAuthUser } from '../auth';
+import {
+  LEVEL_COUNT,
+  getLevel,
+  isSkillMappedToLevel,
+  isSubskillUnderSkills,
+  buildLevelMapPayload,
+} from '../config/skillLevelMap';
+
+const MAX_LOGIC_CHARS = 2000;
+/** Window for the accidental-double-click guard. Not a uniqueness constraint on pedagogy. */
+const DUPLICATE_WINDOW_MS = 60_000;
+
+/**
+ * Every route here is Superadmin-only. Authoring question logic is a curriculum
+ * decision, and the 7-role hierarchy has no curriculum-author role — widening
+ * this later is a one-line change here.
+ */
+function requireSuperadmin(req: express.Request, res: express.Response) {
+  const user = getAuthUser(req);
+  if (!user || user.role !== UserRole.SUPERADMIN) {
+    res.status(403).json({ error: 'Only superadmins can manage question logics.' });
+    return null;
+  }
+  return user;
+}
+
+/**
+ * Server-side validation of a (level, skills, subskills, text) combination.
+ *
+ * The client's cascading dropdowns make invalid combinations hard to *pick*,
+ * but they cannot make them impossible to *send*. A logic filed against a level
+ * that cannot host its skills would flow straight into the question-generation
+ * pipeline and produce questions that assess something the level never claimed
+ * to teach, so this check is the real guard.
+ *
+ * Returns an error string, or null when the combination is valid.
+ */
+function validateCombination(
+  level: number,
+  skills: string[],
+  subskills: string[],
+  logicText: string
+): string | null {
+  if (!Number.isInteger(level) || level < 1 || level > LEVEL_COUNT) {
+    return `level must be an integer in [1, ${LEVEL_COUNT}].`;
+  }
+  const levelInfo = getLevel(level);
+  if (!levelInfo) return `Level L${level} is not present in the curriculum map.`;
+
+  // Defensive: every level in the map should carry at least one skill. If one
+  // does not, say so plainly rather than letting the "skill not mapped" error
+  // below imply the author picked wrongly.
+  if (levelInfo.skills.length === 0) {
+    return `Level L${level} has no skills mapped to it, so no logic can be authored for it.`;
+  }
+
+  if (!Array.isArray(skills) || skills.length === 0) {
+    return 'At least one skill is required.';
+  }
+  for (const sk of skills) {
+    if (!isSkillMappedToLevel(sk, level)) {
+      return `Skill ${sk} is not mapped to L${level}.`;
+    }
+  }
+
+  if (!Array.isArray(subskills)) return 'subskills must be an array.';
+  for (const ss of subskills) {
+    if (!isSubskillUnderSkills(ss, skills)) {
+      return `Sub-skill ${ss} is not under any of the selected skills.`;
+    }
+  }
+
+  const text = (logicText ?? '').trim();
+  if (text.length === 0) return 'Question logic text is required.';
+  if (text.length > MAX_LOGIC_CHARS) {
+    return `Question logic must be ${MAX_LOGIC_CHARS} characters or fewer.`;
+  }
+
+  return null;
+}
+
+export function registerQuestionLogicRoutes(app: express.Express) {
+  /** Everything the authoring form needs to drive its dropdowns, in one call. */
+  app.get('/api/question-logics/level-map', async (req, res) => {
+    if (!requireSuperadmin(req, res)) return;
+    res.json(buildLevelMapPayload());
+  });
+
+  app.get('/api/question-logics/stats', async (req, res) => {
+    if (!requireSuperadmin(req, res)) return;
+    res.json(await dbStore.getQuestionLogicStats(LEVEL_COUNT));
+  });
+
+  app.get('/api/question-logics', async (req, res) => {
+    if (!requireSuperadmin(req, res)) return;
+
+    const includeDeleted = req.query.includeDeleted === 'true';
+    let logics = await dbStore.getQuestionLogics(includeDeleted);
+
+    const levelParam = req.query.level;
+    if (levelParam !== undefined) {
+      const level = Number(levelParam);
+      if (!Number.isInteger(level)) {
+        return res.status(400).json({ error: 'level filter must be an integer.' });
+      }
+      logics = logics.filter(l => l.level === level);
+    }
+
+    const skill = req.query.skill as string | undefined;
+    if (skill) logics = logics.filter(l => l.skills.includes(skill));
+
+    const subskill = req.query.subskill as string | undefined;
+    if (subskill) logics = logics.filter(l => l.subskills.includes(subskill));
+
+    res.json(logics);
+  });
+
+  app.post('/api/question-logics', async (req, res) => {
+    const user = requireSuperadmin(req, res);
+    if (!user) return;
+
+    const level = Number(req.body?.level);
+    const skills: string[] = req.body?.skills ?? [];
+    const subskills: string[] = req.body?.subskills ?? [];
+    const logicText: string = req.body?.logicText ?? '';
+
+    const problem = validateCombination(level, skills, subskills, logicText);
+    if (problem) return res.status(400).json({ error: problem });
+
+    const text = logicText.trim();
+
+    // Double-click guard: same author, same level, same text, within a minute.
+    // Deliberately not a unique index — two Superadmins may legitimately author
+    // near-identical logic for different reasons, and pedagogy should not be
+    // constrained by a database constraint.
+    const existing = await dbStore.getQuestionLogics(false);
+    const cutoff = Date.now() - DUPLICATE_WINDOW_MS;
+    const dupe = existing.find(l =>
+      l.createdBy === user.id &&
+      l.level === level &&
+      l.logicText.trim().toLowerCase() === text.toLowerCase() &&
+      new Date(l.createdAt).getTime() > cutoff
+    );
+    if (dupe) {
+      return res.status(409).json({ error: 'An identical logic was just saved for this level.', id: dupe.id });
+    }
+
+    const now = new Date().toISOString();
+    const logic: QuestionLogic = {
+      id: 'qlogic_' + randomUUID().slice(0, 8),
+      level,
+      levelName: getLevel(level)!.capability,
+      skills,
+      subskills,
+      logicText: text,
+      taxonomy: '3-type',
+      createdBy: user.id,
+      createdByEmail: user.email,
+      createdAt: now,
+      updatedAt: now,
+      updatedBy: user.id,
+      updatedByEmail: user.email,
+      deletedAt: null,
+      deletedBy: null,
+    };
+
+    await dbStore.addQuestionLogic(logic);
+    res.status(201).json(logic);
+  });
+
+  app.patch('/api/question-logics/:id', async (req, res) => {
+    const user = requireSuperadmin(req, res);
+    if (!user) return;
+
+    const current = await dbStore.getQuestionLogicById(req.params.id);
+    if (!current) return res.status(404).json({ error: 'Question logic not found.' });
+    if (current.deletedAt) return res.status(400).json({ error: 'Cannot edit a deleted logic.' });
+
+    // Fall back to the stored value for anything the caller did not send, so a
+    // partial PATCH is still validated as a whole document. This is what makes
+    // "change only the level" fail loudly when the existing skills cannot live
+    // at the new level, instead of silently shipping a mismatched pair.
+    const level = req.body?.level !== undefined ? Number(req.body.level) : current.level;
+    const skills: string[] = req.body?.skills ?? current.skills;
+    const subskills: string[] = req.body?.subskills ?? current.subskills;
+    const logicText: string = req.body?.logicText ?? current.logicText;
+
+    const problem = validateCombination(level, skills, subskills, logicText);
+    if (problem) {
+      // Make the level-only case actionable rather than just rejected.
+      if (req.body?.level !== undefined && req.body?.skills === undefined && problem.includes('not mapped')) {
+        return res.status(400).json({
+          error: `Existing skills [${current.skills.join(', ')}] are not all mapped to the new level L${level}. Update skills in the same request.`,
+        });
+      }
+      return res.status(400).json({ error: problem });
+    }
+
+    const updates: Partial<QuestionLogic> = {
+      level,
+      levelName: getLevel(level)!.capability,
+      skills,
+      subskills,
+      logicText: logicText.trim(),
+      updatedAt: new Date().toISOString(),
+      updatedBy: user.id,
+      updatedByEmail: user.email,
+    };
+
+    const updated = await dbStore.updateQuestionLogic(req.params.id, updates);
+    res.json(updated);
+  });
+
+  app.delete('/api/question-logics/:id', async (req, res) => {
+    const user = requireSuperadmin(req, res);
+    if (!user) return;
+
+    const current = await dbStore.getQuestionLogicById(req.params.id);
+    if (!current) return res.status(404).json({ error: 'Question logic not found.' });
+    if (current.deletedAt) return res.json({ ok: true });
+
+    await dbStore.updateQuestionLogic(req.params.id, {
+      deletedAt: new Date().toISOString(),
+      deletedBy: user.id,
+    });
+    res.json({ ok: true });
+  });
+}

--- a/frontend/src/components/dashboards/SuperadminDashboard.tsx
+++ b/frontend/src/components/dashboards/SuperadminDashboard.tsx
@@ -9,12 +9,13 @@ import { UserCheck, CheckCircle2, XCircle } from 'lucide-react';
 import { Table, Column } from '../Table';
 import { SuperAdminExecutiveDashboard } from '../SuperAdminExecutiveDashboard';
 import { RegionalAnalyticsView } from './RegionalAnalyticsView';
+import { QuestionInterventionPanel } from '../panels/QuestionInterventionPanel';
 
 export type { DashboardProps };
 
 
 export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
-  const [activeTab, setActiveTab] = useState<'overview' | 'coordinators' | 'analytics'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'coordinators' | 'analytics' | 'intervention'>('overview');
   
   // Overview data
   const [schools, setSchools] = useState<School[]>([]);
@@ -291,6 +292,14 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
             }`}
           >
             📊 Geographical Analytics
+          </button>
+          <button
+            onClick={() => setActiveTab('intervention')}
+            className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition-all ${
+              activeTab === 'intervention' ? 'bg-white dark:bg-zinc-700 text-zinc-900 dark:text-white shadow-sm' : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white'
+            }`}
+          >
+            ❓ Question Intervention
           </button>
         </div>
 
@@ -659,6 +668,10 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
 
       {activeTab === 'analytics' && (
         <RegionalAnalyticsView token={token} user={user} />
+      )}
+
+      {activeTab === 'intervention' && (
+        <QuestionInterventionPanel />
       )}
     </div>
   );

--- a/frontend/src/components/panels/QuestionInterventionPanel.tsx
+++ b/frontend/src/components/panels/QuestionInterventionPanel.tsx
@@ -1,0 +1,460 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { FileQuestion, Layers, CheckCircle2, Info, Pencil, Trash2, X } from 'lucide-react';
+import { apiFetch } from '../../services/apiClient';
+import type { QuestionLogic, QuestionLogicStats, LevelMapPayload } from '../../types';
+
+const MAX_LOGIC_CHARS = 2000;
+
+/**
+ * Superadmin authoring surface for "question logic" — the pedagogical
+ * instruction the question-generation pipeline turns into concrete questions.
+ *
+ * This panel stores intent; it does not generate, preview, or grade anything.
+ * The level/skill/sub-skill dropdowns cascade for convenience, but every
+ * combination is re-validated server-side before it is saved.
+ */
+export const QuestionInterventionPanel: React.FC = () => {
+  const [levelMap, setLevelMap] = useState<LevelMapPayload | null>(null);
+  const [logics, setLogics] = useState<QuestionLogic[]>([]);
+  const [stats, setStats] = useState<QuestionLogicStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Form state
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [level, setLevel] = useState<number | ''>('');
+  const [skills, setSkills] = useState<string[]>([]);
+  const [subskills, setSubskills] = useState<string[]>([]);
+  const [logicText, setLogicText] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  // Filters on the list
+  const [filterLevel, setFilterLevel] = useState<number | ''>('');
+  const [filterSkill, setFilterSkill] = useState('');
+
+  const loadAll = async () => {
+    try {
+      const [mapRes, listRes, statsRes] = await Promise.all([
+        apiFetch('/api/question-logics/level-map'),
+        apiFetch('/api/question-logics'),
+        apiFetch('/api/question-logics/stats'),
+      ]);
+      if (!mapRes.ok || !listRes.ok || !statsRes.ok) {
+        setLoadError('Could not load question logics. You may not have superadmin access.');
+        return;
+      }
+      setLevelMap(await mapRes.json());
+      setLogics(await listRes.json());
+      setStats(await statsRes.json());
+      setLoadError(null);
+    } catch {
+      setLoadError('Could not reach the server.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { loadAll(); }, []);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const selectedLevel = useMemo(
+    () => (level === '' ? undefined : levelMap?.levels.find(l => l.levelNumber === level)),
+    [level, levelMap]
+  );
+
+  /** Only skills the chosen level actually maps to are offered. */
+  const availableSkills = useMemo(() => {
+    if (!selectedLevel || !levelMap) return [];
+    return levelMap.skills.filter(s => selectedLevel.skills.includes(s.id));
+  }, [selectedLevel, levelMap]);
+
+  /** Sub-skills are the union across every selected skill. */
+  const availableSubskills = useMemo(() => {
+    if (!levelMap) return [];
+    return levelMap.skills
+      .filter(s => skills.includes(s.id))
+      .flatMap(s => s.subskills);
+  }, [skills, levelMap]);
+
+  /**
+   * Changing the level re-filters the skill list, so any selection that is no
+   * longer valid has to be dropped — otherwise the form would show a skill the
+   * new level cannot host and the save would fail server-side with a confusing
+   * error. Same for sub-skills whose parent skill is gone.
+   */
+  const onLevelChange = (next: number | '') => {
+    setLevel(next);
+    setFormError(null);
+    if (next === '' || !levelMap) { setSkills([]); setSubskills([]); return; }
+    const lvl = levelMap.levels.find(l => l.levelNumber === next);
+    const stillValidSkills = skills.filter(s => lvl?.skills.includes(s));
+    setSkills(stillValidSkills);
+    setSubskills(prev => prev.filter(ss => stillValidSkills.includes(ss.split('.')[0])));
+  };
+
+  const toggleSkill = (skillId: string) => {
+    setFormError(null);
+    setSkills(prev => {
+      const next = prev.includes(skillId) ? prev.filter(s => s !== skillId) : [...prev, skillId];
+      // Deselecting a skill orphans its sub-skills; drop them rather than
+      // silently sending sub-skills the server will reject.
+      setSubskills(cur => cur.filter(ss => next.includes(ss.split('.')[0])));
+      return next;
+    });
+  };
+
+  const toggleSubskill = (id: string) => {
+    setFormError(null);
+    setSubskills(prev => (prev.includes(id) ? prev.filter(s => s !== id) : [...prev, id]));
+  };
+
+  const resetForm = () => {
+    setEditingId(null);
+    setLevel('');
+    setSkills([]);
+    setSubskills([]);
+    setLogicText('');
+    setFormError(null);
+  };
+
+  const startEdit = (l: QuestionLogic) => {
+    setEditingId(l.id);
+    setLevel(l.level);
+    setSkills(l.skills);
+    setSubskills(l.subskills);
+    setLogicText(l.logicText);
+    setFormError(null);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const save = async () => {
+    setFormError(null);
+    if (level === '') return setFormError('Pick a level.');
+    if (skills.length === 0) return setFormError('Pick at least one skill.');
+    if (!logicText.trim()) return setFormError('Write the question logic.');
+
+    setSaving(true);
+    try {
+      const body = { level, skills, subskills, logicText: logicText.trim() };
+      const res = editingId
+        ? await apiFetch(`/api/question-logics/${editingId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          })
+        : await apiFetch('/api/question-logics', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        setFormError(err.error || 'Save failed.');
+        return;
+      }
+
+      await loadAll();
+      const wasEditing = Boolean(editingId);
+      resetForm();
+      // Read the fresh count from the reload rather than guessing it.
+      const s = await (await apiFetch('/api/question-logics/stats')).json();
+      setToast(wasEditing
+        ? 'Updated.'
+        : `Saved. ${s.levelsWithLogic} / ${s.totalLevels} levels now have at least one logic.`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (l: QuestionLogic) => {
+    if (!window.confirm('Delete this question logic? It will no longer be used for question generation.')) return;
+    const res = await apiFetch(`/api/question-logics/${l.id}`, { method: 'DELETE' });
+    if (!res.ok) { setToast('Delete failed.'); return; }
+    if (editingId === l.id) resetForm();
+    await loadAll();
+    setToast('Deleted.');
+  };
+
+  const visibleLogics = useMemo(() => logics.filter(l =>
+    (filterLevel === '' || l.level === filterLevel) &&
+    (filterSkill === '' || l.skills.includes(filterSkill))
+  ), [logics, filterLevel, filterSkill]);
+
+  if (loading) {
+    return <div className="p-6 text-zinc-500 dark:text-zinc-400">Loading question logics…</div>;
+  }
+
+  if (loadError) {
+    return (
+      <div className="p-6">
+        <div className="rounded-lg border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4 text-red-800 dark:text-red-300">
+          {loadError}
+        </div>
+      </div>
+    );
+  }
+
+  const cardCls = 'rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 p-4';
+  const labelCls = 'text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400';
+
+  return (
+    <div className="space-y-6">
+      {/* Header counters */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className={cardCls}>
+          <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400"><FileQuestion size={16} /><span className={labelCls}>Total question logics</span></div>
+          <div className="mt-2 text-3xl font-bold text-zinc-900 dark:text-white tabular-nums">{stats?.totalLogics ?? 0}</div>
+        </div>
+        <div className={cardCls}>
+          <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400"><Layers size={16} /><span className={labelCls}>Total levels</span></div>
+          <div className="mt-2 text-3xl font-bold text-zinc-900 dark:text-white tabular-nums">{stats?.totalLevels ?? 0}</div>
+        </div>
+        <div className={cardCls}>
+          <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400"><CheckCircle2 size={16} /><span className={labelCls}>Levels with a logic</span></div>
+          <div className="mt-2 text-3xl font-bold text-zinc-900 dark:text-white tabular-nums">
+            {stats?.levelsWithLogic ?? 0}
+            <span className="text-lg font-normal text-zinc-400 dark:text-zinc-500"> / {stats?.totalLevels ?? 0}</span>
+          </div>
+        </div>
+        <div className={cardCls}>
+          <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400"><Info size={16} /><span className={labelCls}>Taxonomy</span></div>
+          <div className="mt-2 text-sm text-zinc-700 dark:text-zinc-300">Based on the 3-type FLN framework (prereq / sequence / parallel).</div>
+        </div>
+      </div>
+
+      {toast && (
+        <div className="rounded-lg border border-emerald-300 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 px-4 py-3 text-sm text-emerald-800 dark:text-emerald-300">
+          {toast}
+        </div>
+      )}
+
+      {/* Authoring form */}
+      <div className={cardCls}>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">
+            {editingId ? 'Edit question logic' : 'New question logic'}
+          </h3>
+          {editingId && (
+            <button onClick={resetForm} className="flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200">
+              <X size={14} /> Cancel edit
+            </button>
+          )}
+        </div>
+
+        <div className="space-y-5">
+          {/* Step 1 — level */}
+          <div>
+            <label htmlFor="ql-level" className={labelCls}>Step 1 — Level (required)</label>
+            <select
+              id="ql-level"
+              value={level}
+              onChange={e => onLevelChange(e.target.value === '' ? '' : Number(e.target.value))}
+              className="mt-1 w-full rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-white"
+            >
+              <option value="">Select a level…</option>
+              {levelMap?.levels.map(l => (
+                <option key={l.levelId} value={l.levelNumber}>
+                  {l.stage} · {l.levelId} — {l.capability}
+                </option>
+              ))}
+            </select>
+            {selectedLevel && (
+              <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                {selectedLevel.stage} · {selectedLevel.sCode} · {selectedLevel.skills.length} skill(s) mapped
+              </p>
+            )}
+          </div>
+
+          {/* Step 2 — skills */}
+          <div>
+            <label className={labelCls}>Step 2 — Skills (required, multi-select)</label>
+            {!selectedLevel ? (
+              <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-500">Pick a level first.</p>
+            ) : availableSkills.length === 0 ? (
+              <p className="mt-1 text-sm text-amber-700 dark:text-amber-400">
+                {selectedLevel.levelId} has no skills mapped to it. A logic cannot be authored for this level.
+              </p>
+            ) : (
+              <div className="mt-1 flex flex-wrap gap-2">
+                {availableSkills.map(s => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    onClick={() => toggleSkill(s.id)}
+                    aria-pressed={skills.includes(s.id)}
+                    className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
+                      skills.includes(s.id)
+                        ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200'
+                        : 'border-zinc-300 dark:border-zinc-600 text-zinc-700 dark:text-zinc-300 hover:border-zinc-400'
+                    }`}
+                  >
+                    {s.id} — {s.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Step 3 — sub-skills */}
+          <div>
+            <label className={labelCls}>Step 3 — Sub-skills (optional)</label>
+            {skills.length === 0 ? (
+              <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-500">Pick at least one skill first.</p>
+            ) : availableSubskills.length === 0 ? (
+              <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">These skills have no observable sub-skills.</p>
+            ) : (
+              <>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {availableSubskills.map(ss => (
+                    <button
+                      key={ss.id}
+                      type="button"
+                      onClick={() => toggleSubskill(ss.id)}
+                      aria-pressed={subskills.includes(ss.id)}
+                      className={`rounded-md border px-2.5 py-1 text-xs transition-colors ${
+                        subskills.includes(ss.id)
+                          ? 'border-teal-500 bg-teal-50 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200'
+                          : 'border-zinc-300 dark:border-zinc-600 text-zinc-600 dark:text-zinc-400 hover:border-zinc-400'
+                      }`}
+                    >
+                      {ss.id} · {ss.name}
+                    </button>
+                  ))}
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  {subskills.length} selected. Leaving this empty assesses the skill at full granularity.
+                </p>
+              </>
+            )}
+          </div>
+
+          {/* Step 4 — the logic */}
+          <div>
+            <label htmlFor="ql-text" className={labelCls}>Step 4 — Question logic (required)</label>
+            <textarea
+              id="ql-text"
+              value={logicText}
+              onChange={e => { setLogicText(e.target.value.slice(0, MAX_LOGIC_CHARS)); setFormError(null); }}
+              rows={5}
+              placeholder='e.g. "Show a 10-frame with 7 dots filled. Ask the child to count and write the numeral. Single-digit answer."'
+              className="mt-1 w-full rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-white"
+            />
+            <div className="mt-1 flex justify-between text-xs text-zinc-500 dark:text-zinc-400">
+              <span>This is an instruction for the question generator, not a finished question.</span>
+              <span className="tabular-nums">{logicText.length} / {MAX_LOGIC_CHARS}</span>
+            </div>
+          </div>
+
+          {formError && (
+            <div className="rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-800 dark:text-red-300">
+              {formError}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={resetForm} disabled={saving}
+              className="rounded-md border border-zinc-300 dark:border-zinc-600 px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 disabled:opacity-50">
+              Clear
+            </button>
+            <button type="button" onClick={save} disabled={saving}
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50">
+              {saving ? 'Saving…' : editingId ? 'Update' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Existing logics */}
+      <div className={cardCls}>
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+          <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">
+            Existing logics <span className="text-sm font-normal text-zinc-500">({visibleLogics.length})</span>
+          </h3>
+          <div className="flex gap-2">
+            <select
+              aria-label="Filter by level"
+              value={filterLevel}
+              onChange={e => setFilterLevel(e.target.value === '' ? '' : Number(e.target.value))}
+              className="rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-2 py-1.5 text-sm text-zinc-900 dark:text-white"
+            >
+              <option value="">All levels</option>
+              {levelMap?.levels.map(l => <option key={l.levelId} value={l.levelNumber}>{l.levelId}</option>)}
+            </select>
+            <select
+              aria-label="Filter by skill"
+              value={filterSkill}
+              onChange={e => setFilterSkill(e.target.value)}
+              className="rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-2 py-1.5 text-sm text-zinc-900 dark:text-white"
+            >
+              <option value="">All skills</option>
+              {levelMap?.skills.map(s => <option key={s.id} value={s.id}>{s.id}</option>)}
+            </select>
+          </div>
+        </div>
+
+        {visibleLogics.length === 0 ? (
+          <p className="py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">
+            {logics.length === 0
+              ? 'No question logics yet. Author the first one above — the question-generation pipeline will read it when building worksheets.'
+              : 'No logics match these filters.'}
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-200 dark:border-zinc-700 text-left text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  <th className="py-2 pr-3 font-medium">Level</th>
+                  <th className="py-2 pr-3 font-medium">Skills</th>
+                  <th className="py-2 pr-3 font-medium">Sub-skills</th>
+                  <th className="py-2 pr-3 font-medium">Question logic</th>
+                  <th className="py-2 pr-3 font-medium">Created by</th>
+                  <th className="py-2 pr-3 font-medium">Last updated</th>
+                  <th className="py-2 font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleLogics.map(l => (
+                  <tr key={l.id} className="border-b border-zinc-100 dark:border-zinc-800 align-top">
+                    <td className="py-3 pr-3 whitespace-nowrap text-zinc-900 dark:text-white">
+                      L{l.level}
+                      <div className="text-xs text-zinc-500 dark:text-zinc-400">{l.levelName}</div>
+                    </td>
+                    <td className="py-3 pr-3 text-zinc-600 dark:text-zinc-300">{l.skills.join(', ')}</td>
+                    <td className="py-3 pr-3 text-zinc-600 dark:text-zinc-300">{l.subskills.length ? l.subskills.join(', ') : '—'}</td>
+                    <td className="py-3 pr-3 text-zinc-700 dark:text-zinc-300 max-w-md">
+                      {l.logicText.length > 80 ? `${l.logicText.slice(0, 80)}…` : l.logicText}
+                    </td>
+                    <td className="py-3 pr-3 text-zinc-500 dark:text-zinc-400 whitespace-nowrap">{l.createdByEmail}</td>
+                    <td className="py-3 pr-3 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums">
+                      {new Date(l.updatedAt).toLocaleDateString()}
+                    </td>
+                    <td className="py-3 whitespace-nowrap">
+                      <button onClick={() => startEdit(l)} aria-label={`Edit logic for L${l.level}`}
+                        className="mr-2 inline-flex items-center gap-1 text-indigo-600 dark:text-indigo-400 hover:underline">
+                        <Pencil size={13} /> Edit
+                      </button>
+                      <button onClick={() => remove(l)} aria-label={`Delete logic for L${l.level}`}
+                        className="inline-flex items-center gap-1 text-red-600 dark:text-red-400 hover:underline">
+                        <Trash2 size={13} /> Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default QuestionInterventionPanel;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -337,3 +337,50 @@ export interface DashboardProps {
   token: string;
 }
 
+/**
+ * A Superadmin-authored instruction describing what to ask at a given level.
+ * Mirrors `QuestionLogic` in `backend/src/db.ts`.
+ */
+export interface QuestionLogic {
+  id: string;
+  level: number;
+  levelName: string;
+  skills: string[];
+  subskills: string[];
+  logicText: string;
+  taxonomy: '3-type' | '4-type';
+  createdBy: string;
+  createdByEmail: string;
+  createdAt: string;
+  updatedAt: string;
+  updatedBy: string;
+  updatedByEmail: string;
+  deletedAt: string | null;
+  deletedBy: string | null;
+}
+
+export interface QuestionLogicStats {
+  totalLogics: number;
+  totalLevels: number;
+  levelsWithLogic: number;
+}
+
+/** Payload of `GET /api/question-logics/level-map` — drives the cascading dropdowns. */
+export interface LevelMapPayload {
+  levelCount: number;
+  levels: Array<{
+    levelId: string;
+    levelNumber: number;
+    capability: string;
+    stage: string;
+    sCode: string;
+    skills: string[];
+  }>;
+  skills: Array<{
+    id: string;
+    name: string;
+    domain: string;
+    subskills: Array<{ id: string; name: string }>;
+  }>;
+}
+

--- a/scripts/generate-skill-level-map.ts
+++ b/scripts/generate-skill-level-map.ts
@@ -1,0 +1,135 @@
+// Generates the backend-readable snapshot of the level -> skill -> subskill mapping.
+//
+// Why this exists: the canonical mapping lives in
+// `frontend/src/data/skillProgressionMap.ts`, but `frontend` and `backend` are
+// separate npm workspaces with separate tsconfigs and a bundled backend build —
+// the server cannot import that module at runtime. The Question Intervention
+// feature needs *server-side* validation of "is this skill actually mapped to
+// this level" (the client dropdowns are UX, not a guard), so the backend needs
+// its own copy of the data.
+//
+// A committed JSON snapshot plus a drift check is the same shape as
+// `scripts/check-level-notation-drift.ts` already uses for the L/S crosswalk:
+// one source of truth, a derived artifact, and CI that fails when they diverge.
+//
+// Usage:
+//   npx tsx scripts/generate-skill-level-map.ts           # regenerate the snapshot
+//   npx tsx scripts/generate-skill-level-map.ts --check    # drift check (CI); exit 1 on mismatch
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+const OUTPUT_PATH = path.join(ROOT, 'backend', 'src', 'data', 'skillLevelMap.json');
+
+export interface SkillLevelMapSnapshot {
+  /** Regeneration provenance — not used at runtime, but makes a stale file obvious. */
+  generatedFrom: string;
+  levelCount: number;
+  /** "L30" -> { levelNumber, capability, stage, skills: ["SK05","SK06"] } */
+  levels: Record<string, {
+    levelNumber: number;
+    capability: string;
+    stage: string;
+    sCode: string;
+    skills: string[];
+  }>;
+  /** "SK05" -> { name, domain, subskills: [{ id, name }] } */
+  skills: Record<string, {
+    name: string;
+    domain: string;
+    subskills: Array<{ id: string; name: string }>;
+  }>;
+}
+
+async function build(): Promise<SkillLevelMapSnapshot> {
+  const skillMapPath = path.join(ROOT, 'frontend', 'src', 'data', 'skillProgressionMap.ts');
+  if (!fs.existsSync(skillMapPath)) {
+    console.error(`Source map not found at ${skillMapPath}`);
+    process.exit(1);
+  }
+
+  const mod = await import(skillMapPath);
+  const LEVEL_SKILL_MAP = mod.LEVEL_SKILL_MAP as Array<{
+    levelId: string;
+    levelNumber: number;
+    sCode: string;
+    capability: string;
+    stage: string;
+    primarySkills: string[];
+    supportingSkills: string[];
+  }>;
+  const CORE_SKILLS = mod.CORE_SKILLS as Array<{
+    id: string;
+    name: string;
+    domain: string;
+    subskills: Array<{ id: string; name: string; observable: boolean }>;
+  }>;
+
+  const levels: SkillLevelMapSnapshot['levels'] = {};
+  for (const l of LEVEL_SKILL_MAP) {
+    // A logic may legitimately target either a primary or a supporting skill of
+    // the level, so the validation set is the union. Deduped and sorted so the
+    // generated file is stable across runs (otherwise the drift check flaps).
+    const skills = Array.from(new Set([...l.primarySkills, ...l.supportingSkills])).sort();
+    levels[l.levelId] = {
+      levelNumber: l.levelNumber,
+      capability: l.capability,
+      stage: l.stage,
+      sCode: l.sCode,
+      skills,
+    };
+  }
+
+  const skills: SkillLevelMapSnapshot['skills'] = {};
+  for (const s of CORE_SKILLS) {
+    skills[s.id] = {
+      name: s.name,
+      domain: s.domain,
+      subskills: s.subskills.map(ss => ({ id: ss.id, name: ss.name })),
+    };
+  }
+
+  return {
+    generatedFrom: 'frontend/src/data/skillProgressionMap.ts',
+    levelCount: LEVEL_SKILL_MAP.length,
+    levels,
+    skills,
+  };
+}
+
+async function main() {
+  const check = process.argv.includes('--check');
+  const snapshot = await build();
+  const serialized = JSON.stringify(snapshot, null, 2) + '\n';
+
+  if (check) {
+    if (!fs.existsSync(OUTPUT_PATH)) {
+      console.error(`DRIFT: ${path.relative(ROOT, OUTPUT_PATH)} does not exist.`);
+      console.error('Run: npx tsx scripts/generate-skill-level-map.ts');
+      process.exit(1);
+    }
+    const existing = fs.readFileSync(OUTPUT_PATH, 'utf8');
+    if (existing !== serialized) {
+      console.error(`DRIFT: ${path.relative(ROOT, OUTPUT_PATH)} is out of date with skillProgressionMap.ts.`);
+      console.error('Run: npx tsx scripts/generate-skill-level-map.ts');
+      process.exit(1);
+    }
+    console.log(`OK — skill/level snapshot matches source (${snapshot.levelCount} levels, ${Object.keys(snapshot.skills).length} skills).`);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, serialized);
+  const subskillCount = Object.values(snapshot.skills).reduce((n, s) => n + s.subskills.length, 0);
+  console.log(`Wrote ${path.relative(ROOT, OUTPUT_PATH)}`);
+  console.log(`  ${snapshot.levelCount} levels, ${Object.keys(snapshot.skills).length} skills, ${subskillCount} subskills`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Implements `QUESTION_INTERVENTION.md`. Opening this early so we can iterate on the branch — see **Open for discussion** at the bottom.

A *question logic* is a Superadmin-authored instruction describing **what to ask** at a given FLN level. It is not a question. It is the prompt the question-generation pipeline turns into many concrete questions across many worksheets. The platform previously had nowhere to record that intent — the level generator and seed banks produce numbers, not pedagogy.

## What the Superadmin gets

A fourth tab on the Superadmin dashboard:

- **Four coverage counters** — total logics, total levels (93), levels with at least one logic, and the taxonomy in force.
- **An authoring form** — level → skills → sub-skills → text. Each dropdown filters from the one above it. Sub-skills are optional; empty means "assess the skill at full granularity."
- **A filterable list** — edit or soft-delete. Level stays editable, so a logic filed under the wrong level can be re-tagged.

## Four corrections to the design doc

The doc was written against a slightly stale picture of the repo. Flagging these rather than silently diverging:

**1. The design was unimplementable as written.** §4.1 requires the server to validate skills against levels using `frontend/src/data/skillProgressionMap.ts`. The backend cannot import that file — `frontend` and `backend` are separate npm workspaces with separate tsconfigs, and the backend ships as a single esbuild bundle. Without solving this, the doc's central safety property has no way to exist.

Solved the way this repo already solves the L/S crosswalk: `scripts/generate-skill-level-map.ts` snapshots the map into `backend/src/data/skillLevelMap.json`, and `--check` fails when the two drift. One source of truth, a derived artifact, CI catching skew — same shape as `scripts/check-level-notation-drift.ts`.

**2. §3.3 is out of date.** It says the repo uses `backend/data/db.json` rather than real MongoDB. That file no longer exists; the Mongo cutover landed in July. This targets Mongo directly.

**3. Stale paths.** `ContentPanel.tsx` now lives in `components/panels/`; `backend/src/types/` and `backend/src/modules/` do not exist; routes register in `routes/`, not `index.ts`.

**4. ID convention.** The doc specifies `_id: ObjectId`. Every collection here uses a string `id` (`'int_' + randomUUID().slice(0, 8)`). Followed the codebase.

## Why validation is server-side

The cascading dropdowns make an invalid combination hard to *pick*, but they cannot make it impossible to *send*. A logic filed against a level that cannot host its skills would flow straight into question generation and produce questions assessing something the level never claimed to teach. So the server re-validates every `(level, skills, subskills)` combination and is the authority.

## Verification

Ran a real backend against a scratch MongoDB, then dropped it. **17 checks, all passing:**

| Area | Result |
|---|---|
| Unauthenticated request | 403 |
| Teacher role | 403 |
| Skill not mapped to level | 400, names the skill and level |
| Sub-skill under an unselected skill | 400 |
| Well-formed but nonexistent sub-skill (`SK05.99`) | 400 |
| Level out of range | 400 |
| Empty skills / empty text | 400 |
| Valid create | 201, `levelName` denormalized correctly |
| Level-only PATCH orphaning its skills | 400, *actionable* — see below |
| Level + skills changed together | 200, orphaned sub-skills dropped |
| Duplicate POST within 60s | 409 |
| Soft delete | excluded from default list, present with `includeDeleted=true` |
| Editing a deleted logic | 400 |
| Coverage counters | distinct-level count correct before and after delete |

The level-only PATCH case returns `Existing skills [SK05, SK06] are not all mapped to the new level L1. Update skills in the same request.` — actionable, not merely rejected.

`npm run lint` and `npm run build` clean on both workspaces. Drift check passes (93 levels, 24 skills, 179 sub-skills). **No lockfile churn.**

## Deliberate choices worth a second opinion

- **Seeded empty.** No demo logics. Fabricated curriculum intent feeding the generation pipeline seemed worse than an empty state, which reads: *"Author the first one above — the question-generation pipeline will read it when building worksheets."*
- **Soft delete, not hard.** The generation pipeline may already hold a logic id.
- **`taxonomy` pinned per-document** to `'3-type'`, so the 3-vs-4 reconciliation can migrate without a schema break.
- **Superadmin-only.** No curriculum-author role exists in the 7-role hierarchy; widening later is one line in `requireSuperadmin`.

## Open for discussion

1. **Wire the drift check into `repo-health-check.yml`?** Right now `--check` exists but nothing runs it. Happy to add it here or split it out.
2. **Is empty-seed right,** or would a couple of real logics for the pilot chain help the team see the shape?
3. **Does the question-generation pipeline read this yet,** or is `questionLogics` upstream of something still to be built? Affects whether the Superadmin can see any output of their work.

Co-authored-by: lakshya-aran <lakshya1244612446@gmail.com>