### PR TITLE
fix(login): stop publishing working demo credentials on the public login page

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,16 @@
+# Frontend build-time configuration (Vite).
+# Copy to .env.local for local development. Never commit a real .env.local.
+
+# --- Demo sign-in cards -------------------------------------------------------
+# Renders one-click sample-role buttons on the login page. Intended for local
+# development and demo builds ONLY.
+#
+# Both variables are required together. With the flag on but no password set,
+# nothing renders — a partial config cannot fall back to a built-in credential.
+#
+# Leave BOTH unset for any build that will be deployed. When unset, the panel and
+# the sample account addresses are dropped from the bundle at build time rather
+# than merely hidden at runtime.
+#
+# VITE_ENABLE_DEMO_LOGINS=true
+# VITE_DEMO_LOGIN_PASSWORD=<the password for your local seeded accounts>

--- a/frontend/src/components/DemoLoginPanel.tsx
+++ b/frontend/src/components/DemoLoginPanel.tsx
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+/**
+ * One-click demo sign-in cards.
+ *
+ * This lives in its own module and is loaded lazily so that neither the sample
+ * account addresses nor the panel markup end up in a production bundle. An
+ * earlier version of this panel shipped to production and published a working
+ * Superadmin credential on the public login page; keeping it out of the main
+ * chunk means a future edit cannot reintroduce that by accident.
+ *
+ * Rendered only when VITE_ENABLE_DEMO_LOGINS === 'true' AND
+ * VITE_DEMO_LOGIN_PASSWORD is set. See LoginView.
+ */
+
+interface DemoLoginPanelProps {
+  password: string;
+  onSelect: (email: string, password: string) => void;
+}
+
+const DEMO_ACCOUNTS = [
+  { label: 'Superadmin 🌐', email: 'superadmin@fln.org' },
+  { label: 'Punjab Admin 🌾', email: 'admin.pb@fln.org' },
+  { label: 'Haryana Admin 🌾', email: 'admin.hr@fln.org' },
+  { label: 'UP Admin 🏛️', email: 'admin.up@fln.org' },
+  { label: 'Rajasthan Admin 🏰', email: 'admin.rj@fln.org' },
+  { label: 'Ludhiana Dist 🏢', email: 'district.ldh@fln.org' },
+  { label: 'Ambala Dist 🏢', email: 'district.amb@fln.org' },
+  { label: 'Ludhiana Block 🏫', email: 'block.ldh_01@fln.org' },
+  { label: 'Punjab Principal 🎓', email: 'school.pb_ldh_ldh_01_01@fln.org' },
+  { label: 'Haryana Teacher 👩‍🏫', email: 'teacher.hr_amb_amb_01_01.c2@fln.org' },
+  { label: 'Punjab Volunteer 🤝', email: 'vol.pb_ldh_ldh_01_03@fln.org' },
+  { label: 'Haryana Volunteer 🤝', email: 'vol.hr_amb_amb_01_03@fln.org' }
+];
+
+const DemoLoginPanel: React.FC<DemoLoginPanelProps> = ({ password, onSelect }) => (
+  <div className="mt-8 border-t-2 border-slate-100 dark:border-slate-800 pt-5">
+    <p className="text-[10px] font-extrabold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2.5">
+      Demo build — sample roles
+    </p>
+    <div className="grid grid-cols-2 gap-2 text-[10px]">
+      {DEMO_ACCOUNTS.map(u => (
+        <button
+          key={u.email}
+          onClick={() => onSelect(u.email, password)}
+          className="rounded-lg bg-slate-50 dark:bg-slate-800 p-2 text-left border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 transition hover:bg-amber-50/70 dark:hover:bg-amber-950/40 hover:border-amber-300 dark:hover:border-amber-800 hover:text-indigo-700 dark:hover:text-amber-400 cursor-pointer"
+        >
+          <div className="font-extrabold truncate text-slate-900 dark:text-white">
+            {u.label}
+          </div>
+          <div className="truncate text-slate-400 dark:text-slate-500 text-[9px]">{u.email}</div>
+        </button>
+      ))}
+    </div>
+  </div>
+);
+
+export default DemoLoginPanel;

