### PR TITLE
feat(curriculum): expose all 93 levels over HTTP and in the dashboard

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -39,6 +39,7 @@ import { registerAnalyticsRoutes } from './routes/analytics';
 import { registerQuestionLogicRoutes } from './routes/questionLogics';
 import { registerDiagnosticBulkRoutes } from './routes/diagnosticBulk';
 import { registerMisconceptionRoutes } from './routes/misconceptions';
+import { registerCurriculumRoutes } from './routes/curriculum';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 import bcrypt from 'bcrypt';
@@ -134,6 +135,7 @@ registerStatsRoutes(app);
   // Read-only analysis over already-graded submissions: clusters a cohort on
   // HOW its children fail rather than how much they score.
   registerMisconceptionRoutes(app);
+  registerCurriculumRoutes(app);
 
   // --- Intervention Tracking & Best Practices Repository ---
 

--- a/backend/src/routes/curriculum.ts
+++ b/backend/src/routes/curriculum.ts
@@ -1,0 +1,109 @@
+import express from 'express';
+import { dbStore } from '../db';
+import { getAuthUser } from '../auth';
+
+/**
+ * Read-only access to the 93-level curriculum.
+ *
+ * PR #408 seeded `curriculumLevels` and added accessors on `dbStore`, but never
+ * exposed them over HTTP — so the 93 levels existed in the database and nothing
+ * on the site could read them. Every level list in the UI was still built from
+ * a hand-authored table. This is the route that lets those surfaces read the
+ * real thing.
+ *
+ * Read-only by design. Levels are seeded (`npm run seed:levels`), and
+ * `conceptId` is immutable because student evidence points at it — so there is
+ * deliberately no POST/PATCH/DELETE here. Authenticated rather than
+ * Superadmin-only: this is curriculum reference data every role's dashboard
+ * needs to render a level name, not something only curriculum authors read.
+ */
+
+/**
+ * Whether a level's worksheets can actually be produced today.
+ *
+ * Three states, not two, and the distinction is the whole point:
+ *
+ *  - `ready`     — mapped to legacy content that exists on disk. Generation works.
+ *  - `no-content`— mapped, but the legacy level it maps to has no worksheet
+ *                  file or builder. A real, known gap.
+ *  - `unmapped`  — we do not know yet. The level has no `legacyLevel59`, so
+ *                  nothing connects it to the 1-59 worksheet engine.
+ *
+ * `unmapped` is NOT the same as "cannot be built", and collapsing the two would
+ * make the UI lie. Today the worksheet engine builds 59 levels perfectly well;
+ * what is missing is the crosswalk saying WHICH 93-space level each of those
+ * corresponds to. Until `Research/fln_59_to_93_crosswalk.json` lands, every
+ * level is `unmapped` — including ones whose content demonstrably works.
+ *
+ * `hasStaticHtml`/`hasBuilder` are both gated on `legacyLevel59 !== null` at
+ * seed time (seedCurriculumLevels.ts), so reading them alone would report all
+ * 93 as contentless. That would be pessimistically wrong, which is why this
+ * derives a status rather than surfacing the raw booleans as "buildable".
+ */
+export type LevelContentStatus = 'ready' | 'no-content' | 'unmapped';
+
+function contentStatusOf(level: { legacyLevel59: number | null; hasStaticHtml: boolean; hasBuilder: boolean }): LevelContentStatus {
+  if (level.legacyLevel59 === null) return 'unmapped';
+  return (level.hasStaticHtml || level.hasBuilder) ? 'ready' : 'no-content';
+}
+
+export function registerCurriculumRoutes(app: express.Express) {
+  /** All 93 levels, ascending, each with its derived content status. */
+  app.get('/api/curriculum/levels', async (req, res) => {
+    if (!getAuthUser(req)) return res.status(401).json({ error: 'Unauthorized' });
+    try {
+      const levels = await dbStore.getCurriculumLevels();
+      res.json(levels.map((l) => ({ ...l, contentStatus: contentStatusOf(l) })));
+    } catch (err: any) {
+      console.error('[curriculum] failed to read curriculumLevels:', err);
+      res.status(500).json({ error: 'Failed to read the curriculum levels.' });
+    }
+  });
+
+  /**
+   * Coverage summary. `unmapped` is reported as its own number rather than
+   * folded into a single percentage, so a reader cannot mistake "we have not
+   * mapped this yet" for "we have measured this and there is nothing there".
+   */
+  app.get('/api/curriculum/coverage', async (req, res) => {
+    if (!getAuthUser(req)) return res.status(401).json({ error: 'Unauthorized' });
+    try {
+      const [coverage, levels] = await Promise.all([
+        dbStore.getCurriculumCoverage(),
+        dbStore.getCurriculumLevels(),
+      ]);
+      const byStatus = { ready: 0, 'no-content': 0, unmapped: 0 };
+      for (const l of levels) byStatus[contentStatusOf(l)]++;
+      res.json({
+        ...coverage,
+        byStatus,
+        crosswalkLanded: byStatus.unmapped < levels.length,
+      });
+    } catch (err: any) {
+      console.error('[curriculum] failed to compute coverage:', err);
+      res.status(500).json({ error: 'Failed to compute curriculum coverage.' });
+    }
+  });
+
+  /** One level by its 1-93 number. */
+  app.get('/api/curriculum/levels/:levelNumber', async (req, res) => {
+    if (!getAuthUser(req)) return res.status(401).json({ error: 'Unauthorized' });
+    const levelNumber = Number(req.params.levelNumber);
+    if (!Number.isInteger(levelNumber)) {
+      return res.status(400).json({ error: 'levelNumber must be an integer.' });
+    }
+    try {
+      const level = await dbStore.getCurriculumLevel(levelNumber);
+      if (!level) {
+        return res.status(404).json({
+          error: `No curriculum level ${levelNumber}. The curriculum defines levels 1-93; ` +
+            `run "npm run seed:levels" if the collection is empty.`,
+        });
+      }
+      res.json({ ...level, contentStatus: contentStatusOf(level) });
+    } catch (err: any) {
+      console.error('[curriculum] failed to read level:', err);
+      res.status(500).json({ error: 'Failed to read the curriculum level.' });
+    }
+  });
+}

