### PR TITLE
fix(authz): scope ADMIN to its own state on /api/schools, and fail closed

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -66,8 +66,10 @@ export function registerAdminRoutes(app: express.Express) {
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
     const users = await dbStore.getUsers();
-    let filtered = users;
-    if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
+    let filtered: typeof users;
+    if (user.role === UserRole.SUPERADMIN) {
+      filtered = users;
+    } else if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
       filtered = users.filter(u => u.schoolId === user.schoolId);
     } else if (user.role === UserRole.VOLUNTEER) {
       filtered = users.filter(u => user.assignedSchools?.includes(u.schoolId || ''));
@@ -77,6 +79,11 @@ export function registerAdminRoutes(app: express.Express) {
       filtered = users.filter(u => u.blockCode === user.blockCode);
     } else if (user.role === UserRole.ADMIN) {
       filtered = users.filter(u => u.stateCode === user.stateCode);
+    } else {
+      // Fail closed. This started as `let filtered = users` with no final branch,
+      // so SUPERADMIN fell through correctly by accident — and so would any role
+      // added later, handing it every user in the system.
+      return res.status(403).json({ error: 'Forbidden: role not permitted to list coordinators.' });
     }
     res.json(filtered.map(sanitizeUser));
   });

--- a/backend/src/routes/schools.ts
+++ b/backend/src/routes/schools.ts
@@ -9,8 +9,14 @@ export function registerSchoolRoutes(app: express.Express) {
     const schools = await dbStore.getSchools();
 
     let scoped: typeof schools;
-    if (user.role === UserRole.SUPERADMIN || user.role === UserRole.ADMIN) {
+    if (user.role === UserRole.SUPERADMIN) {
       scoped = schools;
+    } else if (user.role === UserRole.ADMIN) {
+      // State admin, so scoped to their own state. GET /api/logbook and
+      // GET /api/admin/coordinators both already scope ADMIN by stateCode; this
+      // endpoint returned every school nationwide, so a Punjab admin could read
+      // Rajasthan's schools.
+      scoped = schools.filter(s => s.stateCode === user.stateCode);
     } else if (user.role === UserRole.SCHOOL || user.role === UserRole.TEACHER) {
       scoped = schools.filter(s => s.id === user.schoolId);
     } else if (user.role === UserRole.VOLUNTEER) {
@@ -20,7 +26,10 @@ export function registerSchoolRoutes(app: express.Express) {
     } else if (user.role === UserRole.BLOCK_ADMIN) {
       scoped = schools.filter(s => s.blockCode === user.blockCode);
     } else {
-      scoped = schools;
+      // Fail closed. This branch previously returned every school nationwide, so
+      // any role added later leaked the full list until someone remembered to
+      // come back here.
+      return res.status(403).json({ error: 'Forbidden: role not permitted to list schools.' });
     }
 
     // Opt-in pagination (same pattern as GET /api/students, PR #115).


### PR DESCRIPTION
## First, a correction to the premise

Three endpoints were flagged as leaking nationwide data to roles that should be scoped: `GET /api/schools`, `GET /api/logbook`, `GET /api/admin/coordinators`.

**All three are already scoped on `main`.** That part of the report is stale and no longer needs action. I checked each one before changing anything.

Two real defects turned up while verifying it, and this PR fixes those.

## 1. `/api/schools` gave every state admin the whole country

```ts
if (user.role === UserRole.SUPERADMIN || user.role === UserRole.ADMIN) {
  scoped = schools;   // <- ADMIN is a *state* role
}
```

`ADMIN` is state-scoped: `/api/logbook` filters it by `stateCode`, and so does `/api/admin/coordinators`. Only this endpoint treated it as equivalent to Superadmin.

So a Punjab admin could list Rajasthan's schools — and the same role was scoped differently depending on which endpoint you asked. Now filtered by `stateCode`, consistent with the other two.

## 2. Both endpoints failed **open** for unknown roles

`/api/schools` ended in:

```ts
} else {
  scoped = schools;   // every school, nationwide
}
```

`/api/admin/coordinators` began from `let filtered = users` with **no final branch at all** — so `SUPERADMIN` worked by accident rather than by intent, and so would anything else.

Either way, the next role added to `UserRole` receives the full unscoped list until someone remembers to come back and update the if-chain. Nothing fails, nothing logs; it just quietly returns everything.

Both now end in an explicit `403`, and `SUPERADMIN` is named as its own branch rather than relying on fall-through.

## Impact

No behaviour change for any role already handled — **except `ADMIN` on `/api/schools`**, which is the fix. If any frontend view assumes a state admin can see schools outside their state, it will now get a shorter list; I did not find one, but it is the thing to check.

`tsc --noEmit` clean.

## Still open, not in this PR

The other half of the original report — that admin / district admin / block admin can **edit** student data when they should be read-only pending Superadmin approval — is a separate change and needs the approval-queue design settled first (one of the four open Permissions SRS items).