### PR TITLE
fix(diagnostic): stop mis-placing children on notation and missing levels

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "seed:levels": "tsx src/seedCurriculumLevels.ts",
     "seed:question-bank": "tsx src/seedQuestionBank.ts",
     "seed:geo": "tsx src/utils/seedGeo.ts",
-    "reseed": "tsx src/reseed.ts"
+    "reseed": "tsx src/reseed.ts",
+    "test:answer-matching": "tsx src/answerMatching.test.ts"
   },
   "dependencies": {
     "@google/genai": "^2.4.0",

--- a/backend/src/answerMatching.test.ts
+++ b/backend/src/answerMatching.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for diagnostic answer matching.
+ *
+ * Plain-script convention (node:assert, no runner). Run with:
+ *   npm run test:answer-matching --workspace @fln/backend
+ *
+ * This comparison decides `recommendedLevel`, so the cases that matter most
+ * are the ones where being wrong changes a child's placement: notation the
+ * grader must accept, and genuine errors it must NOT quietly forgive.
+ */
+import assert from 'node:assert';
+import { normalizeAnswer, answersMatch } from './answerMatching';
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn();
+    passed++;
+    console.log(`  PASS  ${name}`);
+  } catch (error: any) {
+    failed++;
+    console.error(`  FAIL  ${name}\n        ${error?.message || error}`);
+  }
+}
+
+const ok = (s: unknown, e: unknown) =>
+  assert.strictEqual(answersMatch(s, e), true, `expected ${JSON.stringify(s)} to match ${JSON.stringify(e)}`);
+const no = (s: unknown, e: unknown) =>
+  assert.strictEqual(answersMatch(s, e), false, `expected ${JSON.stringify(s)} NOT to match ${JSON.stringify(e)}`);
+
+console.log('\nnormalizeAnswer');
+test('trims, lowercases and collapses whitespace', () => {
+  assert.strictEqual(normalizeAnswer('  Seven   Apples '), 'seven apples');
+});
+test('tidies spacing around list separators', () => {
+  assert.strictEqual(normalizeAnswer('2,  3 , 4'), '2,3,4');
+});
+test('drops a trailing full stop', () => {
+  assert.strictEqual(normalizeAnswer('7.'), '7');
+});
+test('keeps a decimal point that is not trailing', () => {
+  assert.strictEqual(normalizeAnswer('2.5'), '2.5');
+});
+test('handles null and undefined', () => {
+  assert.strictEqual(normalizeAnswer(null), '');
+  assert.strictEqual(normalizeAnswer(undefined), '');
+});
+
+console.log('\nnotation that must be accepted');
+test('leading zero', () => ok('07', '7'));
+test('trailing decimal zero', () => ok('2.0', '2'));
+test('both directions', () => { ok('2', '2.0'); ok('7', '07'); });
+test('thousands separator', () => ok('1,000', '1000'));
+test('surrounding whitespace', () => ok('  12  ', '12'));
+test('case differences in worded answers', () => ok('Seven', 'seven'));
+test('trailing full stop the child wrote', () => ok('7.', '7'));
+test('negative numbers', () => ok('-03', '-3'));
+
+console.log('\ngenuine errors that must NOT be forgiven');
+test('a different number', () => no('8', '7'));
+test('off-by-one with a leading zero', () => no('08', '7'));
+test('fraction vs decimal is left as a real difference', () => no('2/3', '0.67'));
+test('a word answer vs a number', () => no('seven', '7'));
+test('operand concatenation, the misconception we must keep visible', () => no('56', '11'));
+test('digit reversal', () => no('21', '12'));
+test('empty submission against a real answer', () => no('', '7'));
+test('whitespace-only submission', () => no('   ', '7'));
+test('empty submission against an empty expected answer', () => no('', ''));
+
+console.log('\nmulti-blank rows (comma-joined)');
+test('matches element-wise', () => ok('2,3', '2,3'));
+test('tolerates spacing and leading zeros per blank', () => ok('02, 3', '2,3'));
+test('rejects a wrong blank', () => no('2,4', '2,3'));
+test('rejects a different number of blanks', () => no('2,3,4', '2,3'));
+test('rejects an empty blank', () => no('2,', '2,3'));
+test('does not reorder blanks', () => no('3,2', '2,3'));
+
+console.log('\nnon-numeric strings are not coerced');
+test('units are not stripped', () => no('7cm', '7'));
+test('exponent notation is not treated as a number', () => no('1e3', '1000'));
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/backend/src/answerMatching.ts
+++ b/backend/src/answerMatching.ts
@@ -1,0 +1,75 @@
+/**
+ * Deciding whether a child's written answer matches the expected one.
+ *
+ * This is the single most consequential comparison in the diagnostic path:
+ * its result feeds `recommendedLevel`, so a false negative here does not just
+ * lose a mark — it places the child at a lower level and hands them the wrong
+ * worksheets. The inputs are OCR'd handwriting, so surface-level variation is
+ * the norm rather than the exception.
+ *
+ * The rule followed here: normalise only differences that are unambiguously
+ * *notation*, never differences that could be a genuine misconception. "07"
+ * and "7" are the same number written two ways. "2/3" and "0.67" are not
+ * obviously the same claim by a seven-year-old, and treating them as equal
+ * would erase exactly the evidence the misconception work needs. So numeric
+ * equality is applied only when BOTH sides parse as plain numbers, and
+ * anything else falls back to a normalised string compare.
+ */
+
+/** Lowercase, collapse whitespace, tidy list separators, drop a trailing full stop. */
+export function normalizeAnswer(value: unknown): string {
+  let s = String(value ?? '').trim().toLowerCase();
+  s = s.replace(/\s+/g, ' ');        // "12   apples" -> "12 apples"
+  s = s.replace(/\s*,\s*/g, ',');    // "2, 3" -> "2,3"  (multi-blank rows are comma-joined)
+  s = s.replace(/\.$/, '');          // "7." -> "7"      (a full stop the child wrote as punctuation)
+  return s.trim();
+}
+
+/**
+ * A plain number, written the way a child writes one. Deliberately narrow:
+ * optional sign, digits with optional thousands separators, optional decimal
+ * part. No exponents, no fractions, no units — those must not be silently
+ * treated as numbers.
+ */
+const PLAIN_NUMBER = /^[+-]?(\d{1,3}(,\d{3})+|\d+)(\.\d+)?$/;
+
+function asNumber(normalized: string): number | null {
+  if (!PLAIN_NUMBER.test(normalized)) return null;
+  const n = Number(normalized.replace(/,/g, ''));
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Whether a submitted answer should be graded correct against the expected one.
+ *
+ * A blank submission is never correct, even against a blank expected answer —
+ * an unanswered question is missing evidence, not a demonstrated skill.
+ */
+export function answersMatch(submitted: unknown, expected: unknown): boolean {
+  const s = normalizeAnswer(submitted);
+  const e = normalizeAnswer(expected);
+  if (s === '') return false;
+  if (s === e) return true;
+
+  // Same number, different notation: "07" vs "7", "2.0" vs "2", "1,000" vs "1000".
+  const sn = asNumber(s);
+  const en = asNumber(e);
+  if (sn !== null && en !== null) return sn === en;
+
+  // Multi-blank rows arrive comma-joined ("2,3"). Compare element-wise so one
+  // blank written as "03" does not fail the whole row. Order is significant:
+  // the blanks are positional on the printed sheet.
+  if (s.includes(',') && e.includes(',')) {
+    const sParts = s.split(',');
+    const eParts = e.split(',');
+    if (sParts.length !== eParts.length) return false;
+    return sParts.every((part, i) => {
+      if (part === eParts[i]) return part !== '';
+      const pn = asNumber(part);
+      const qn = asNumber(eParts[i]);
+      return pn !== null && qn !== null && pn === qn;
+    });
+  }
+
+  return false;
+}

--- a/backend/src/routes/students.ts
+++ b/backend/src/routes/students.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import path from 'path';
 import fs from 'fs';
 import { dbStore, UserRole, Student, Question, AnswerSubmission, EvaluationReport, EvaluationReasoning, CYCLE_NAMES } from '../db';
+import { answersMatch } from '../answerMatching';
 import { getAuthUser, canAccessStudent } from '../auth';
 import { generateDiagnosticPaper } from '../paperGenerator';
 import { generateQuestionsForLevel } from '../levelGenerator';
@@ -853,12 +854,14 @@ export function registerStudentRoutes(app: express.Express) {
     //                       recommended level based on how many of that level's
     //                       questions were missed.
     const questionResults = questions.map((q) => {
-      const submitted = String(answers[q.question_id] ?? '').trim().toLowerCase();
-      const correct = String(q.answer ?? '').trim().toLowerCase();
       const srcLevel = Number(q.source_level);
       return {
         q,
-        isCorrect: submitted !== '' && submitted === correct,
+        // answersMatch, not string equality: these answers are OCR'd
+        // handwriting, and "07" vs "7" is notation rather than a wrong
+        // answer. Getting this wrong does not just lose a mark, it lowers
+        // the child's placement. See backend/src/answerMatching.ts.
+        isCorrect: answersMatch(answers[q.question_id], q.answer),
         sourceLevel: Number.isFinite(srcLevel) ? srcLevel : NaN,
       };
     });
@@ -879,20 +882,37 @@ export function registerStudentRoutes(app: express.Express) {
       );
     }
     const allCorrect = questionResults.every((r) => r.isCorrect);
+    const wrongResults = questionResults.filter((r) => !r.isCorrect);
+    const assessedLevels: number[] = questionResults
+      .map((r) => r.sourceLevel)
+      .filter((l): l is number => Number.isFinite(l));
     const failedLevels: number[] = (Array.from(new Set(
-      questionResults
-        .filter((r) => !r.isCorrect)
+      wrongResults
         .map((r) => r.sourceLevel)
         .filter((l): l is number => Number.isFinite(l))
     )) as number[]).sort((a, b) => a - b);
+
     if (failedLevels.length > 0) {
-      const firstFailed = failedLevels[0];
-      recommendedLevel = Math.max(1, firstFailed);
-    } else {
-      const maxLevel = Math.max(0, ...questionResults
-        .map((r) => r.sourceLevel)
-        .filter((l): l is number => Number.isFinite(l))
+      // Weakest-Level Mapping: place at the lowest level the child failed.
+      recommendedLevel = Math.max(1, failedLevels[0]);
+    } else if (wrongResults.length > 0) {
+      // The child got questions wrong, but none of those questions carries a
+      // usable `source_level`. Branching on `failedLevels` alone would fall
+      // through to the mastery case below and PROMOTE a child who failed —
+      // `source_level` is typed `number` but arrives from Mongo unchecked,
+      // which is why it is guarded at all. Hold at the lowest level the paper
+      // actually assessed instead, and say so loudly: this is a data defect
+      // in the paper, not a fact about the child.
+      const lowestAssessed = assessedLevels.length > 0 ? Math.min(...assessedLevels) : 1;
+      recommendedLevel = Math.max(1, lowestAssessed);
+      console.warn(
+        `[diag] ${student.id}: ${wrongResults.length} wrong answer(s) but none carry a numeric source_level. ` +
+        `Holding at Level ${recommendedLevel} rather than promoting. Question ids: ` +
+        wrongResults.map((r) => r.q.question_id).join(', ')
       );
+    } else {
+      // Genuinely all correct: advance one past the hardest level assessed.
+      const maxLevel = Math.max(0, ...assessedLevels);
       recommendedLevel = Math.min(93, maxLevel + 1);
     }
     pipelineDetail = readPipelineDetail({}, questions, answers);
@@ -948,16 +968,13 @@ export function registerStudentRoutes(app: express.Express) {
 
     // Determine the subLevel based on weakest-level mapping questions
     let subLevel = 0; // default Mastery
-    const levelQuestions = questions.filter(q => q.source_level === recommendedLevel);
+    // Reuses questionResults rather than re-grading: the same comparison
+    // implemented twice is the same comparison waiting to drift apart, and
+    // the second copy here previously used bare string equality even after
+    // the first was fixed.
+    const levelQuestions = questionResults.filter(r => r.sourceLevel === recommendedLevel);
     if (levelQuestions.length > 0) {
-      let failedCount = 0;
-      levelQuestions.forEach(q => {
-        const submitted = (answers[q.question_id] || '').trim().toLowerCase();
-        const correct = q.answer.trim().toLowerCase();
-        if (submitted !== correct) {
-          failedCount++;
-        }
-      });
+      const failedCount = levelQuestions.filter(r => !r.isCorrect).length;
 
       if (failedCount === levelQuestions.length) {
         subLevel = 2; // Remedial (failed all)


### PR DESCRIPTION
Two defects in the deterministic placement introduced by #420. Both move a **real child to the wrong level**. Both reproduced against a scratch MongoDB before and after the change.

This is the prerequisite for deploying #421 — the next build+restart on the box activates #420's placement code either way, so these are worth fixing first.

## 1. A child who answered questions wrong could be promoted

Placement branched on `if (failedLevels.length > 0)`, but that array collects only *finite* `source_level` values **from wrong answers**. When the wrong answers sit on questions whose `source_level` is missing, the array is empty and control fell through to the `else` branch — the all-correct case — advancing the child past the hardest level on the paper. `allCorrect` was computed two lines above and was not what decided.

Measured on a 3-question paper (levels 3, 5, and one with no level) where the child answered **the level-less question wrong**:

```
against unmodified main:   want L3   got L6     <- promoted above everything assessed
after this change:         want L3   got L3
```

`source_level` is typed `number` but arrives from Mongo unchecked — which is why #420 guarded it with `Number.isFinite` at all. Wrong answers with no usable level now hold at the lowest level the paper assessed, and log a warning naming the question ids. That combination is a defect in the paper, not a fact about the child.

Worth noting for accuracy: the case where *every* question lacks a level was **not** broken — it already landed at L1. Only the mixed case promoted.

## 2. Grading compared answer strings exactly, on OCR'd handwriting

`submitted === correct` after trim and lowercase only. A child who wrote `07` for 7 was marked wrong. Because placement is Weakest-Level Mapping, one such miss does not cost a mark — it **drops the placement to that question's level**.

Measured on a child who answered **all three questions correctly** but wrote `07` and `2.0`:

```
against unmodified main:   want L9   got L3     <- six levels too low
after this change:         want L9   got L9
```

Six levels too low also means six levels of worksheets they do not need.

New `backend/src/answerMatching.ts` applies numeric equality **only when both sides parse as plain numbers**, and compares comma-joined multi-blank rows element-wise.

Deliberately conservative — it normalises notation, never meaning:

| accepted | still fails |
|---|---|
| `07` = `7` | `2/3` ≠ `0.67` |
| `2.0` = `2` | `7cm` ≠ `7` |
| `1,000` = `1000` | `56` ≠ `11` (operand concatenation) |
| `7.` = `7` | `21` ≠ `12` (digit reversal) |
| `02, 3` = `2,3` | `1e3` ≠ `1000` |

Normalising a genuine misconception into a pass would erase exactly the evidence #410 and #413 are being built to collect. Blank submissions are never correct, including against a blank expected answer — an unanswered question is missing evidence, not demonstrated skill.

## 3. Duplicate grading pass removed

The `subLevel` block re-implemented the same comparison by hand. Left alone, it would have kept using bare string equality after the fix above. It now reuses `questionResults`.

## Verification

- **30 unit tests** over the matcher — `npm run test:answer-matching --workspace @fln/backend` (new script). Covers notation that must be accepted, errors that must not be forgiven, multi-blank rows, and non-numeric strings that must not be coerced.
- **12 end-to-end placement submissions** against a live backend on a scratch MongoDB: all-correct, each failure position, missing `source_level`, notation variants, and real errors that must still fail.
- Both defects **confirmed to reproduce on unmodified `main`** and confirmed gone after — the numbers above are from those runs, not from reasoning about the code.
- `npm run lint` clean across both workspaces.

## Still open from the #420 review, not addressed here

These need a decision rather than a patch:

- **Personalized exam generation was silently dropped** — `personalized_evaluation_pipeline.py` is no longer invoked anywhere in `backend/src`. Intentional retirement, or collateral?
- **Every diagnostic now records `errorType: 'unclassified'`** — with the Python pipeline gone, `readPipelineDetail({}, …)` takes its no-root-causes path. Honest, but automated error typing is now structurally absent, and #410/#413 read exactly those fields.
- **Placement caps at 93 while worksheet generation stops at 59** — a student placed above 59 hits #419's `UnknownLevelError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ryfSeYFQfUTUPvixGTjXA