--- a/frontend/src/components/dashboards/SuperadminDashboard.tsx
+++ b/frontend/src/components/dashboards/SuperadminDashboard.tsx
@@ -10,12 +10,13 @@ import { Table, Column } from '../Table';
 import { SuperAdminExecutiveDashboard } from '../SuperAdminExecutiveDashboard';
 import { RegionalAnalyticsView } from './RegionalAnalyticsView';
 import { QuestionInterventionPanel } from '../panels/QuestionInterventionPanel';
+import { CurriculumLevelsPanel } from '../panels/CurriculumLevelsPanel';
 
 export type { DashboardProps };
 
 
 export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
-  const [activeTab, setActiveTab] = useState<'overview' | 'coordinators' | 'analytics' | 'intervention'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'coordinators' | 'analytics' | 'intervention' | 'curriculum'>('overview');
   
   // Overview data
   const [schools, setSchools] = useState<School[]>([]);
@@ -300,6 +301,14 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
             }`}
           >
             ❓ Question Intervention
+          </button>
+          <button
+            onClick={() => setActiveTab('curriculum')}
+            className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition-all ${
+              activeTab === 'curriculum' ? 'bg-white dark:bg-zinc-700 text-zinc-900 dark:text-white shadow-sm' : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white'
+            }`}
+          >
+            🎯 Curriculum Levels
           </button>
         </div>
 
@@ -672,6 +681,10 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
 
       {activeTab === 'intervention' && (
         <QuestionInterventionPanel />
+      )}
+
+      {activeTab === 'curriculum' && (
+        <CurriculumLevelsPanel />
       )}
     </div>
   );

