### PR TITLE
fix(seed): migrate question-bank rows written before questionId existed

### DIFF
--- a/backend/src/seedQuestionBank.ts
+++ b/backend/src/seedQuestionBank.ts
@@ -55,6 +55,39 @@ async function seed() {
   await client.connect();
   const collection = client.db().collection('questionBank');
 
+  // Migrate rows seeded before questionId existed.
+  //
+  // The previous seeder wrote rows with no stable id, so an existing
+  // deployment has 1202 of them with `questionId` unset. The unique index
+  // below would then fail to build with a bare
+  //   E11000 duplicate key ... dup key: { questionId: null }
+  // which stops the deploy with nothing an operator can act on.
+  //
+  // Those rows are safe to drop: they predate review state entirely, so they
+  // carry no human decision to lose, and every one of them is re-inserted from
+  // the JSON immediately below with a proper id. Anything that DOES carry a
+  // decision has a questionId by definition and is left alone.
+  const legacyRows = await collection.countDocuments({ questionId: { $exists: false } });
+  if (legacyRows > 0) {
+    const withDecisions = await collection.countDocuments({
+      questionId: { $exists: false },
+      reviewStatus: { $in: ['mapped', 'retired'] },
+    });
+    if (withDecisions > 0) {
+      console.error(
+        `ABORT: ${withDecisions} row(s) carry a review decision but have no questionId. ` +
+        `That should be impossible — review state is only ever written alongside an id. ` +
+        `Refusing to delete a human decision; inspect the collection by hand.`
+      );
+      process.exit(1);
+    }
+    await collection.deleteMany({ questionId: { $exists: false } });
+    console.log(
+      `Migrated: removed ${legacyRows} row(s) seeded before questionId existed ` +
+      `(no review decisions on them; re-inserted below with stable ids).`
+    );
+  }
+
   await collection.createIndex({ questionId: 1 }, { unique: true });
   await collection.createIndex({ level: 1 });
   await collection.createIndex({ level: 1, sectionType: 1 });


### PR DESCRIPTION
**Deploy blocker for #423.** Found while preparing the production deploy.

#423 adds a unique index on `questionId`, but production already holds 1,202 rows seeded by the old script, which had no such field. The index build then fails:

```
E11000 duplicate key error ... index: questionId_1 dup key: { questionId: null }
```

It **fails safe** — nothing is corrupted, no duplicates are written, the seeder exits — but the message names neither the cause nor the fix, and it lands in the middle of a deploy.

## The fix

Detect those rows before building the index and remove them. They predate review state entirely, so they carry no human decision, and every one is re-inserted from the JSON moments later with a stable id.

**Guarded rather than assumed:** if any id-less row somehow carries a `mapped` or `retired` status, the seeder aborts instead of deleting it. That should be impossible — review state is only ever written alongside an id — but the entire point of this work is that a human's curriculum decisions are never silently destroyed by a seed script, so it refuses rather than trusting the invariant.

## Verified against a simulated pre-#423 collection

**A — migration is clean:**
```
Migrated: removed 2 row(s) seeded before questionId existed
questionBank: 1202 inserted, 0 updated
total: 1202   without id: 0   duplicates of L22/Mastery/q1: 1
```

**B — review work still survives a later re-seed:**
```
mapped before: 1  ->  re-seed  ->  mapped by a human: 1 (preserved)
```

**C — refuses to delete a decision:**
```
ABORT: 1 row(s) carry a review decision but have no questionId.
Refusing to delete a human decision; inspect the collection by hand.
row still present: 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ryfSeYFQfUTUPvixGTjXA