--- a/frontend/src/components/LoginView.tsx
+++ b/frontend/src/components/LoginView.tsx
@@ -4,9 +4,19 @@ import { apiFetch } from '../services/apiClient';
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
+import React, { Suspense, lazy, useState } from 'react';
 import { Eye, EyeOff, AlertCircle, ArrowLeft } from 'lucide-react';
 import { User, UserRole } from '../types';
+
+// Loaded only in an explicitly-flagged demo build — see DemoLoginPanel.
+// The ternary is deliberate: Vite substitutes the env literal at build time, so in
+// a normal build this folds to `null` and Rollup drops the dynamic import
+// altogether. A plain `lazy(() => import(...))` would still emit the chunk as a
+// fetchable file even though nothing renders it.
+const DemoLoginPanel =
+  import.meta.env.VITE_ENABLE_DEMO_LOGINS === 'true'
+    ? lazy(() => import('./DemoLoginPanel'))
+    : null;
 
 interface LoginViewProps {
   onLoginSuccess: (token: string, user: User) => void;
@@ -20,20 +30,18 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const mockUsersList = [
-    { label: 'Superadmin 🌐', email: 'superadmin@fln.org', pass: 'Fln@2026' },
-    { label: 'Punjab Admin 🌾', email: 'admin.pb@fln.org', pass: 'Fln@2026' },
-    { label: 'Haryana Admin 🌾', email: 'admin.hr@fln.org', pass: 'Fln@2026' },
-    { label: 'UP Admin 🏛️', email: 'admin.up@fln.org', pass: 'Fln@2026' },
-    { label: 'Rajasthan Admin 🏰', email: 'admin.rj@fln.org', pass: 'Fln@2026' },
-    { label: 'Ludhiana Dist 🏢', email: 'district.ldh@fln.org', pass: 'Fln@2026' },
-    { label: 'Ambala Dist 🏢', email: 'district.amb@fln.org', pass: 'Fln@2026' },
-    { label: 'Ludhiana Block 🏫', email: 'block.ldh_01@fln.org', pass: 'Fln@2026' },
-    { label: 'Punjab Principal 🎓', email: 'school.pb_ldh_ldh_01_01@fln.org', pass: 'Fln@2026' },
-    { label: 'Haryana Teacher 👩‍🏫', email: 'teacher.hr_amb_amb_01_01.c2@fln.org', pass: 'Fln@2026' },
-    { label: 'Punjab Volunteer 🤝', email: 'vol.pb_ldh_ldh_01_03@fln.org', pass: 'Fln@2026' },
-    { label: 'Haryana Volunteer 🤝', email: 'vol.hr_amb_amb_01_03@fln.org', pass: 'Fln@2026' }
-  ];
+  // Demo one-click sign-in cards. OFF unless VITE_ENABLE_DEMO_LOGINS is explicitly
+  // "true" at build time, because this panel previously shipped to production and
+  // published a working Superadmin credential on the public login page.
+  //
+  // The password is not hardcoded any more — it comes from
+  // VITE_DEMO_LOGIN_PASSWORD alongside the flag. A build with the flag on but no
+  // password set renders nothing, so a partial config cannot reveal the old value.
+  // The panel itself is a lazy import so the sample addresses stay out of the
+  // production bundle entirely.
+  const showDemoLogins =
+    import.meta.env.VITE_ENABLE_DEMO_LOGINS === 'true' &&
+    !!import.meta.env.VITE_DEMO_LOGIN_PASSWORD;
 
   const handleLogin = async (e?: React.FormEvent, customEmail?: string, customPass?: string) => {
     if (e) e.preventDefault();
@@ -150,26 +158,14 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLoginSuccess, onBackToHo
           </button>
         </form>
 
-        {/* Quick Credentials Panel for Mock Access */}
-        <div className="mt-8 border-t-2 border-slate-100 dark:border-slate-800 pt-5">
-          <p className="text-[10px] font-extrabold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-2.5">
-            Active System Roles for Demonstration (Password: Fln@2026)
-          </p>
-          <div className="grid grid-cols-2 gap-2 text-[10px]">
-            {mockUsersList.map(u => (
-              <button
-                key={u.email}
-                onClick={() => handleLogin(undefined, u.email, u.pass)}
-                className="rounded-lg bg-slate-50 dark:bg-slate-800 p-2 text-left border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 transition hover:bg-amber-50/70 dark:hover:bg-amber-950/40 hover:border-amber-300 dark:hover:border-amber-800 hover:text-indigo-700 dark:hover:text-amber-400 cursor-pointer"
-              >
-                <div className="font-extrabold truncate text-slate-900 dark:text-white">
-                  {u.label}
-                </div>
-                <div className="truncate text-slate-400 dark:text-slate-500 text-[9px]">{u.email}</div>
-              </button>
-            ))}
-          </div>
-        </div>
+        {showDemoLogins && DemoLoginPanel && (
+          <Suspense fallback={null}>
+            <DemoLoginPanel
+              password={import.meta.env.VITE_DEMO_LOGIN_PASSWORD as string}
+              onSelect={(demoEmail, demoPass) => handleLogin(undefined, demoEmail, demoPass)}
+            />
+          </Suspense>
+        )}
 
         {/* Back to Home CTA */}
         <button


### PR DESCRIPTION
## The problem

The FLN login page rendered a panel headed **`Active System Roles for Demonstration (Password: Fln@2026)`** with one-click sign-in buttons for twelve seeded accounts — **including Superadmin**.

This shipped to production and was reachable by anyone on the open internet. The password was printed in plain text, and each button logged you straight in. No credential guessing required.

## The fix

The panel is genuinely useful for local development, so this gates it rather than deleting it.

- **The password is no longer in the source.** It comes from `VITE_DEMO_LOGIN_PASSWORD`, supplied alongside `VITE_ENABLE_DEMO_LOGINS`. With the flag on but no password set, nothing renders — a partial config cannot silently fall back to the old value.
- **The panel moved to its own module behind a conditional dynamic import.** Vite substitutes the env literal at build time, so an unflagged build folds the condition to `null` and Rollup drops the chunk entirely.

That second point is the reason for the slightly unusual ternary. A plain `lazy(() => import('./DemoLoginPanel'))` still emits `DemoLoginPanel-*.js` as a **fetchable file** containing all twelve sample addresses, even though nothing renders it. Writing the flag check into the import expression is what makes Rollup drop it.

## Verification

Built three ways and grepped the output:

| Build | `Fln@2026` | sample addresses | demo chunk |
|---|---|---|---|
| no flags (production) | absent | absent | not emitted |
| flag + password | present | present | emitted, panel works |
| flag set, password missing | absent | present in chunk | panel does not render |

`tsc --noEmit` clean. `frontend/.env.example` added documenting both variables.

## What this does NOT do

**This removes the published credential, not the accounts.** The seeded demo passwords still work — anyone who already read the login page has them. **They need rotating in the production database separately**, and that is the part that actually closes the exposure.

Two things noticed while in here, not addressed:

- `frontend/src/components/panels/usePanelData.ts:44` hardcodes a mock row `{ name: 'Jinal Gupta', email: 'superadmin@fln.org', role: 'Super Admin' }`. Unrelated to login, but it is fabricated data rendered as real, which the permissions SRS rules out.
- `Database/test.users.json` carries `Fln@2026` on ~20 seeded accounts. Fine as a fixture, but it is where the production seed gets its passwords.