### PR TITLE
feat(curriculum): review and map the existing questions to the 93 levels

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -216,8 +216,19 @@ export interface LevelHtmlTemplate {
 }
 
 export interface QuestionBankEntry {
+  /**
+   * Stable identity, derived from (level, section, questionNumber) — verified
+   * unique across all 1202 seeded questions. Deliberately NOT derived from the
+   * question text: 314 questions share their text with another, and fixing a
+   * typo must not orphan a reviewer's mapping.
+   *
+   * This exists so review work survives a re-seed. Before it, `seedQuestionBank`
+   * did deleteMany + insertMany, so every re-seed rotated the Mongo _ids and
+   * would have silently destroyed every mapping a superadmin had made.
+   */
+  questionId: string;
+
   level: number;
-  conceptId?: string; // Immutable concept tag (S1.1 - S7.18)
   levelTitle: string;
   section: string;
   sectionType: string;
@@ -225,6 +236,28 @@ export interface QuestionBankEntry {
   questionText: string;
   answer: string;
   svgHtml: string;
+
+  // --- Review state. Written by a human, never by the seeder. ---
+
+  /** The 93-space level this question actually assesses, once a human says so. */
+  mappedLevel?: number | null;
+  /** Immutable concept tag (S1.1 - S7.18), set from the mapped level. */
+  conceptId?: string;
+  /**
+   * `untagged` — nobody has looked at it yet.
+   * `mapped`   — a human assigned it to a 93-space level.
+   * `retired`  — a human judged it not worth keeping. Kept, not deleted, so the
+   *              decision is auditable and reversible; readers must filter it out.
+   */
+  reviewStatus?: 'untagged' | 'mapped' | 'retired';
+  reviewedBy?: string;
+  reviewedAt?: string;
+  reviewNote?: string;
+}
+
+/** The one place the question identity is computed. Seeder and API must agree. */
+export function questionBankId(level: number | string, section: string, questionNumber: number | string): string {
+  return `qb_L${level}_${String(section).replace(/[^A-Za-z0-9.]+/g, '-')}_${questionNumber}`;
 }
 
 // Canonical set of assessment cycle names, used everywhere a cycle name is
@@ -1828,6 +1861,105 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   // a feature that cannot get what it needs from these is a signal the schema
   // is missing a field, not licence to start a seventh copy of the taxonomy.
 
+  // --- Question bank review ---------------------------------------------
+  //
+  // The bank holds the concrete questions that already exist (levels 22-59 of
+  // the retired numbering). Mapping each one to a 93-space level is what lets
+  // the 59 space be retired WITHOUT a level-to-level crosswalk: content is
+  // addressed by the question's own tag rather than by the level it came from.
+
+  async getQuestionBank(opts: {
+    level?: number;
+    sectionType?: string;
+    status?: 'untagged' | 'mapped' | 'retired';
+    mappedLevel?: number;
+    limit?: number;
+    skip?: number;
+  } = {}) {
+    const filter: any = {};
+    if (opts.level !== undefined) filter.level = opts.level;
+    if (opts.sectionType) filter.sectionType = opts.sectionType;
+    if (opts.status) filter.reviewStatus = opts.status;
+    if (opts.mappedLevel !== undefined) filter.mappedLevel = opts.mappedLevel;
+    const coll = this.mongoDb!.collection<QuestionBankEntry>('questionBank');
+    const [items, total] = await Promise.all([
+      coll.find(filter).sort({ level: 1, section: 1, questionNumber: 1 })
+        .skip(opts.skip || 0).limit(opts.limit || 50).toArray(),
+      coll.countDocuments(filter),
+    ]);
+    return { items, total };
+  }
+
+  async getQuestionBankEntry(questionId: string) {
+    return (await this.mongoDb!.collection<QuestionBankEntry>('questionBank')
+      .findOne({ questionId })) || undefined;
+  }
+
+  /** Apply a review decision to one question. Returns the updated row. */
+  async reviewQuestion(questionId: string, patch: {
+    mappedLevel?: number | null;
+    conceptId?: string;
+    reviewStatus: 'untagged' | 'mapped' | 'retired';
+    reviewedBy: string;
+    reviewNote?: string;
+  }) {
+    const coll = this.mongoDb!.collection<QuestionBankEntry>('questionBank');
+    await coll.updateOne({ questionId }, {
+      $set: { ...patch, reviewedAt: new Date().toISOString() } as any,
+    });
+    return await this.getQuestionBankEntry(questionId);
+  }
+
+  /** Apply one decision to every question in a (level, section). */
+  async reviewQuestionsBulk(filter: { level: number; section?: string; sectionType?: string }, patch: {
+    mappedLevel?: number | null;
+    conceptId?: string;
+    reviewStatus: 'untagged' | 'mapped' | 'retired';
+    reviewedBy: string;
+  }) {
+    const q: any = { level: filter.level };
+    if (filter.section) q.section = filter.section;
+    if (filter.sectionType) q.sectionType = filter.sectionType;
+    const res = await this.mongoDb!.collection<QuestionBankEntry>('questionBank').updateMany(q, {
+      $set: { ...patch, reviewedAt: new Date().toISOString() } as any,
+    });
+    return { matched: res.matchedCount, modified: res.modifiedCount };
+  }
+
+  /**
+   * Review progress, plus the shape of the work remaining.
+   *
+   * `legacyLevelsWithoutQuestions` is the honest other half: the bank only
+   * covers levels 22-59, so those legacy levels have nothing to tag and must be
+   * mapped level-to-level instead.
+   */
+  async getQuestionBankProgress() {
+    const coll = this.mongoDb!.collection<QuestionBankEntry>('questionBank');
+    const [total, mapped, retired, untagged, levels, targets] = await Promise.all([
+      coll.countDocuments({}),
+      coll.countDocuments({ reviewStatus: 'mapped' }),
+      coll.countDocuments({ reviewStatus: 'retired' }),
+      coll.countDocuments({ reviewStatus: 'untagged' }),
+      coll.distinct('level'),
+      coll.distinct('mappedLevel', { reviewStatus: 'mapped' }),
+    ]);
+    const byLevel = await coll.aggregate([
+      { $group: {
+          _id: '$level',
+          total: { $sum: 1 },
+          mapped: { $sum: { $cond: [{ $eq: ['$reviewStatus', 'mapped'] }, 1, 0] } },
+          retired: { $sum: { $cond: [{ $eq: ['$reviewStatus', 'retired'] }, 1, 0] } },
+      } },
+      { $sort: { _id: 1 } },
+    ]).toArray();
+    return {
+      total, mapped, retired, untagged,
+      legacyLevelsInBank: levels.sort((a: number, b: number) => a - b),
+      targetLevelsCovered: (targets as (number | null)[]).filter((n): n is number => typeof n === 'number').sort((a, b) => a - b),
+      byLevel: byLevel.map((r: any) => ({ level: r._id, total: r.total, mapped: r.mapped, retired: r.retired })),
+    };
+  }
+
   async getCurriculumLevels() {
     return await this.mongoDb!.collection<CurriculumLevel>('curriculumLevels')
       .find({}).sort({ levelNumber: 1 }).toArray();
@@ -1848,6 +1980,24 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   async getCurriculumLevelByLegacy59(legacyLevel59: number) {
     return (await this.mongoDb!.collection<CurriculumLevel>('curriculumLevels')
       .findOne({ legacyLevel59 })) || undefined;
+  }
+
+  /**
+   * Point a 93-space level at a retired 1-59 level, or clear the pointer.
+   *
+   * Passing `null` as the target clears whichever level currently claims
+   * `legacyLevel59`, so a mis-mapping can be undone without knowing where it
+   * landed.
+   */
+  async setCurriculumLegacyMapping(levelNumber: number | null, legacyLevel59: number) {
+    const coll = this.mongoDb!.collection<CurriculumLevel>('curriculumLevels');
+    // Only one 93-space level may claim a given legacy id.
+    await coll.updateMany({ legacyLevel59 }, { $set: { legacyLevel59: null } });
+    if (levelNumber !== null) {
+      await coll.updateOne({ levelNumber }, {
+        $set: { legacyLevel59, updatedAt: new Date().toISOString() },
+      });
+    }
   }
 
   /** Coverage summary — how much of the 93 can actually be rendered today. */

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -40,6 +40,7 @@ import { registerQuestionLogicRoutes } from './routes/questionLogics';
 import { registerDiagnosticBulkRoutes } from './routes/diagnosticBulk';
 import { registerMisconceptionRoutes } from './routes/misconceptions';
 import { registerCurriculumRoutes } from './routes/curriculum';
+import { registerQuestionBankRoutes } from './routes/questionBank';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 import bcrypt from 'bcrypt';
@@ -136,6 +137,7 @@ registerStatsRoutes(app);
   // HOW its children fail rather than how much they score.
   registerMisconceptionRoutes(app);
   registerCurriculumRoutes(app);
+  registerQuestionBankRoutes(app);
 
   // --- Intervention Tracking & Best Practices Repository ---
 

--- a/backend/src/routes/questionBank.ts
+++ b/backend/src/routes/questionBank.ts
@@ -1,0 +1,217 @@
+import express from 'express';
+import { dbStore, UserRole } from '../db';
+import { getAuthUser } from '../auth';
+
+/**
+ * Superadmin review of the existing question bank.
+ *
+ * Purpose: retire the 1-59 numbering WITHOUT a level-to-level crosswalk. Each
+ * concrete question is tagged with the 93-space level it actually assesses, so
+ * content is addressed by its own tag rather than by the level it came from.
+ * Once every question carries a tag, nothing needs to know what old level 41
+ * corresponded to.
+ *
+ * The bank covers old levels 22-59 only. Levels 1-21 are procedural generators
+ * with no stored questions, so they have nothing to tag and are mapped
+ * level-to-level instead — see the /legacy-levels endpoints below.
+ *
+ * Superadmin-only: which level a question belongs to is global curriculum
+ * content that feeds generation for every school, the same reasoning that keeps
+ * question-logic authoring restricted.
+ */
+function requireSuperadmin(req: express.Request, res: express.Response) {
+  const user = getAuthUser(req);
+  if (!user || user.role !== UserRole.SUPERADMIN) {
+    res.status(403).json({ error: 'Only superadmins can review the question bank.' });
+    return null;
+  }
+  return user;
+}
+
+/** The 93-space level a question is being mapped to must actually exist. */
+async function resolveTarget(levelNumber: number) {
+  return await dbStore.getCurriculumLevel(levelNumber);
+}
+
+export function registerQuestionBankRoutes(app: express.Express) {
+  /** Paged question list. Filter by legacy level, section type, review status. */
+  app.get('/api/question-bank', async (req, res) => {
+    if (!requireSuperadmin(req, res)) return;
+    try {
+      const { level, sectionType, status, limit, skip } = req.query;
+      const result = await dbStore.getQuestionBank({
+        level: level !== undefined ? Number(level) : undefined,
+        sectionType: sectionType ? String(sectionType) : undefined,
+        status: status ? (String(status) as any) : undefined,
+        limit: limit ? Math.min(Number(limit), 200) : 50,
+        skip: skip ? Number(skip) : 0,
+      });
+      res.json(result);
+    } catch (err: any) {
+      console.error('[question-bank] list failed:', err);
+      res.status(500).json({ error: 'Failed to read the question bank.' });
+    }
+  });
+
+  /** Review progress, and the shape of what is left. */
+  app.get('/api/question-bank/progress', async (req, res) => {
+    if (!requireSuperadmin(req, res)) return;
+    try {
+      res.json(await dbStore.getQuestionBankProgress());
+    } catch (err: any) {
+      console.error('[question-bank] progress failed:', err);
+      res.status(500).json({ error: 'Failed to compute review progress.' });
+    }
+  });
+
+  /**
+   * Map one question to a 93-space level, or retire it.
+   *
+   * Retiring keeps the row and marks it, rather than deleting: the decision
+   * that a question is not worth using is itself a curriculum judgement worth
+   * auditing, and it must be reversible. Readers filter on reviewStatus.
+   */
+  app.patch('/api/question-bank/:questionId', async (req, res) => {
+    const user = requireSuperadmin(req, res);
+    if (!user) return;
+    const { mappedLevel, reviewStatus, reviewNote } = req.body || {};
+
+    if (!['mapped', 'retired', 'untagged'].includes(reviewStatus)) {
+      return res.status(400).json({ error: 'reviewStatus must be "mapped", "retired" or "untagged".' });
+    }
+    try {
+      const existing = await dbStore.getQuestionBankEntry(req.params.questionId);
+      if (!existing) return res.status(404).json({ error: 'No such question in the bank.' });
+
+      const patch: any = { reviewStatus, reviewedBy: user.email, reviewNote };
+
+      if (reviewStatus === 'mapped') {
+        const target = await resolveTarget(Number(mappedLevel));
+        if (!target) {
+          return res.status(400).json({
+            error: `Level ${mappedLevel} is not a curriculum level. Valid levels are 1-93; ` +
+                   `if the collection is empty run "npm run seed:levels".`,
+          });
+        }
+        patch.mappedLevel = target.levelNumber;
+        // conceptId travels from the level, so the question inherits the same
+        // immutable identity student evidence already points at.
+        patch.conceptId = target.conceptId;
+      } else {
+        patch.mappedLevel = null;
+        patch.conceptId = undefined;
+      }
+
+      res.json(await dbStore.reviewQuestion(req.params.questionId, patch));
+    } catch (err: any) {
+      console.error('[question-bank] review failed:', err);
+      res.status(500).json({ error: 'Failed to save the review decision.' });
+    }
+  });
+
+  /**
+   * Apply one decision to a whole (level, section).
+   *
+   * The questions repeat heavily within a section — one legacy level's 48 items
+   * can be 48 variations of the same task — so reviewing them one at a time
+   * would be busywork rather than judgement.
+   */
+  app.post('/api/question-bank/bulk', async (req, res) => {
+    const user = requireSuperadmin(req, res);
+    if (!user) return;
+    const { level, section, sectionType, mappedLevel, reviewStatus } = req.body || {};
+
+    if (level === undefined || Number.isNaN(Number(level))) {
+      return res.status(400).json({ error: 'level is required.' });
+    }
+    if (!['mapped', 'retired', 'untagged'].includes(reviewStatus)) {
+      return res.status(400).json({ error: 'reviewStatus must be "mapped", "retired" or "untagged".' });
+    }
+    try {
+      const patch: any = { reviewStatus, reviewedBy: user.email };
+      if (reviewStatus === 'mapped') {
+        const target = await resolveTarget(Number(mappedLevel));
+        if (!target) return res.status(400).json({ error: `Level ${mappedLevel} is not a curriculum level (1-93).` });
+        patch.mappedLevel = target.levelNumber;
+        patch.conceptId = target.conceptId;
+      } else {
+        patch.mappedLevel = null;
+        patch.conceptId = undefined;
+      }
+      const result = await dbStore.reviewQuestionsBulk(
+        { level: Number(level), section, sectionType }, patch);
+      res.json(result);
+    } catch (err: any) {
+      console.error('[question-bank] bulk review failed:', err);
+      res.status(500).json({ error: 'Failed to apply the bulk decision.' });
+    }
+  });
+
+  /**
+   * The legacy levels that have NO questions to tag.
+   *
+   * The bank starts at old level 22. Levels 1-21 are procedural generators, so
+   * there is nothing to review question-by-question — they are mapped whole,
+   * onto one 93-space level each. This is the small residual crosswalk: 21 rows
+   * rather than 59, and the 21 easiest ones.
+   */
+  app.get('/api/question-bank/legacy-levels', async (req, res) => {
+    if (!requireSuperadmin(req, res)) return;
+    try {
+      const progress = await dbStore.getQuestionBankProgress();
+      const inBank = new Set(progress.legacyLevelsInBank);
+      const levels = await dbStore.getCurriculumLevels();
+      const mappedByLegacy = new Map(levels.filter(l => l.legacyLevel59 !== null).map(l => [l.legacyLevel59, l]));
+      const rows = [];
+      for (let legacyId = 1; legacyId <= 59; legacyId++) {
+        if (inBank.has(legacyId)) continue;
+        const target = mappedByLegacy.get(legacyId);
+        rows.push({
+          legacyId,
+          hasQuestions: false,
+          mappedLevel: target ? target.levelNumber : null,
+          mappedCapability: target ? target.capability : null,
+        });
+      }
+      res.json({ rows, note: 'These legacy levels have no stored questions — map the level itself.' });
+    } catch (err: any) {
+      console.error('[question-bank] legacy-levels failed:', err);
+      res.status(500).json({ error: 'Failed to read the unmapped legacy levels.' });
+    }
+  });
+
+  /** Map a question-less legacy level onto one 93-space level. */
+  app.patch('/api/question-bank/legacy-levels/:legacyId', async (req, res) => {
+    const user = requireSuperadmin(req, res);
+    if (!user) return;
+    const legacyId = Number(req.params.legacyId);
+    const { mappedLevel } = req.body || {};
+    if (!Number.isInteger(legacyId) || legacyId < 1 || legacyId > 59) {
+      return res.status(400).json({ error: 'legacyId must be an integer between 1 and 59.' });
+    }
+    try {
+      if (mappedLevel === null) {
+        await dbStore.setCurriculumLegacyMapping(null, legacyId);
+        return res.json({ legacyId, mappedLevel: null });
+      }
+      const target = await resolveTarget(Number(mappedLevel));
+      if (!target) return res.status(400).json({ error: `Level ${mappedLevel} is not a curriculum level (1-93).` });
+
+      // One legacy level cannot feed two 93-space levels: the seeder aborts on
+      // exactly this collision rather than picking a winner, so refuse it here
+      // too instead of writing a state the seed would later reject.
+      const clash = await dbStore.getCurriculumLevelByLegacy59(legacyId);
+      if (clash && clash.levelNumber !== target.levelNumber) {
+        return res.status(409).json({
+          error: `Legacy level ${legacyId} is already mapped to L${clash.levelNumber} (${clash.capability}). ` +
+                 `Clear that mapping first if it should move to L${target.levelNumber}.`,
+        });
+      }
+      await dbStore.setCurriculumLegacyMapping(target.levelNumber, legacyId);
+      res.json({ legacyId, mappedLevel: target.levelNumber, mappedCapability: target.capability });
+    } catch (err: any) {
+      console.error('[question-bank] legacy mapping failed:', err);
+      res.status(500).json({ error: 'Failed to save the legacy level mapping.' });
+    }
+  });
+}

--- a/backend/src/seedQuestionBank.ts
+++ b/backend/src/seedQuestionBank.ts
@@ -3,10 +3,25 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { MongoClient } from 'mongodb';
+import { questionBankId } from './db';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const QUESTION_BANK_PATH = path.join(__dirname, '../../data/questionBank.json');
 
+/**
+ * Seed the question bank WITHOUT destroying review work.
+ *
+ * This used to be `deleteMany({})` followed by `insertMany`. That was safe only
+ * while nothing on a question was human-authored. Now a superadmin maps each
+ * question to a 93-space level, and a wipe-and-reinsert would throw all of that
+ * away — silently, and with no way to recover it, because the Mongo _ids rotate
+ * too.
+ *
+ * So: upsert on the stable `questionId`. Content fields are `$set` (the JSON
+ * file stays the source of truth for the question itself), review fields are
+ * `$setOnInsert` (a human is the source of truth for those, and re-running this
+ * must never overwrite them). Same division of authority as seedCurriculumLevels.
+ */
 async function seed() {
   const uri = process.env.MONGODB_URI;
   if (!uri) {
@@ -14,38 +29,78 @@ async function seed() {
     process.exit(1);
   }
 
-  const questions = JSON.parse(fs.readFileSync(QUESTION_BANK_PATH, 'utf-8'));
-  console.log(`Loaded ${questions.length} questions from questionBank.json`);
+  const raw = JSON.parse(fs.readFileSync(QUESTION_BANK_PATH, 'utf-8'));
+  console.log(`Loaded ${raw.length} questions from questionBank.json`);
+
+  // Identity must be unique or an upsert would merge two distinct questions
+  // into one row. Verified unique over the shipped file; re-checked here
+  // because the file can change.
+  const seen = new Map<string, any>();
+  const collisions: string[] = [];
+  for (const q of raw) {
+    const id = questionBankId(q.level, q.section, q.questionNumber);
+    if (seen.has(id)) collisions.push(id);
+    seen.set(id, q);
+  }
+  if (collisions.length > 0) {
+    console.error(
+      `ABORT: ${collisions.length} question(s) share an id, so upserting would merge distinct questions.\n` +
+      `First few: ${collisions.slice(0, 5).join(', ')}\n` +
+      `Identity is (level, section, questionNumber) — fix the duplicates in questionBank.json.`
+    );
+    process.exit(1);
+  }
 
   const client = new MongoClient(uri);
   await client.connect();
-  const db = client.db();
+  const collection = client.db().collection('questionBank');
 
-  const collection = db.collection('questionBank');
-
-  await collection.deleteMany({});
-  console.log('Cleared existing questionBank collection');
-
-  if (questions.length > 0) {
-    await collection.insertMany(questions);
-    console.log(`Inserted ${questions.length} questions`);
-  }
-
+  await collection.createIndex({ questionId: 1 }, { unique: true });
   await collection.createIndex({ level: 1 });
   await collection.createIndex({ level: 1, sectionType: 1 });
-  console.log('Created indexes on level, sectionType');
+  await collection.createIndex({ reviewStatus: 1 });
 
-  const byLevel: Record<number, number> = {};
-  for (const q of questions) {
-    byLevel[q.level] = (byLevel[q.level] || 0) + 1;
-  }
-  console.log('\nQuestions per level:');
-  for (const [lvl, count] of Object.entries(byLevel).sort((a, b) => Number(a[0]) - Number(b[0]))) {
-    console.log(`  Level ${lvl}: ${count}`);
-  }
+  const ops = [...seen.entries()].map(([questionId, q]) => ({
+    updateOne: {
+      filter: { questionId },
+      update: {
+        $set: {
+          level: Number(q.level),
+          levelTitle: q.levelTitle,
+          section: q.section,
+          sectionType: q.sectionType,
+          questionNumber: Number(q.questionNumber),
+          questionText: q.questionText,
+          answer: q.answer,
+          svgHtml: q.svgHtml,
+        },
+        $setOnInsert: {
+          questionId,
+          mappedLevel: null,
+          reviewStatus: 'untagged',
+        },
+      },
+      upsert: true,
+    },
+  }));
+
+  const result = await collection.bulkWrite(ops, { ordered: false });
+  const inserted = result.upsertedCount;
+  const updated = result.modifiedCount;
+
+  const total = await collection.countDocuments();
+  const mapped = await collection.countDocuments({ reviewStatus: 'mapped' });
+  const retired = await collection.countDocuments({ reviewStatus: 'retired' });
+  const untagged = await collection.countDocuments({ reviewStatus: 'untagged' });
+
+  console.log(`\nquestionBank: ${inserted} inserted, ${updated} updated (content refreshed)`);
+  console.log(`  total in collection:  ${total}`);
+  console.log(`  mapped by a human:    ${mapped}   (preserved — never touched by this script)`);
+  console.log(`  retired by a human:   ${retired}   (preserved)`);
+  console.log(`  awaiting review:      ${untagged}`);
 
   await client.close();
-  console.log('\nDone!');
+  console.log('\nDone.');
 }
 
-seed().catch(console.error);
+seed().catch((err) => { console.error(err); process.exit(1); });

--- a/frontend/src/components/dashboards/SuperadminDashboard.tsx
+++ b/frontend/src/components/dashboards/SuperadminDashboard.tsx
@@ -11,12 +11,13 @@ import { SuperAdminExecutiveDashboard } from '../SuperAdminExecutiveDashboard';
 import { RegionalAnalyticsView } from './RegionalAnalyticsView';
 import { QuestionInterventionPanel } from '../panels/QuestionInterventionPanel';
 import { CurriculumLevelsPanel } from '../panels/CurriculumLevelsPanel';
+import { QuestionReviewPanel } from '../panels/QuestionReviewPanel';
 
 export type { DashboardProps };
 
 
 export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) => {
-  const [activeTab, setActiveTab] = useState<'overview' | 'coordinators' | 'analytics' | 'intervention' | 'curriculum'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'coordinators' | 'analytics' | 'intervention' | 'curriculum' | 'qreview'>('overview');
   
   // Overview data
   const [schools, setSchools] = useState<School[]>([]);
@@ -309,6 +310,14 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
             }`}
           >
             🎯 Curriculum Levels
+          </button>
+          <button
+            onClick={() => setActiveTab('qreview')}
+            className={`px-3 py-1.5 text-xs font-semibold rounded-lg transition-all ${
+              activeTab === 'qreview' ? 'bg-white dark:bg-zinc-700 text-zinc-900 dark:text-white shadow-sm' : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white'
+            }`}
+          >
+            📝 Question Review
           </button>
         </div>
 
@@ -685,6 +694,10 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
 
       {activeTab === 'curriculum' && (
         <CurriculumLevelsPanel />
+      )}
+
+      {activeTab === 'qreview' && (
+        <QuestionReviewPanel />
       )}
     </div>
   );

--- a/frontend/src/components/panels/QuestionReviewPanel.tsx
+++ b/frontend/src/components/panels/QuestionReviewPanel.tsx
@@ -1,0 +1,346 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ClipboardList, Check, Ban, Layers, AlertTriangle } from 'lucide-react';
+import { apiFetch } from '../../services/apiClient';
+import type {
+  QuestionBankEntry, QuestionBankProgress, QuestionReviewStatus,
+  LegacyLevelRow, CurriculumLevel,
+} from '../../types';
+
+/**
+ * Superadmin review of the existing question bank.
+ *
+ * This is how the retired 1-59 numbering gets dropped WITHOUT a level-to-level
+ * crosswalk. Every stored question is tagged with the 93-space level it really
+ * assesses, so content is found by its own tag rather than by the level it came
+ * from. Once everything carries a tag, nothing needs to know what old level 41
+ * meant.
+ *
+ * Two kinds of work, because the source data has two shapes:
+ *  - Old levels 22-59 have real stored questions → tag them (in bulk per
+ *    section, since one level's 48 items are often 48 variations of one task).
+ *  - Old levels 1-21 are procedural generators with nothing stored → there is
+ *    no question to judge, so the level itself is mapped, once.
+ */
+
+const STATUS_STYLE: Record<QuestionReviewStatus, string> = {
+  untagged: 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700',
+  mapped: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-300 dark:border-emerald-800',
+  retired: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-300 dark:border-amber-800',
+};
+
+const PAGE = 25;
+
+export const QuestionReviewPanel: React.FC = () => {
+  const [tab, setTab] = useState<'questions' | 'levels'>('questions');
+  const [levels, setLevels] = useState<CurriculumLevel[]>([]);
+  const [progress, setProgress] = useState<QuestionBankProgress | null>(null);
+  const [items, setItems] = useState<QuestionBankEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [legacyRows, setLegacyRows] = useState<LegacyLevelRow[]>([]);
+  const [levelFilter, setLevelFilter] = useState<number | ''>('');
+  const [statusFilter, setStatusFilter] = useState<QuestionReviewStatus | ''>('untagged');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [bulkTarget, setBulkTarget] = useState<number | ''>('');
+
+  const loadProgress = useCallback(async () => {
+    const [pRes, lRes] = await Promise.all([
+      apiFetch('/api/question-bank/progress'),
+      apiFetch('/api/curriculum/levels'),
+    ]);
+    if (pRes.ok) setProgress(await pRes.json());
+    if (lRes.ok) setLevels(await lRes.json());
+  }, []);
+
+  const loadQuestions = useCallback(async () => {
+    const params = new URLSearchParams({ limit: String(PAGE), skip: String(page * PAGE) });
+    if (levelFilter !== '') params.set('level', String(levelFilter));
+    if (statusFilter) params.set('status', statusFilter);
+    const res = await apiFetch(`/api/question-bank?${params}`);
+    if (!res.ok) throw new Error(`Could not load questions (${res.status})`);
+    const data = await res.json();
+    setItems(data.items);
+    setTotal(data.total);
+  }, [page, levelFilter, statusFilter]);
+
+  const loadLegacy = useCallback(async () => {
+    const res = await apiFetch('/api/question-bank/legacy-levels');
+    if (res.ok) setLegacyRows((await res.json()).rows);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await Promise.all([loadProgress(), loadQuestions(), loadLegacy()]);
+        if (!cancelled) setError(null);
+      } catch (err: any) {
+        if (!cancelled) setError(err?.message || 'Could not load the question bank.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [loadProgress, loadQuestions, loadLegacy]);
+
+  const decide = async (q: QuestionBankEntry, reviewStatus: QuestionReviewStatus, mappedLevel?: number) => {
+    setBusy(q.questionId);
+    try {
+      const res = await apiFetch(`/api/question-bank/${encodeURIComponent(q.questionId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reviewStatus, mappedLevel }),
+      });
+      if (!res.ok) { setError((await res.json()).error || 'Could not save that decision.'); return; }
+      setError(null);
+      await Promise.all([loadQuestions(), loadProgress()]);
+    } finally { setBusy(null); }
+  };
+
+  const bulkAssign = async () => {
+    if (levelFilter === '' || bulkTarget === '') return;
+    const count = items.length;
+    if (!window.confirm(
+      `Map every question in old level ${levelFilter} to L${bulkTarget}?\n\n` +
+      `This applies to all ${total} question(s) matching the current filter, not just the ${count} on screen.`
+    )) return;
+    setBusy('bulk');
+    try {
+      const res = await apiFetch('/api/question-bank/bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ level: levelFilter, reviewStatus: 'mapped', mappedLevel: bulkTarget }),
+      });
+      if (!res.ok) { setError((await res.json()).error || 'Bulk assignment failed.'); return; }
+      setError(null);
+      await Promise.all([loadQuestions(), loadProgress()]);
+    } finally { setBusy(null); }
+  };
+
+  const mapLegacy = async (legacyId: number, mappedLevel: number | null) => {
+    setBusy(`legacy-${legacyId}`);
+    try {
+      const res = await apiFetch(`/api/question-bank/legacy-levels/${legacyId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mappedLevel }),
+      });
+      if (!res.ok) { setError((await res.json()).error || 'Could not map that level.'); return; }
+      setError(null);
+      await Promise.all([loadLegacy(), loadProgress()]);
+    } finally { setBusy(null); }
+  };
+
+  const bankLevels = useMemo(() => progress?.legacyLevelsInBank ?? [], [progress]);
+  const pages = Math.ceil(total / PAGE);
+
+  if (loading) return <div className="p-6 text-slate-500 dark:text-zinc-400">Loading the question bank…</div>;
+
+  return (
+    <div className="p-6 space-y-5">
+      <header className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="text-xl font-bold text-slate-800 dark:text-white flex items-center gap-2">
+            <ClipboardList className="w-5 h-5 text-violet-600" />
+            Question Review
+          </h2>
+          <p className="text-sm text-slate-500 dark:text-zinc-400 mt-1">
+            Tag every existing question with the curriculum level it actually assesses.
+          </p>
+        </div>
+        {progress && (
+          <div className="flex gap-2 flex-wrap text-sm">
+            <div className="px-3 py-2 rounded-lg border bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-300 dark:border-emerald-800">
+              <b className="text-lg">{progress.mapped}</b> mapped
+            </div>
+            <div className="px-3 py-2 rounded-lg border bg-slate-100 text-slate-600 border-slate-200 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700">
+              <b className="text-lg">{progress.untagged}</b> to review
+            </div>
+            <div className="px-3 py-2 rounded-lg border bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-300 dark:border-amber-800">
+              <b className="text-lg">{progress.retired}</b> retired
+            </div>
+            <div className="px-3 py-2 rounded-lg border bg-violet-50 text-violet-700 border-violet-200 dark:bg-violet-950 dark:text-violet-300 dark:border-violet-800">
+              <b className="text-lg">{progress.targetLevelsCovered.length}</b> / 93 levels have content
+            </div>
+          </div>
+        )}
+      </header>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950 dark:border-red-800 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="flex gap-1 border-b border-slate-200 dark:border-zinc-700">
+        {([['questions', `Questions (${progress?.total ?? 0})`], ['levels', `Levels with no questions (${legacyRows.length})`]] as const).map(([id, label]) => (
+          <button key={id} onClick={() => setTab(id)}
+            className={`px-4 py-2 text-sm font-semibold border-b-2 -mb-px ${
+              tab === id
+                ? 'border-violet-600 text-violet-700 dark:text-violet-300'
+                : 'border-transparent text-slate-500 dark:text-zinc-400 hover:text-slate-800 dark:hover:text-white'
+            }`}>{label}</button>
+        ))}
+      </div>
+
+      {tab === 'questions' && (
+        <>
+          <div className="flex gap-3 flex-wrap items-center">
+            <select value={levelFilter} onChange={(e) => { setPage(0); setLevelFilter(e.target.value === '' ? '' : Number(e.target.value)); }}
+              className="border border-slate-300 rounded-lg px-3 py-2 text-sm dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100">
+              <option value="">All source levels</option>
+              {bankLevels.map((l) => <option key={l} value={l}>Old level {l}</option>)}
+            </select>
+            <select value={statusFilter} onChange={(e) => { setPage(0); setStatusFilter(e.target.value as QuestionReviewStatus | ''); }}
+              className="border border-slate-300 rounded-lg px-3 py-2 text-sm dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100">
+              <option value="">Any status</option>
+              <option value="untagged">To review</option>
+              <option value="mapped">Mapped</option>
+              <option value="retired">Retired</option>
+            </select>
+            <span className="text-sm text-slate-500 dark:text-zinc-400">{total} question{total === 1 ? '' : 's'}</span>
+
+            {levelFilter !== '' && (
+              <div className="ml-auto flex gap-2 items-center">
+                <select value={bulkTarget} onChange={(e) => setBulkTarget(e.target.value === '' ? '' : Number(e.target.value))}
+                  className="border border-slate-300 rounded-lg px-3 py-2 text-sm dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100">
+                  <option value="">Map all {total} to…</option>
+                  {levels.map((l) => <option key={l.levelNumber} value={l.levelNumber}>L{l.levelNumber} — {l.capability}</option>)}
+                </select>
+                <button onClick={bulkAssign} disabled={bulkTarget === '' || busy === 'bulk'}
+                  className="px-3 py-2 rounded-lg text-sm font-semibold bg-violet-600 text-white disabled:opacity-40">
+                  {busy === 'bulk' ? 'Applying…' : 'Apply to all'}
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            {items.length === 0 && (
+              <p className="text-sm text-slate-500 dark:text-zinc-400 py-8 text-center">
+                Nothing matches this filter.
+              </p>
+            )}
+            {items.map((q) => (
+              <article key={q.questionId}
+                className="border border-slate-200 dark:border-zinc-700 rounded-lg p-4 bg-white dark:bg-zinc-900 grid md:grid-cols-[1fr_320px] gap-4">
+                <div className="min-w-0">
+                  <div className="flex gap-2 items-center flex-wrap text-xs mb-2">
+                    <span className="font-mono text-slate-400 dark:text-zinc-500">old L{q.level}</span>
+                    <span className="text-slate-500 dark:text-zinc-400">{q.section}</span>
+                    <span className={`px-2 py-0.5 rounded border ${STATUS_STYLE[q.reviewStatus ?? 'untagged']}`}>
+                      {q.reviewStatus === 'mapped' ? `L${q.mappedLevel}` : q.reviewStatus ?? 'untagged'}
+                    </span>
+                  </div>
+                  <p className="text-sm text-slate-800 dark:text-zinc-100 break-words">{q.questionText}</p>
+                  <p className="text-sm mt-1">
+                    <span className="text-slate-500 dark:text-zinc-400">Answer: </span>
+                    <code className="font-mono text-emerald-700 dark:text-emerald-300">{q.answer}</code>
+                  </p>
+                  {q.svgHtml && (
+                    <div className="mt-2 overflow-x-auto border border-slate-100 dark:border-zinc-800 rounded p-2 bg-white"
+                      dangerouslySetInnerHTML={{ __html: q.svgHtml }} />
+                  )}
+                </div>
+                <div className="flex flex-col gap-2">
+                  <select
+                    value={q.mappedLevel ?? ''}
+                    onChange={(e) => e.target.value !== '' && decide(q, 'mapped', Number(e.target.value))}
+                    disabled={busy === q.questionId}
+                    className="border border-slate-300 rounded-lg px-2 py-1.5 text-sm dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100">
+                    <option value="">Assign a level…</option>
+                    {levels.map((l) => <option key={l.levelNumber} value={l.levelNumber}>L{l.levelNumber} — {l.capability}</option>)}
+                  </select>
+                  <div className="flex gap-2">
+                    <button onClick={() => decide(q, 'retired')} disabled={busy === q.questionId}
+                      className="flex-1 px-2 py-1.5 rounded-lg border border-amber-300 text-amber-700 text-sm font-medium dark:border-amber-800 dark:text-amber-300 disabled:opacity-40">
+                      <Ban className="w-3.5 h-3.5 inline mr-1" />Retire
+                    </button>
+                    {q.reviewStatus !== 'untagged' && (
+                      <button onClick={() => decide(q, 'untagged')} disabled={busy === q.questionId}
+                        className="px-2 py-1.5 rounded-lg border border-slate-300 text-slate-600 text-sm dark:border-zinc-700 dark:text-zinc-300 disabled:opacity-40">
+                        Undo
+                      </button>
+                    )}
+                  </div>
+                  {q.reviewedBy && (
+                    <p className="text-xs text-slate-400 dark:text-zinc-500">Decided by {q.reviewedBy}</p>
+                  )}
+                </div>
+              </article>
+            ))}
+          </div>
+
+          {pages > 1 && (
+            <div className="flex gap-2 items-center justify-center pt-2">
+              <button onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0}
+                className="px-3 py-1.5 rounded-lg border border-slate-300 text-sm dark:border-zinc-700 dark:text-zinc-200 disabled:opacity-40">Previous</button>
+              <span className="text-sm text-slate-500 dark:text-zinc-400">Page {page + 1} of {pages}</span>
+              <button onClick={() => setPage((p) => Math.min(pages - 1, p + 1))} disabled={page >= pages - 1}
+                className="px-3 py-1.5 rounded-lg border border-slate-300 text-sm dark:border-zinc-700 dark:text-zinc-200 disabled:opacity-40">Next</button>
+            </div>
+          )}
+        </>
+      )}
+
+      {tab === 'levels' && (
+        <>
+          <div className="rounded-lg border border-sky-200 bg-sky-50 p-4 text-sm text-sky-900 dark:bg-sky-950 dark:border-sky-800 dark:text-sky-200 flex gap-3">
+            <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5" />
+            <p>
+              These {legacyRows.length} old levels build their questions on the fly, so there is nothing stored to
+              review one by one. Map the level itself instead — whatever it generates then belongs to the level you choose.
+            </p>
+          </div>
+          <div className="overflow-x-auto border border-slate-200 dark:border-zinc-700 rounded-lg">
+            <table className="min-w-full text-sm">
+              <thead className="bg-slate-50 dark:bg-zinc-800 text-slate-600 dark:text-zinc-300">
+                <tr>
+                  <th className="text-left px-4 py-2.5 font-semibold">Old level</th>
+                  <th className="text-left px-4 py-2.5 font-semibold">Mapped to</th>
+                  <th className="text-left px-4 py-2.5 font-semibold">Assign</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-zinc-800">
+                {legacyRows.map((row) => (
+                  <tr key={row.legacyId} className="hover:bg-slate-50 dark:hover:bg-zinc-800/60">
+                    <td className="px-4 py-2.5 font-mono font-bold text-slate-800 dark:text-white">L{row.legacyId}</td>
+                    <td className="px-4 py-2.5">
+                      {row.mappedLevel
+                        ? <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded border text-xs bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-300 dark:border-emerald-800">
+                            <Check className="w-3.5 h-3.5" />L{row.mappedLevel} — {row.mappedCapability}
+                          </span>
+                        : <span className="text-slate-400 dark:text-zinc-500">Not mapped</span>}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <div className="flex gap-2 items-center">
+                        <select value={row.mappedLevel ?? ''}
+                          onChange={(e) => mapLegacy(row.legacyId, e.target.value === '' ? null : Number(e.target.value))}
+                          disabled={busy === `legacy-${row.legacyId}`}
+                          className="border border-slate-300 rounded-lg px-2 py-1.5 text-sm dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100">
+                          <option value="">Choose a level…</option>
+                          {levels.map((l) => <option key={l.levelNumber} value={l.levelNumber}>L{l.levelNumber} — {l.capability}</option>)}
+                        </select>
+                        {row.mappedLevel && (
+                          <button onClick={() => mapLegacy(row.legacyId, null)} disabled={busy === `legacy-${row.legacyId}`}
+                            className="px-2 py-1.5 rounded-lg border border-slate-300 text-slate-600 text-xs dark:border-zinc-700 dark:text-zinc-300">Clear</button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      <p className="text-xs text-slate-400 dark:text-zinc-500 pt-2 flex items-center gap-1.5">
+        <Layers className="w-3.5 h-3.5" />
+        Decisions are kept when the question bank is re-seeded — re-running the seed refreshes question text only.
+      </p>
+    </div>
+  );
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -424,3 +424,42 @@ export interface CurriculumCoverage {
   /** False while no level has a legacyLevel59 — i.e. the crosswalk has not landed. */
   crosswalkLanded: boolean;
 }
+
+/** Review state of one question in the bank. */
+export type QuestionReviewStatus = 'untagged' | 'mapped' | 'retired';
+
+export interface QuestionBankEntry {
+  questionId: string;
+  level: number;
+  levelTitle: string;
+  section: string;
+  sectionType: string;
+  questionNumber: number;
+  questionText: string;
+  answer: string;
+  svgHtml: string;
+  mappedLevel?: number | null;
+  conceptId?: string;
+  reviewStatus?: QuestionReviewStatus;
+  reviewedBy?: string;
+  reviewedAt?: string;
+  reviewNote?: string;
+}
+
+export interface QuestionBankProgress {
+  total: number;
+  mapped: number;
+  retired: number;
+  untagged: number;
+  legacyLevelsInBank: number[];
+  targetLevelsCovered: number[];
+  byLevel: Array<{ level: number; total: number; mapped: number; retired: number }>;
+}
+
+/** A retired-numbering level with no stored questions — mapped whole, not per question. */
+export interface LegacyLevelRow {
+  legacyId: number;
+  hasQuestions: boolean;
+  mappedLevel: number | null;
+  mappedCapability: string | null;
+}


### PR DESCRIPTION
**Retires the 1–59 numbering by tagging content instead of mapping levels.**

## Why this replaces the crosswalk

The 59→93 crosswalk exists only because content is addressed *by level*. It has been blocked for weeks on a pedagogy ruling, and the auto-generated proposal is unusable — it maps 16 of 59 levels and pairs *Numbers 1-10* with *Reading & Writing 3-Digit Numbers* because both contain the word "numbers".

But there are already **1,202 concrete questions** in `data/questionBank.json`, each with text, answer and rendered SVG. And `QuestionBankEntry` has carried a `conceptId` field — documented as *"Immutable concept tag (S1.1 – S7.18)"* — since it was written. **None of the 1,202 were ever populated.**

Tag each question with the 93-space level it actually assesses, and no level-to-level mapping is needed at all: content is found by its own tag, and the 59 space simply stops being referenced.

## Two shapes of work, because the data has two

| Old levels | What exists | How it's reviewed |
|---|---|---|
| **22–59** | 1,202 stored questions | Review and tag — in bulk per section, since one level's 48 items are often 48 variations of one task |
| **1–21** | Procedural generators, nothing stored | No question to judge, so the **level itself** is mapped, once. 21 rows, and the easiest ones |

## The trap that had to be closed first

`seedQuestionBank` did `deleteMany({})` + `insertMany`, and `QuestionBankEntry` had **no stable id**. A superadmin could tag 400 questions and lose every one of them to the next `npm run seed:question-bank` — silently and unrecoverably, since the Mongo `_id`s rotate too.

Questions now carry a deterministic `questionId` from `(level, section, questionNumber)`, verified unique across all 1,202. Deliberately **not** derived from the question text: 314 questions share their text with another, and fixing a typo must not orphan a reviewer's mapping. The seeder upserts — `$set` for content, `$setOnInsert` for review state — the same division of authority as `seedCurriculumLevels`.

Proven, not assumed:

```
mapped 45 questions  ->  re-ran seed:question-bank  ->
  questionBank: 0 inserted, 0 updated
  mapped by a human:  45   (preserved)
  retired by a human:  1   (preserved)
```

**Retiring marks the row rather than deleting it.** Judging a question not worth using is itself a curriculum decision — it stays auditable and reversible, and readers filter on `reviewStatus`.

## Endpoints

`GET /api/question-bank` (paged, filter by level / sectionType / status) · `GET /api/question-bank/progress` · `PATCH /api/question-bank/:questionId` · `POST /api/question-bank/bulk` · `GET /api/question-bank/legacy-levels` · `PATCH /api/question-bank/legacy-levels/:legacyId`

Superadmin-only — which level a question belongs to is global curriculum content feeding generation for every school, the same reasoning that gates question-logic authoring. Mapping a question inherits the target level's `conceptId`, so it points at the same immutable identity student evidence already uses.

Mapping a legacy level returns **409** if that legacy id is already claimed by another 93-level, rather than writing a state `seed:levels` would later abort on.

## Verification

**20 API tests** against a scratch MongoDB seeded with all 1,202 real questions: auth (403 unauthenticated), filters, single and bulk mapping, retire, progress, legacy-level mapping — plus rejection of an unknown level, a bad status, an unknown question, a `legacyId` outside 1–59, and a second mapping onto an already-claimed legacy level.

**Panel driven in a real browser end-to-end:** logged in, opened the tab, assigned a level from the dropdown, watched progress move 45 → 46, **reloaded the page and confirmed it came back from the database**. 25 cards render with their SVGs; both tabs work; no page errors; dark mode handled from the start.

## What this does not solve

**The ≥34 levels with no ancestor still have no content.** 59 old levels can cover at most 59 of 93, and tagging cannot create questions for levels nothing covers. That authoring project is untouched by this and no mapping approach removes it — but this panel makes the gap visible and precise, since `n / 93 levels have content` is now driven by real tagged questions.

**Note for deploy:** production needs `npm run seed:question-bank` if `db.questionBank.countDocuments()` is 0 — I could not check that from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ryfSeYFQfUTUPvixGTjXA