--- a/frontend/src/components/panels/CurriculumLevelsPanel.tsx
+++ b/frontend/src/components/panels/CurriculumLevelsPanel.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Layers, CheckCircle2, AlertTriangle, HelpCircle, Info } from 'lucide-react';
+import { apiFetch } from '../../services/apiClient';
+import type { CurriculumLevel, CurriculumCoverage, LevelContentStatus } from '../../types';
+
+/**
+ * The whole 93-level curriculum, read from the `curriculumLevels` collection.
+ *
+ * Every other level list in this app is built from a hand-authored table. This
+ * one is not: it renders whatever the database holds, so a level added or
+ * re-described by `npm run seed:levels` shows up here without a code change.
+ *
+ * The content badge deliberately has three states rather than a buildable
+ * yes/no. `unmapped` means "we do not know yet" — the 59-space worksheet engine
+ * builds plenty of content today, but nothing records which 93-space level each
+ * piece belongs to until the reviewed crosswalk lands. Rendering that as "no
+ * content" would understate what the platform can actually do.
+ */
+
+const STATUS_META: Record<LevelContentStatus, { label: string; hint: string; className: string; Icon: typeof CheckCircle2 }> = {
+  ready: {
+    label: 'Worksheets ready',
+    hint: 'Mapped to legacy content that exists on disk — generation works for this level.',
+    className: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-300 dark:border-emerald-800',
+    Icon: CheckCircle2,
+  },
+  'no-content': {
+    label: 'No content',
+    hint: 'Mapped, but the legacy level it maps to has no worksheet file or builder. A real gap.',
+    className: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-300 dark:border-amber-800',
+    Icon: AlertTriangle,
+  },
+  unmapped: {
+    label: 'Not yet mapped',
+    hint: 'No link to the 1-59 worksheet engine yet. Not the same as "no content" — it is unknown until the 59->93 crosswalk is reviewed.',
+    className: 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700',
+    Icon: HelpCircle,
+  },
+};
+
+export const CurriculumLevelsPanel: React.FC = () => {
+  const [levels, setLevels] = useState<CurriculumLevel[]>([]);
+  const [coverage, setCoverage] = useState<CurriculumCoverage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [strandFilter, setStrandFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState<LevelContentStatus | ''>('');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [levelsRes, coverageRes] = await Promise.all([
+          apiFetch('/api/curriculum/levels'),
+          apiFetch('/api/curriculum/coverage'),
+        ]);
+        if (!levelsRes.ok) throw new Error(`Levels request failed (${levelsRes.status})`);
+        if (!coverageRes.ok) throw new Error(`Coverage request failed (${coverageRes.status})`);
+        const [levelsJson, coverageJson] = await Promise.all([levelsRes.json(), coverageRes.json()]);
+        if (cancelled) return;
+        setLevels(levelsJson);
+        setCoverage(coverageJson);
+        setLoadError(null);
+      } catch (err: any) {
+        if (!cancelled) setLoadError(err?.message || 'Could not load the curriculum.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const strands = useMemo(
+    () => Array.from(new Set(levels.map((l) => l.strand))).sort(),
+    [levels],
+  );
+
+  const visible = useMemo(
+    () => levels.filter((l) =>
+      (!strandFilter || l.strand === strandFilter) &&
+      (!statusFilter || l.contentStatus === statusFilter)),
+    [levels, strandFilter, statusFilter],
+  );
+
+  if (loading) return <div className="p-6 text-slate-500 dark:text-zinc-400">Loading the curriculum…</div>;
+
+  if (loadError) {
+    return (
+      <div className="p-6">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:bg-red-950 dark:border-red-800 dark:text-red-300">
+          <p className="font-semibold">Could not load the curriculum levels.</p>
+          <p className="text-sm mt-1">{loadError}</p>
+          <p className="text-sm mt-2">
+            If the collection is empty, seed it with <code className="font-mono">npm run seed:levels</code>.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <header className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="text-xl font-bold text-slate-800 dark:text-white flex items-center gap-2">
+            <Layers className="w-5 h-5 text-violet-600" />
+            Curriculum Levels
+          </h2>
+          <p className="text-sm text-slate-500 dark:text-zinc-400 mt-1">
+            All {levels.length} levels, read live from the curriculum database.
+          </p>
+        </div>
+        {coverage && (
+          <div className="flex gap-2 flex-wrap">
+            {(Object.keys(STATUS_META) as LevelContentStatus[]).map((status) => {
+              const meta = STATUS_META[status];
+              return (
+                <div key={status} title={meta.hint}
+                  className={`px-3 py-2 rounded-lg border text-sm ${meta.className}`}>
+                  <span className="font-bold text-lg">{coverage.byStatus[status]}</span>{' '}
+                  <span className="opacity-80">{meta.label}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </header>
+
+      {coverage && !coverage.crosswalkLanded && (
+        <div className="rounded-lg border border-sky-200 bg-sky-50 p-4 text-sky-900 dark:bg-sky-950 dark:border-sky-800 dark:text-sky-200 flex gap-3">
+          <Info className="w-5 h-5 shrink-0 mt-0.5" />
+          <div className="text-sm">
+            <p className="font-semibold">Worksheet availability is not known yet for any level.</p>
+            <p className="mt-1">
+              The worksheet engine builds levels in the retired 1–59 numbering. Nothing yet records which
+              of these {levels.length} levels each piece of that content belongs to, so every level below reads
+              “Not yet mapped”. That is a missing mapping, not missing content — it resolves when the
+              reviewed 59→93 crosswalk lands.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="flex gap-3 flex-wrap">
+        <select value={strandFilter} onChange={(e) => setStrandFilter(e.target.value)}
+          className="border border-slate-300 rounded-lg px-3 py-2 text-sm dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100">
+          <option value="">All strands</option>
+          {strands.map((s) => <option key={s} value={s}>{s}</option>)}
+        </select>
+        <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as LevelContentStatus | '')}
+          className="border border-slate-300 rounded-lg px-3 py-2 text-sm dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100">
+          <option value="">All content states</option>
+          {(Object.keys(STATUS_META) as LevelContentStatus[]).map((s) =>
+            <option key={s} value={s}>{STATUS_META[s].label}</option>)}
+        </select>
+        <span className="text-sm text-slate-500 dark:text-zinc-400 self-center">
+          Showing {visible.length} of {levels.length}
+        </span>
+      </div>
+
+      <div className="overflow-x-auto border border-slate-200 dark:border-zinc-700 rounded-lg">
+        <table className="min-w-full text-sm">
+          <thead className="bg-slate-50 dark:bg-zinc-800 text-slate-600 dark:text-zinc-300">
+            <tr>
+              <th className="text-left px-4 py-3 font-semibold">Level</th>
+              <th className="text-left px-4 py-3 font-semibold">Capability</th>
+              <th className="text-left px-4 py-3 font-semibold">Stage</th>
+              <th className="text-left px-4 py-3 font-semibold">Strand</th>
+              <th className="text-left px-4 py-3 font-semibold">Skills</th>
+              <th className="text-left px-4 py-3 font-semibold">Worksheets</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 dark:divide-zinc-800">
+            {visible.map((level) => {
+              const meta = STATUS_META[level.contentStatus];
+              return (
+                <tr key={level.conceptId} className="hover:bg-slate-50 dark:hover:bg-zinc-800/60">
+                  <td className="px-4 py-3 whitespace-nowrap">
+                    <span className="font-bold text-slate-800 dark:text-white">L{level.levelNumber}</span>
+                    <span className="text-slate-400 dark:text-zinc-500 ml-2 font-mono text-xs">{level.sCode}</span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-700 dark:text-zinc-200">{level.capability}</td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-zinc-400 whitespace-nowrap">{level.stage}</td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-zinc-400 whitespace-nowrap">{level.strand}</td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-zinc-400 whitespace-nowrap">
+                    {level.primarySkills.length} primary
+                    {level.supportingSkills.length > 0 && ` · ${level.supportingSkills.length} supporting`}
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap">
+                    <span title={meta.hint}
+                      className={`inline-flex items-center gap-1.5 px-2 py-1 rounded border text-xs font-medium ${meta.className}`}>
+                      <meta.Icon className="w-3.5 h-3.5" />
+                      {meta.label}
+                    </span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -384,3 +384,43 @@ export interface LevelMapPayload {
   }>;
 }
 
+
+/**
+ * Whether a curriculum level's worksheets can be produced today.
+ * Mirrors LevelContentStatus in backend/src/routes/curriculum.ts — three
+ * states because "not yet mapped to the 59-space worksheet engine" is not the
+ * same claim as "measured, and there is no content".
+ */
+export type LevelContentStatus = 'ready' | 'no-content' | 'unmapped';
+
+/** One row of the 93-level curriculum, as served by /api/curriculum/levels. */
+export interface CurriculumLevel {
+  conceptId: string;
+  levelNumber: number;
+  sCode: string;
+  legacyLevel59: number | null;
+  stage: string;
+  capability: string;
+  strand: string;
+  primarySkills: string[];
+  supportingSkills: string[];
+  subskills: string[];
+  hasStaticHtml: boolean;
+  hasBuilder: boolean;
+  curriculumVersion: string;
+  createdAt: string;
+  updatedAt: string;
+  contentStatus: LevelContentStatus;
+}
+
+/** Summary served by /api/curriculum/coverage. */
+export interface CurriculumCoverage {
+  totalLevels: number;
+  withStaticHtml: number;
+  withBuilder: number;
+  withAnyContent: number;
+  mappedFromLegacy59: number;
+  byStatus: Record<LevelContentStatus, number>;
+  /** False while no level has a legacyLevel59 — i.e. the crosswalk has not landed. */
+  crosswalkLanded: boolean;
+}


### PR DESCRIPTION
Makes the 93-level curriculum visible across the site, read from the database rather than from hand-authored tables.

## Why this was needed

PR #408 seeded the `curriculumLevels` collection and added `getCurriculumLevels` / `getCurriculumLevel` / `getCurriculumCoverage` to `dbStore` — but **never added a route**. The 93 levels have been sitting in production since this morning's deploy (verified: `db.curriculumLevels.countDocuments()` → 93) with nothing on the site able to read them.

## What's here

**Backend** — new read-only `backend/src/routes/curriculum.ts`:

| Endpoint | Returns |
|---|---|
| `GET /api/curriculum/levels` | all 93, ascending, each with a derived `contentStatus` |
| `GET /api/curriculum/coverage` | counts per status + `crosswalkLanded` |
| `GET /api/curriculum/levels/:levelNumber` | one level |

Read-only by design — levels are seeded and `conceptId` is immutable because student evidence points at it, so no POST/PATCH/DELETE. Authenticated rather than Superadmin-only: a level's name is reference data every role's dashboard needs to render.

**Frontend** — `CurriculumLevelsPanel`, mounted as a "Curriculum Levels" tab on the Superadmin dashboard. Renders whatever the database holds, so a level added or re-described by `seed:levels` appears without a code change. Filters by strand and by content state.

## The one design decision worth reviewing

**Content status has three states, not a buildable yes/no.**

```
ready       mapped to legacy content that exists — generation works
no-content  mapped, but the legacy level has no worksheet file or builder
unmapped    no link to the 1-59 engine yet — not known
```

`hasStaticHtml` and `hasBuilder` are **both gated on `legacyLevel59 !== null`** at seed time (`seedCurriculumLevels.ts:188-189`), and no crosswalk has landed, so every row currently has both `false`.

Surfacing those raw as "buildable" would report **all 93 levels as having no content** — while the worksheet engine demonstrably builds 59 levels today. What is missing is the *mapping* saying which 93-space level each piece of that content belongs to, not the content itself. So the panel shows a banner saying exactly that, rather than a UI that understates what the platform can do.

Every level reads "Not yet mapped" today. That resolves the moment `Research/fln_59_to_93_crosswalk.json` lands — no code change needed here.

## Verification

Against a scratch MongoDB seeded with the real 93 levels:

- `401` unauthenticated
- 93 levels returned, ordered 1→93
- coverage: `{ready: 0, no-content: 0, unmapped: 93}`, `crosswalkLanded: false`
- `404` for level 999 (with an actionable message), `400` for a non-integer

The `ready` / `no-content` branches would otherwise have been dead code, so they were exercised directly by patching three rows to simulate a landed crosswalk — L8 (static html) and L12 (builder) both → `ready`, L30 (mapped but empty) → `no-content` — then reverted.

Panel render-checked in a real browser end-to-end: logged in as superadmin, opened the tab, confirmed **93 rows L1→L93**, correct badge counts, banner present, zero page errors. The first pass rendered low-contrast in dark mode; `dark:` variants were added to match the surrounding dashboards and it was re-checked.

`npm run lint` clean across both workspaces.

## Not in scope

This does not make levels 60–93 generate worksheets — that needs the reviewed crosswalk (migration step 3) and, for levels with no legacy ancestor, actual content authoring. This makes the state visible and honest; it does not invent content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ryfSeYFQfUTUPvixGTjXA