### PR TITLE
feat: author questions directly, with bulk CSV upload

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -651,6 +651,95 @@ export interface QuestionLogic {
 }
 
 /**
+ * A Superadmin-authored question: the stem a child reads, how the answer is
+ * recorded, and the constraints that govern the numbers inside it.
+ *
+ * Distinct from `QuestionLogic`, which described a question in prose and left
+ * the generator to interpret it. A template says the same thing in fields that
+ * can be validated, compared and bulk-imported, so two authors describing the
+ * same variation produce the same row rather than two sentences that only a
+ * human can tell apart.
+ *
+ * Addressed by `conceptId`, never by level number. Levels are insertable and
+ * re-orderable; the concept a question assesses is not. See `CurriculumLevel`.
+ */
+export interface QuestionTemplate {
+  id: string;
+
+  /** Canonical curriculum identity, e.g. "S3.4". The thing this question assesses. */
+  conceptId: string;
+  /**
+   * Display alias only, resolved from `conceptId` at write time. Never the
+   * identity: it is denormalised so the list view needs no join, and it is
+   * recomputed whenever the concept changes.
+   */
+  levelNumber: number;
+  levelName: string;
+
+  /** At least one. Validated server-side against the level's primary+supporting skills. */
+  skills: string[];
+  /** Optional. Empty means "assess the skill at full granularity", which is a valid choice. */
+  subskills: string[];
+
+  /**
+   * What the child reads. Placeholders in braces are filled by the generator
+   * from the constraints below, e.g. "{a} + {b} = ___". A stem with no
+   * placeholder is a fixed question and is equally valid.
+   */
+  stem: string;
+  /**
+   * How the answer is derived, in the same placeholder vocabulary as the stem,
+   * e.g. "{a}+{b}". Held as text rather than evaluated here: nothing in this
+   * chunk generates questions, and pinning an evaluator now would fix a choice
+   * the generator work has not made yet.
+   */
+  answerSpec: string;
+
+  // --- Structured parameters. See backend/src/types/questionTemplateParams.ts ---
+  numeralRange: string | null;
+  digitCount: string | null;
+  /** Empty means "not specified", not "any operation". */
+  operations: string[];
+  maxOperandCount: number | null;
+  carryBehavior: string | null;
+  borrowBehavior: string | null;
+  maxSumOrDifference: string | null;
+  answerType: string | null;
+  blankCount: number | null;
+  questionCount: number | null;
+  subjectCategory: string | null;
+
+  /**
+   * Human-readable name for this variation, derived from the parameters at
+   * creation. Editable afterwards, and an edit is preserved: the derivation
+   * runs again only when an author asks for it.
+   */
+  name: string;
+  /**
+   * Fingerprint of (conceptId + parameters). Two templates constraining the
+   * same thing at the same concept share a key, which is what makes duplicate
+   * variations findable. Deliberately not a unique index — two Superadmins may
+   * legitimately author the same variation with different stems.
+   */
+  variantKey: string;
+  /** Free-form author tags, lowercased and de-duplicated on write. */
+  tags: string[];
+
+  /** Where the row came from. Bulk imports are worth being able to find again. */
+  source: 'form' | 'csv';
+
+  createdBy: string;
+  createdByEmail: string;
+  createdAt: string;
+  updatedAt: string;
+  updatedBy: string;
+  updatedByEmail: string;
+  /** Soft delete: a generated paper may already cite this id, so the row stays for audit. */
+  deletedAt: string | null;
+  deletedBy: string | null;
+}
+
+/**
  * One row per FLN level in the canonical 93-level taxonomy.
  *
  * This collection exists to give the curriculum a single queryable home. Before
@@ -726,6 +815,7 @@ interface DatabaseSchema {
   misconceptionClusters: MisconceptionCluster[];
   testHistory: TestHistoryEntry[];
   questionLogics: QuestionLogic[];
+  questionTemplates: QuestionTemplate[];
   curriculumLevels: CurriculumLevel[];
 }
 
@@ -750,6 +840,7 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   misconceptionClusters: 'misconception_clusters',
   testHistory: 'testHistory',
   questionLogics: 'questionLogics',
+  questionTemplates: 'questionTemplates',
   curriculumLevels: 'curriculumLevels',
 };
 
@@ -871,6 +962,25 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
           console.log('Successfully ensured indexes on "users" collection');
         } catch (e: any) {
           console.warn('Failed to ensure indexes on "users" collection:', e.message);
+        }
+
+        // Ensure indexes on the authoring collections.
+        //
+        // `questionLogics` has never carried any index, including on `id`,
+        // which `getQuestionLogicById` queries by. Added here alongside the
+        // new collection rather than left for later.
+        try {
+          const logicsColl = db.collection('questionLogics');
+          await logicsColl.createIndex({ id: 1 }, { unique: true });
+
+          const templatesColl = db.collection('questionTemplates');
+          await templatesColl.createIndex({ id: 1 }, { unique: true });
+          await templatesColl.createIndex({ conceptId: 1, deletedAt: 1 });
+          await templatesColl.createIndex({ variantKey: 1, deletedAt: 1 });
+          await templatesColl.createIndex({ tags: 1, deletedAt: 1 });
+          console.log('Successfully ensured indexes on the question authoring collections');
+        } catch (e: any) {
+          console.warn('Failed to ensure indexes on the question authoring collections:', e.message);
         }
 
         // Ensure indexes on evaluationReports collection for performance
@@ -1854,6 +1964,69 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
     };
   }
 
+  // --- Question Template Methods ----------------------------------------
+  //
+  // Templates are addressed by `conceptId`. Nothing here takes a level number:
+  // levels are insertable and re-orderable, so a stored level number would be
+  // a reference that quietly stops meaning what it meant when it was written.
+
+  async getQuestionTemplates(includeDeleted = false) {
+    const filter = includeDeleted ? {} : { deletedAt: null };
+    return await this.mongoDb!.collection<QuestionTemplate>('questionTemplates')
+      .find(filter).sort({ createdAt: -1 }).toArray();
+  }
+
+  async getQuestionTemplateById(id: string) {
+    return (await this.mongoDb!.collection<QuestionTemplate>('questionTemplates').findOne({ id })) || undefined;
+  }
+
+  /** Live templates sharing a variant fingerprint. Drives the duplicate warning. */
+  async getQuestionTemplatesByVariantKey(variantKey: string) {
+    return await this.mongoDb!.collection<QuestionTemplate>('questionTemplates')
+      .find({ variantKey, deletedAt: null }).toArray();
+  }
+
+  async addQuestionTemplate(template: QuestionTemplate) {
+    await this.mongoDb!.collection('questionTemplates').insertOne(template);
+    if (this.data) this.data.questionTemplates.push(template);
+    return template;
+  }
+
+  /**
+   * Insert a validated batch in one round trip.
+   *
+   * Callers validate every row before calling: a CSV import that writes half a
+   * file and then rejects the rest leaves the author reconciling two states by
+   * hand, which is worse than importing nothing.
+   */
+  async addQuestionTemplates(templates: QuestionTemplate[]) {
+    if (templates.length === 0) return [];
+    await this.mongoDb!.collection('questionTemplates').insertMany(templates as any[]);
+    if (this.data) this.data.questionTemplates.push(...templates);
+    return templates;
+  }
+
+  async updateQuestionTemplate(id: string, updates: Partial<QuestionTemplate>) {
+    await this.mongoDb!.collection('questionTemplates').updateOne({ id }, { $set: updates });
+    const t = await this.mongoDb!.collection<QuestionTemplate>('questionTemplates').findOne({ id });
+    if (t && this.data) {
+      const idx = this.data.questionTemplates.findIndex(x => x.id === id);
+      if (idx !== -1) this.data.questionTemplates[idx] = t;
+    }
+    return t || undefined;
+  }
+
+  async getQuestionTemplateStats(totalLevels: number) {
+    const live = await this.mongoDb!.collection<QuestionTemplate>('questionTemplates')
+      .find({ deletedAt: null }).toArray();
+    return {
+      totalTemplates: live.length,
+      totalLevels,
+      levelsWithTemplate: new Set(live.map(t => t.conceptId)).size,
+      distinctVariants: new Set(live.map(t => t.variantKey)).size,
+    };
+  }
+
   // --- Curriculum Level Methods ---
   //
   // The single accessor path for curriculum data. Anything that needs to reason
@@ -1968,6 +2141,12 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   async getCurriculumLevel(levelNumber: number) {
     return (await this.mongoDb!.collection<CurriculumLevel>('curriculumLevels')
       .findOne({ levelNumber })) || undefined;
+  }
+
+  /** Look a level up by its permanent identity rather than by its position. */
+  async getCurriculumLevelByConceptId(conceptId: string) {
+    return (await this.mongoDb!.collection<CurriculumLevel>('curriculumLevels')
+      .findOne({ conceptId })) || undefined;
   }
 
   /**
@@ -3934,6 +4113,7 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
       // Superadmin, and inventing demo ones would put fabricated curriculum
       // intent in front of the question-generation pipeline.
       questionLogics: [],
+      questionTemplates: [],
       // Populated by `npm run seed:levels`, not by the demo seed — the
       // curriculum is real data with one source, not fixture content.
       curriculumLevels: []

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -37,6 +37,7 @@ import { registerWorksheetRoutes } from './routes/worksheets';
 import { registerEvaluationRoutes } from './routes/evaluation';
 import { registerAnalyticsRoutes } from './routes/analytics';
 import { registerQuestionLogicRoutes } from './routes/questionLogics';
+import { registerQuestionTemplateRoutes } from './routes/questionTemplates';
 import { registerDiagnosticBulkRoutes } from './routes/diagnosticBulk';
 import { registerMisconceptionRoutes } from './routes/misconceptions';
 import { registerCurriculumRoutes } from './routes/curriculum';
@@ -131,6 +132,7 @@ registerStatsRoutes(app);
   registerWorksheetRoutes(app);
   registerAnalyticsRoutes(app);
   registerQuestionLogicRoutes(app);
+  registerQuestionTemplateRoutes(app);
   registerDiagnosticBulkRoutes(app);
 
   // Read-only analysis over already-graded submissions: clusters a cohort on

--- a/backend/src/routes/questionLogics.ts
+++ b/backend/src/routes/questionLogics.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { randomUUID } from 'crypto';
-import { dbStore, UserRole, QuestionLogic } from '../db';
-import { getAuthUser } from '../auth';
+import { dbStore, QuestionLogic } from '../db';
+import { requireSuperadmin } from './superadminGuard';
 import {
   LEVEL_COUNT,
   getLevel,
@@ -13,20 +13,6 @@ import {
 const MAX_LOGIC_CHARS = 2000;
 /** Window for the accidental-double-click guard. Not a uniqueness constraint on pedagogy. */
 const DUPLICATE_WINDOW_MS = 60_000;
-
-/**
- * Every route here is Superadmin-only. Authoring question logic is a curriculum
- * decision, and the 7-role hierarchy has no curriculum-author role — widening
- * this later is a one-line change here.
- */
-function requireSuperadmin(req: express.Request, res: express.Response) {
-  const user = getAuthUser(req);
-  if (!user || user.role !== UserRole.SUPERADMIN) {
-    res.status(403).json({ error: 'Only superadmins can manage question logics.' });
-    return null;
-  }
-  return user;
-}
 
 /**
  * Server-side validation of a (level, skills, subskills, text) combination.

--- a/backend/src/routes/questionTemplates.ts
+++ b/backend/src/routes/questionTemplates.ts
@@ -1,0 +1,520 @@
+import express from 'express';
+import { randomUUID } from 'crypto';
+import { dbStore, QuestionTemplate } from '../db';
+import { requireSuperadmin } from './superadminGuard';
+import { getLevel, isSkillMappedToLevel, isSubskillUnderSkills, buildLevelMapPayload, LEVEL_COUNT } from '../config/skillLevelMap';
+import { getLevelForConcept } from '../config/curriculumMap';
+import {
+  QuestionTemplateParams,
+  coerceParams,
+  validateParams,
+  deriveTemplateName,
+  variantKeyFor,
+  getParamCatalog,
+  QUESTION_COUNT_DEFAULT,
+} from '../types/questionTemplateParams';
+
+const MAX_STEM_CHARS = 2000;
+const MAX_ANSWER_SPEC_CHARS = 500;
+const MAX_NAME_CHARS = 200;
+const MAX_TAGS = 20;
+const MAX_TAG_CHARS = 40;
+/** Cap on one import. Large enough for a curriculum batch, small enough to stay a single round trip. */
+const MAX_IMPORT_ROWS = 1000;
+
+const SUBJECT = 'question templates';
+
+/**
+ * Server-side validation of a whole template.
+ *
+ * The client's cascading dropdowns make an invalid combination hard to pick,
+ * but they cannot make it impossible to send, and the CSV import has no
+ * dropdowns at all. A template filed against a concept that cannot host its
+ * skills would go on to produce questions assessing something the level never
+ * claimed to teach, so this is the real guard.
+ *
+ * Returns an error string, or null when the template is valid.
+ */
+function validateTemplate(
+  conceptId: string,
+  skills: string[],
+  subskills: string[],
+  stem: string,
+  answerSpec: string,
+  params: QuestionTemplateParams,
+  tags: string[],
+  name: string
+): string | null {
+  if (typeof conceptId !== 'string' || conceptId.trim().length === 0) {
+    return 'conceptId is required.';
+  }
+  const concept = getLevelForConcept(conceptId.trim());
+  if (!concept) return `Concept ${conceptId} is not present in the curriculum map.`;
+
+  const levelInfo = getLevel(concept.levelNumber);
+  if (!levelInfo) return `Concept ${conceptId} resolves to L${concept.levelNumber}, which is not in the skill map.`;
+
+  // Defensive: every level in the map should carry at least one skill. If one
+  // does not, say so plainly rather than letting the "skill not mapped" error
+  // below imply the author picked wrongly.
+  if (levelInfo.skills.length === 0) {
+    return `L${concept.levelNumber} has no skills mapped to it, so no question can be authored for it.`;
+  }
+
+  if (!Array.isArray(skills) || skills.length === 0) return 'At least one skill is required.';
+  for (const sk of skills) {
+    if (!isSkillMappedToLevel(sk, concept.levelNumber)) {
+      return `Skill ${sk} is not mapped to L${concept.levelNumber}.`;
+    }
+  }
+
+  if (!Array.isArray(subskills)) return 'subskills must be an array.';
+  for (const ss of subskills) {
+    if (!isSubskillUnderSkills(ss, skills)) {
+      return `Sub-skill ${ss} is not under any of the selected skills.`;
+    }
+  }
+
+  const stemText = (stem ?? '').trim();
+  if (stemText.length === 0) return 'Question text is required.';
+  if (stemText.length > MAX_STEM_CHARS) {
+    return `Question text must be ${MAX_STEM_CHARS} characters or fewer.`;
+  }
+
+  const answer = (answerSpec ?? '').trim();
+  if (answer.length > MAX_ANSWER_SPEC_CHARS) {
+    return `Answer must be ${MAX_ANSWER_SPEC_CHARS} characters or fewer.`;
+  }
+
+  if (name.length > MAX_NAME_CHARS) {
+    return `Name must be ${MAX_NAME_CHARS} characters or fewer.`;
+  }
+
+  if (!Array.isArray(tags)) return 'tags must be an array.';
+  if (tags.length > MAX_TAGS) return `A template may carry at most ${MAX_TAGS} tags.`;
+  for (const t of tags) {
+    if (typeof t !== 'string' || t.trim().length === 0) return 'tags must be non-empty strings.';
+    if (t.length > MAX_TAG_CHARS) return `Each tag must be ${MAX_TAG_CHARS} characters or fewer.`;
+  }
+
+  return validateParams(params);
+}
+
+/** Lowercased, trimmed, de-duplicated, order preserved. */
+function normalizeTags(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of raw) {
+    if (typeof t !== 'string') continue;
+    const tag = t.trim().toLowerCase();
+    if (tag.length === 0 || seen.has(tag)) continue;
+    seen.add(tag);
+    out.push(tag);
+  }
+  return out;
+}
+
+/**
+ * Build the stored row from validated inputs.
+ *
+ * Shared by the single-create route and the importer so that a row authored in
+ * the form and the same row imported from a CSV are byte-for-byte the same
+ * document, rather than two shapes that only mostly agree.
+ */
+function buildTemplate(
+  input: {
+    conceptId: string;
+    skills: string[];
+    subskills: string[];
+    stem: string;
+    answerSpec: string;
+    params: QuestionTemplateParams;
+    name: string;
+    tags: string[];
+    source: 'form' | 'csv';
+  },
+  user: { id: string; email: string },
+  now: string
+): QuestionTemplate {
+  const concept = getLevelForConcept(input.conceptId)!;
+  const params = input.params;
+  return {
+    id: 'qtpl_' + randomUUID().slice(0, 8),
+    conceptId: input.conceptId,
+    levelNumber: concept.levelNumber,
+    levelName: getLevel(concept.levelNumber)!.capability,
+    skills: input.skills,
+    subskills: input.subskills,
+    stem: input.stem.trim(),
+    answerSpec: input.answerSpec.trim(),
+    numeralRange: params.numeralRange,
+    digitCount: params.digitCount,
+    operations: params.operations,
+    maxOperandCount: params.maxOperandCount,
+    carryBehavior: params.carryBehavior,
+    borrowBehavior: params.borrowBehavior,
+    maxSumOrDifference: params.maxSumOrDifference,
+    answerType: params.answerType,
+    blankCount: params.blankCount,
+    questionCount: params.questionCount ?? QUESTION_COUNT_DEFAULT,
+    subjectCategory: params.subjectCategory,
+    name: input.name.trim() || deriveTemplateName(params),
+    variantKey: variantKeyFor(input.conceptId, params),
+    tags: input.tags,
+    source: input.source,
+    createdBy: user.id,
+    createdByEmail: user.email,
+    createdAt: now,
+    updatedAt: now,
+    updatedBy: user.id,
+    updatedByEmail: user.email,
+    deletedAt: null,
+    deletedBy: null,
+  };
+}
+
+/**
+ * Minimal RFC 4180 reader: quoted fields, doubled quotes inside them, and
+ * newlines inside quotes. Hand-rolled because it is the only CSV in the
+ * backend and a dependency would be carried into every bundle for this.
+ */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') { field += '"'; i++; }
+        else inQuotes = false;
+      } else field += ch;
+      continue;
+    }
+    if (ch === '"') { inQuotes = true; continue; }
+    if (ch === ',') { row.push(field); field = ''; continue; }
+    if (ch === '\r') continue;
+    if (ch === '\n') { row.push(field); rows.push(row); row = []; field = ''; continue; }
+    field += ch;
+  }
+  row.push(field);
+  rows.push(row);
+
+  // Trailing newline produces one empty final row; blank lines anywhere are noise.
+  return rows.filter(r => r.some(c => c.trim().length > 0));
+}
+
+/** Pipe-separated list cell, e.g. "SK03|SK07". Empty cell means empty list. */
+function splitList(cell: string): string[] {
+  return (cell ?? '').split('|').map(s => s.trim()).filter(s => s.length > 0);
+}
+
+function cellOrNull(cell: string): string | null {
+  const v = (cell ?? '').trim();
+  return v.length === 0 ? null : v;
+}
+
+const CSV_COLUMNS = [
+  'conceptId', 'skills', 'subskills', 'stem', 'answerSpec',
+  'numeralRange', 'digitCount', 'operations', 'maxOperandCount',
+  'carryBehavior', 'borrowBehavior', 'maxSumOrDifference',
+  'answerType', 'blankCount', 'questionCount', 'subjectCategory',
+  'name', 'tags',
+] as const;
+
+export function registerQuestionTemplateRoutes(app: express.Express) {
+  /** The legal values and context rules the form renders itself from. */
+  app.get('/api/question-templates/param-catalog', (req, res) => {
+    if (!requireSuperadmin(req, res, SUBJECT)) return;
+    res.json(getParamCatalog());
+  });
+
+  /** Levels, skills and sub-skills for the cascading pickers, in one call. */
+  app.get('/api/question-templates/level-map', (req, res) => {
+    if (!requireSuperadmin(req, res, SUBJECT)) return;
+    res.json(buildLevelMapPayload());
+  });
+
+  /** The header row the importer expects, so the form can offer a blank file. */
+  app.get('/api/question-templates/csv-template', (req, res) => {
+    if (!requireSuperadmin(req, res, SUBJECT)) return;
+    res.type('text/csv').send(CSV_COLUMNS.join(',') + '\n');
+  });
+
+  app.get('/api/question-templates/stats', async (req, res) => {
+    if (!requireSuperadmin(req, res, SUBJECT)) return;
+    res.json(await dbStore.getQuestionTemplateStats(LEVEL_COUNT));
+  });
+
+  app.get('/api/question-templates', async (req, res) => {
+    if (!requireSuperadmin(req, res, SUBJECT)) return;
+
+    const includeDeleted = req.query.includeDeleted === 'true';
+    let templates = await dbStore.getQuestionTemplates(includeDeleted);
+
+    const conceptId = req.query.conceptId as string | undefined;
+    if (conceptId) templates = templates.filter(t => t.conceptId === conceptId);
+
+    const skill = req.query.skill as string | undefined;
+    if (skill) templates = templates.filter(t => t.skills.includes(skill));
+
+    const subskill = req.query.subskill as string | undefined;
+    if (subskill) templates = templates.filter(t => t.subskills.includes(subskill));
+
+    const tag = req.query.tag as string | undefined;
+    if (tag) templates = templates.filter(t => t.tags.includes(tag.toLowerCase()));
+
+    const variantKey = req.query.variantKey as string | undefined;
+    if (variantKey) templates = templates.filter(t => t.variantKey === variantKey);
+
+    res.json(templates);
+  });
+
+  app.post('/api/question-templates', async (req, res) => {
+    const user = requireSuperadmin(req, res, SUBJECT);
+    if (!user) return;
+
+    const conceptId: string = (req.body?.conceptId ?? '').trim();
+    const skills: string[] = req.body?.skills ?? [];
+    const subskills: string[] = req.body?.subskills ?? [];
+    const stem: string = req.body?.stem ?? '';
+    const answerSpec: string = req.body?.answerSpec ?? '';
+    const params = coerceParams(req.body);
+    const tags = normalizeTags(req.body?.tags);
+    const name: string = (req.body?.name ?? '').trim();
+
+    const problem = validateTemplate(conceptId, skills, subskills, stem, answerSpec, params, tags, name);
+    if (problem) return res.status(400).json({ error: problem });
+
+    const template = buildTemplate(
+      { conceptId, skills, subskills, stem, answerSpec, params, name, tags, source: 'form' },
+      user,
+      new Date().toISOString()
+    );
+
+    await dbStore.addQuestionTemplate(template);
+
+    // Not a rejection: two Superadmins may legitimately author the same
+    // variation with different stems. Reported so the author can see it rather
+    // than discovering the collision in a generated paper.
+    const siblings = (await dbStore.getQuestionTemplatesByVariantKey(template.variantKey))
+      .filter(t => t.id !== template.id);
+
+    res.status(201).json({
+      template,
+      duplicateVariants: siblings.map(t => ({ id: t.id, name: t.name, stem: t.stem })),
+    });
+  });
+
+  app.patch('/api/question-templates/:id', async (req, res) => {
+    const user = requireSuperadmin(req, res, SUBJECT);
+    if (!user) return;
+
+    const current = await dbStore.getQuestionTemplateById(req.params.id);
+    if (!current) return res.status(404).json({ error: 'Question template not found.' });
+    if (current.deletedAt) return res.status(400).json({ error: 'Cannot edit a deleted template.' });
+
+    // Fall back to the stored value for anything the caller did not send, so a
+    // partial PATCH is still validated as a whole document. This is what makes
+    // "change only the concept" fail loudly when the existing skills cannot
+    // live at the new level, instead of silently storing a mismatched pair.
+    const conceptId: string = (req.body?.conceptId ?? current.conceptId).trim();
+    const skills: string[] = req.body?.skills ?? current.skills;
+    const subskills: string[] = req.body?.subskills ?? current.subskills;
+    const stem: string = req.body?.stem ?? current.stem;
+    const answerSpec: string = req.body?.answerSpec ?? current.answerSpec;
+    const tags = req.body?.tags !== undefined ? normalizeTags(req.body.tags) : current.tags;
+    const params = coerceParams({ ...current, ...req.body });
+    const name: string = (req.body?.name ?? current.name).trim();
+
+    const problem = validateTemplate(conceptId, skills, subskills, stem, answerSpec, params, tags, name);
+    if (problem) {
+      // Make the concept-only case actionable rather than merely rejected.
+      if (req.body?.conceptId !== undefined && req.body?.skills === undefined && problem.includes('not mapped')) {
+        return res.status(400).json({
+          error: `Existing skills [${current.skills.join(', ')}] are not all mapped to ${conceptId}. Update skills in the same request.`,
+        });
+      }
+      return res.status(400).json({ error: problem });
+    }
+
+    const concept = getLevelForConcept(conceptId)!;
+
+    // The name is the author's once they have edited it, so it is only
+    // re-derived when the caller explicitly asks or has left it empty.
+    const regenerate = req.body?.regenerateName === true || name.length === 0;
+
+    const updates: Partial<QuestionTemplate> = {
+      conceptId,
+      levelNumber: concept.levelNumber,
+      levelName: getLevel(concept.levelNumber)!.capability,
+      skills,
+      subskills,
+      stem: stem.trim(),
+      answerSpec: answerSpec.trim(),
+      numeralRange: params.numeralRange,
+      digitCount: params.digitCount,
+      operations: params.operations,
+      maxOperandCount: params.maxOperandCount,
+      carryBehavior: params.carryBehavior,
+      borrowBehavior: params.borrowBehavior,
+      maxSumOrDifference: params.maxSumOrDifference,
+      answerType: params.answerType,
+      blankCount: params.blankCount,
+      questionCount: params.questionCount ?? QUESTION_COUNT_DEFAULT,
+      subjectCategory: params.subjectCategory,
+      name: regenerate ? deriveTemplateName(params) : name,
+      variantKey: variantKeyFor(conceptId, params),
+      tags,
+      updatedAt: new Date().toISOString(),
+      updatedBy: user.id,
+      updatedByEmail: user.email,
+    };
+
+    const updated = await dbStore.updateQuestionTemplate(req.params.id, updates);
+    res.json(updated);
+  });
+
+  app.delete('/api/question-templates/:id', async (req, res) => {
+    const user = requireSuperadmin(req, res, SUBJECT);
+    if (!user) return;
+
+    const current = await dbStore.getQuestionTemplateById(req.params.id);
+    if (!current) return res.status(404).json({ error: 'Question template not found.' });
+    if (current.deletedAt) return res.json({ ok: true });
+
+    await dbStore.updateQuestionTemplate(req.params.id, {
+      deletedAt: new Date().toISOString(),
+      deletedBy: user.id,
+    });
+    res.json({ ok: true });
+  });
+
+  /**
+   * Bulk import from CSV.
+   *
+   * All-or-nothing by design. A partial import that writes the valid rows and
+   * rejects the rest leaves the author reconciling a half-written file against
+   * a list of errors by hand, which is harder than fixing the file and trying
+   * again. `dryRun` runs every check and writes nothing, so the same request
+   * doubles as the preview.
+   */
+  app.post('/api/question-templates/import', async (req, res) => {
+    const user = requireSuperadmin(req, res, SUBJECT);
+    if (!user) return;
+
+    const csv: string = req.body?.csv ?? '';
+    const dryRun: boolean = req.body?.dryRun === true;
+
+    if (typeof csv !== 'string' || csv.trim().length === 0) {
+      return res.status(400).json({ error: 'csv is required.' });
+    }
+
+    const rows = parseCsv(csv);
+    if (rows.length < 2) {
+      return res.status(400).json({ error: 'The file needs a header row and at least one data row.' });
+    }
+
+    const header = rows[0].map(h => h.trim());
+    const missing = CSV_COLUMNS.filter(c => !header.includes(c));
+    if (missing.length > 0) {
+      return res.status(400).json({ error: `Missing columns: ${missing.join(', ')}.` });
+    }
+
+    const dataRows = rows.slice(1);
+    if (dataRows.length > MAX_IMPORT_ROWS) {
+      return res.status(400).json({ error: `At most ${MAX_IMPORT_ROWS} rows per import; this file has ${dataRows.length}.` });
+    }
+
+    const col = (row: string[], name: string) => (row[header.indexOf(name)] ?? '').trim();
+    const now = new Date().toISOString();
+    const errors: Array<{ row: number; error: string }> = [];
+    const prepared: QuestionTemplate[] = [];
+
+    dataRows.forEach((row, i) => {
+      // +2 so the number matches what the author sees in a spreadsheet: one for
+      // the header, one because spreadsheets count from 1.
+      const rowNumber = i + 2;
+
+      const conceptId = col(row, 'conceptId');
+      const skills = splitList(col(row, 'skills'));
+      const subskills = splitList(col(row, 'subskills'));
+      const stem = col(row, 'stem');
+      const answerSpec = col(row, 'answerSpec');
+      const tags = normalizeTags(splitList(col(row, 'tags')));
+      const name = col(row, 'name');
+
+      const params = coerceParams({
+        numeralRange: cellOrNull(col(row, 'numeralRange')),
+        digitCount: cellOrNull(col(row, 'digitCount')),
+        operations: splitList(col(row, 'operations')),
+        maxOperandCount: cellOrNull(col(row, 'maxOperandCount')),
+        carryBehavior: cellOrNull(col(row, 'carryBehavior')),
+        borrowBehavior: cellOrNull(col(row, 'borrowBehavior')),
+        maxSumOrDifference: cellOrNull(col(row, 'maxSumOrDifference')),
+        answerType: cellOrNull(col(row, 'answerType')),
+        blankCount: cellOrNull(col(row, 'blankCount')),
+        questionCount: cellOrNull(col(row, 'questionCount')),
+        subjectCategory: cellOrNull(col(row, 'subjectCategory')),
+      });
+
+      const problem = validateTemplate(conceptId, skills, subskills, stem, answerSpec, params, tags, name);
+      if (problem) {
+        errors.push({ row: rowNumber, error: problem });
+        return;
+      }
+
+      prepared.push(buildTemplate(
+        { conceptId, skills, subskills, stem, answerSpec, params, name, tags, source: 'csv' },
+        user,
+        now
+      ));
+    });
+
+    if (errors.length > 0) {
+      return res.status(400).json({
+        imported: 0,
+        rowsRead: dataRows.length,
+        errors,
+        error: `${errors.length} of ${dataRows.length} rows are invalid. Nothing was imported.`,
+      });
+    }
+
+    // Variations that already exist, and variations the file repeats within
+    // itself. Both are reported, neither blocks the import.
+    const withinFile = new Map<string, number>();
+    for (const t of prepared) withinFile.set(t.variantKey, (withinFile.get(t.variantKey) ?? 0) + 1);
+    const existingKeys: string[] = [];
+    for (const key of withinFile.keys()) {
+      const siblings = await dbStore.getQuestionTemplatesByVariantKey(key);
+      if (siblings.length > 0) existingKeys.push(key);
+    }
+
+    if (dryRun) {
+      return res.json({
+        dryRun: true,
+        imported: 0,
+        rowsRead: dataRows.length,
+        wouldImport: prepared.length,
+        errors: [],
+        repeatedInFile: [...withinFile.entries()].filter(([, n]) => n > 1).map(([key, n]) => ({ variantKey: key, count: n })),
+        alreadyExists: existingKeys,
+        preview: prepared.slice(0, 10).map(t => ({ conceptId: t.conceptId, name: t.name, stem: t.stem })),
+      });
+    }
+
+    await dbStore.addQuestionTemplates(prepared);
+
+    res.status(201).json({
+      dryRun: false,
+      imported: prepared.length,
+      rowsRead: dataRows.length,
+      errors: [],
+      repeatedInFile: [...withinFile.entries()].filter(([, n]) => n > 1).map(([key, n]) => ({ variantKey: key, count: n })),
+      alreadyExists: existingKeys,
+    });
+  });
+}

--- a/backend/src/routes/superadminGuard.ts
+++ b/backend/src/routes/superadminGuard.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import { UserRole } from '../db';
+import { getAuthUser } from '../auth';
+
+/**
+ * Superadmin-only guard for the curriculum authoring routes.
+ *
+ * Authoring what a question asks is a curriculum decision, and the 7-role
+ * hierarchy has no curriculum-author role, so these routes stop at Superadmin.
+ * Shared rather than repeated per route file: two copies drift, and a guard
+ * that is 403 in one file and 401 in another is a real access bug.
+ *
+ * Returns the user, or null after having already sent the 403.
+ */
+export function requireSuperadmin(
+  req: express.Request,
+  res: express.Response,
+  subject = 'question logics'
+) {
+  const user = getAuthUser(req);
+  if (!user || user.role !== UserRole.SUPERADMIN) {
+    res.status(403).json({ error: `Only superadmins can manage ${subject}.` });
+    return null;
+  }
+  return user;
+}

--- a/backend/src/types/questionTemplateParams.ts
+++ b/backend/src/types/questionTemplateParams.ts
@@ -1,0 +1,300 @@
+/**
+ * The structured parameters a Superadmin sets when authoring a question
+ * template, plus their validators and the naming derived from them.
+ *
+ * These describe the *shape* of a question — how big the numbers get, which
+ * operations appear, how the child records an answer — as opposed to the stem
+ * and answer, which say what the question actually asks. Both live on
+ * `QuestionTemplate`; they are separated here because only this half is a
+ * closed set of legal values, and only this half drives the derived name.
+ *
+ * Hand-rolled validators rather than a schema library: the backend ships as a
+ * single esbuild bundle and this is the only place in it that validates a
+ * closed value set, so a dependency would carry more weight than the checks.
+ */
+
+import { createHash } from 'crypto';
+
+export const NUMERAL_RANGES = ['0-9', '0-20', '0-50', '0-100', '0-1000', '0-10000'] as const;
+export const DIGIT_COUNTS = ['1-digit', '2-digit', '3-digit', '4-digit'] as const;
+export const OPERATIONS = ['add', 'subtract', 'multiply', 'divide'] as const;
+export const CARRY_BEHAVIORS = ['none', 'allowed', 'required'] as const;
+export const BORROW_BEHAVIORS = ['none', 'allowed', 'required'] as const;
+export const MAX_SUM_OR_DIFFERENCES = ['<=10', '<=20', '<=50', '<=100', '<=1000', '<=10000'] as const;
+export const MAX_OPERAND_COUNTS = [2, 3, 4] as const;
+export const ANSWER_TYPES = ['single-number', 'mcq-4', 'fill-blanks', 'true-false', 'matching', 'trace'] as const;
+export const SUBJECT_CATEGORIES = [
+  'fruits', 'vegetables', 'animals', 'pets', 'vehicles', 'street-furniture',
+  'buildings', 'clothing', 'flowers-trees', 'classroom-objects', 'mixed',
+] as const;
+
+export type NumeralRange = (typeof NUMERAL_RANGES)[number];
+export type DigitCount = (typeof DIGIT_COUNTS)[number];
+export type Operation = (typeof OPERATIONS)[number];
+export type CarryBehavior = (typeof CARRY_BEHAVIORS)[number];
+export type BorrowBehavior = (typeof BORROW_BEHAVIORS)[number];
+export type MaxSumOrDifference = (typeof MAX_SUM_OR_DIFFERENCES)[number];
+export type MaxOperandCount = (typeof MAX_OPERAND_COUNTS)[number];
+export type AnswerType = (typeof ANSWER_TYPES)[number];
+export type SubjectCategory = (typeof SUBJECT_CATEGORIES)[number];
+
+export const BLANK_COUNT_MIN = 1;
+export const BLANK_COUNT_MAX = 6;
+export const QUESTION_COUNT_MIN = 1;
+export const QUESTION_COUNT_MAX = 50;
+export const QUESTION_COUNT_DEFAULT = 10;
+
+/**
+ * Every parameter is nullable, and `operations` empty, because an author may
+ * legitimately not have decided yet. Empty `operations` therefore means "not
+ * specified", NOT "any operation is allowed" — the two readings conflict once
+ * the context rules below reject `carryBehavior` without an explicit `add`.
+ */
+export interface QuestionTemplateParams {
+  numeralRange: NumeralRange | null;
+  digitCount: DigitCount | null;
+  operations: Operation[];
+  maxOperandCount: MaxOperandCount | null;
+  carryBehavior: CarryBehavior | null;
+  borrowBehavior: BorrowBehavior | null;
+  maxSumOrDifference: MaxSumOrDifference | null;
+  answerType: AnswerType | null;
+  blankCount: number | null;
+  questionCount: number | null;
+  subjectCategory: SubjectCategory | null;
+}
+
+export const EMPTY_PARAMS: QuestionTemplateParams = {
+  numeralRange: null,
+  digitCount: null,
+  operations: [],
+  maxOperandCount: null,
+  carryBehavior: null,
+  borrowBehavior: null,
+  maxSumOrDifference: null,
+  answerType: null,
+  blankCount: null,
+  questionCount: null,
+  subjectCategory: null,
+};
+
+/** True when the author has set at least one parameter. Drives the "is this row structured?" stat. */
+export function hasAnyParam(p: QuestionTemplateParams): boolean {
+  return (
+    p.operations.length > 0 ||
+    p.numeralRange !== null ||
+    p.digitCount !== null ||
+    p.maxOperandCount !== null ||
+    p.carryBehavior !== null ||
+    p.borrowBehavior !== null ||
+    p.maxSumOrDifference !== null ||
+    p.answerType !== null ||
+    p.blankCount !== null ||
+    p.questionCount !== null ||
+    p.subjectCategory !== null
+  );
+}
+
+function oneOf<T extends readonly unknown[]>(allowed: T, value: unknown): boolean {
+  return (allowed as readonly unknown[]).includes(value);
+}
+
+/**
+ * Normalise whatever arrived on the request body into a full params object.
+ *
+ * Absent and explicitly-null are treated the same, so a PATCH that omits a
+ * parameter and one that clears it both end up null. Unknown values are left
+ * as-is for `validateParams` to reject, rather than being silently dropped —
+ * a typo in a CSV column should fail loudly, not import as null.
+ */
+export function coerceParams(body: any): QuestionTemplateParams {
+  const ops = body?.operations;
+  return {
+    numeralRange: body?.numeralRange ?? null,
+    digitCount: body?.digitCount ?? null,
+    operations: Array.isArray(ops) ? ops : [],
+    // Cast rather than narrow: an out-of-range value has to survive as far as
+    // `validateParams` so the author is told what was wrong with it.
+    maxOperandCount: body?.maxOperandCount != null ? (Number(body.maxOperandCount) as MaxOperandCount) : null,
+    carryBehavior: body?.carryBehavior ?? null,
+    borrowBehavior: body?.borrowBehavior ?? null,
+    maxSumOrDifference: body?.maxSumOrDifference ?? null,
+    answerType: body?.answerType ?? null,
+    blankCount: body?.blankCount != null ? Number(body.blankCount) : null,
+    questionCount: body?.questionCount != null ? Number(body.questionCount) : null,
+    subjectCategory: body?.subjectCategory ?? null,
+  };
+}
+
+/**
+ * Returns an error string, or null when every parameter is legal.
+ *
+ * Three kinds of check, in order: the value is in its enum, numbers are in
+ * range, and a parameter is only set when the thing it qualifies is also set.
+ * The last one is what stops "carry required" being stored against a
+ * multiplication-only template, where it would silently mean nothing.
+ */
+export function validateParams(p: QuestionTemplateParams): string | null {
+  if (p.numeralRange !== null && !oneOf(NUMERAL_RANGES, p.numeralRange)) {
+    return `numeralRange must be one of ${NUMERAL_RANGES.join(', ')}.`;
+  }
+  if (p.digitCount !== null && !oneOf(DIGIT_COUNTS, p.digitCount)) {
+    return `digitCount must be one of ${DIGIT_COUNTS.join(', ')}.`;
+  }
+
+  if (!Array.isArray(p.operations)) return 'operations must be an array.';
+  for (const op of p.operations) {
+    if (!oneOf(OPERATIONS, op)) return `operations may only contain ${OPERATIONS.join(', ')}.`;
+  }
+  if (new Set(p.operations).size !== p.operations.length) {
+    return 'operations must not repeat a value.';
+  }
+
+  if (p.maxOperandCount !== null && !oneOf(MAX_OPERAND_COUNTS, p.maxOperandCount)) {
+    return 'maxOperandCount must be 2, 3 or 4.';
+  }
+  if (p.carryBehavior !== null && !oneOf(CARRY_BEHAVIORS, p.carryBehavior)) {
+    return `carryBehavior must be one of ${CARRY_BEHAVIORS.join(', ')}.`;
+  }
+  if (p.borrowBehavior !== null && !oneOf(BORROW_BEHAVIORS, p.borrowBehavior)) {
+    return `borrowBehavior must be one of ${BORROW_BEHAVIORS.join(', ')}.`;
+  }
+  if (p.maxSumOrDifference !== null && !oneOf(MAX_SUM_OR_DIFFERENCES, p.maxSumOrDifference)) {
+    return `maxSumOrDifference must be one of ${MAX_SUM_OR_DIFFERENCES.join(', ')}.`;
+  }
+  if (p.answerType !== null && !oneOf(ANSWER_TYPES, p.answerType)) {
+    return `answerType must be one of ${ANSWER_TYPES.join(', ')}.`;
+  }
+  if (p.subjectCategory !== null && !oneOf(SUBJECT_CATEGORIES, p.subjectCategory)) {
+    return `subjectCategory must be one of ${SUBJECT_CATEGORIES.join(', ')}.`;
+  }
+
+  if (p.blankCount !== null) {
+    if (!Number.isInteger(p.blankCount) || p.blankCount < BLANK_COUNT_MIN || p.blankCount > BLANK_COUNT_MAX) {
+      return `blankCount must be an integer in [${BLANK_COUNT_MIN}, ${BLANK_COUNT_MAX}].`;
+    }
+  }
+  if (p.questionCount !== null) {
+    if (!Number.isInteger(p.questionCount) || p.questionCount < QUESTION_COUNT_MIN || p.questionCount > QUESTION_COUNT_MAX) {
+      return `questionCount must be an integer in [${QUESTION_COUNT_MIN}, ${QUESTION_COUNT_MAX}].`;
+    }
+  }
+
+  const hasAdd = p.operations.includes('add');
+  const hasSubtract = p.operations.includes('subtract');
+
+  if (p.carryBehavior !== null && !hasAdd) {
+    return "carryBehavior requires 'add' in operations.";
+  }
+  if (p.borrowBehavior !== null && !hasSubtract) {
+    return "borrowBehavior requires 'subtract' in operations.";
+  }
+  if (p.maxOperandCount !== null && !hasAdd && !hasSubtract) {
+    return "maxOperandCount requires 'add' or 'subtract' in operations.";
+  }
+  if (p.maxSumOrDifference !== null && !hasAdd && !hasSubtract) {
+    return "maxSumOrDifference requires 'add' or 'subtract' in operations.";
+  }
+  if (p.blankCount !== null && p.answerType !== 'fill-blanks') {
+    return "blankCount requires answerType 'fill-blanks'.";
+  }
+
+  return null;
+}
+
+const RANGE_LABELS: Record<NumeralRange, string> = {
+  '0-9': '0 to 9',
+  '0-20': '0 to 20',
+  '0-50': '0 to 50',
+  '0-100': '0 to 100',
+  '0-1000': '0 to 1000',
+  '0-10000': '0 to 10000',
+};
+
+const ANSWER_LABELS: Record<AnswerType, string> = {
+  'single-number': 'single number',
+  'mcq-4': 'MCQ',
+  'fill-blanks': 'fill in the blanks',
+  'true-false': 'true or false',
+  matching: 'matching',
+  trace: 'trace',
+};
+
+/**
+ * The human-readable name for a template, built from its parameters.
+ *
+ * Authors get this instead of naming every variation by hand, which is what
+ * keeps two templates with the same constraints from acquiring two different
+ * names. Stored rather than computed at read time so that an author who edits
+ * the name keeps their edit; regenerating it is an explicit action.
+ */
+export function deriveTemplateName(p: QuestionTemplateParams): string {
+  const parts: string[] = [];
+
+  if (p.operations.length > 0) {
+    parts.push(p.operations.join(' and '));
+  }
+  if (p.digitCount) parts.push(p.digitCount);
+  if (p.numeralRange) parts.push(RANGE_LABELS[p.numeralRange]);
+  if (p.maxOperandCount) parts.push(`${p.maxOperandCount} operands`);
+  if (p.carryBehavior) parts.push(`carry ${p.carryBehavior}`);
+  if (p.borrowBehavior) parts.push(`borrow ${p.borrowBehavior}`);
+  if (p.maxSumOrDifference) parts.push(`result ${p.maxSumOrDifference}`);
+  if (p.answerType) parts.push(ANSWER_LABELS[p.answerType]);
+  if (p.blankCount) parts.push(`${p.blankCount} blanks`);
+  if (p.subjectCategory) parts.push(p.subjectCategory);
+
+  if (parts.length === 0) return 'Unspecified variation';
+
+  const name = parts.join(', ');
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/**
+ * A stable fingerprint of the parameters, scoped to a concept.
+ *
+ * Two templates that constrain the same thing at the same level produce the
+ * same key, which is how duplicate variations are found. Order-insensitive on
+ * `operations` so that ['add','subtract'] and ['subtract','add'] do not read as
+ * two different variations.
+ */
+export function variantKeyFor(conceptId: string, p: QuestionTemplateParams): string {
+  const canonical = JSON.stringify([
+    conceptId,
+    [...p.operations].sort(),
+    p.numeralRange,
+    p.digitCount,
+    p.maxOperandCount,
+    p.carryBehavior,
+    p.borrowBehavior,
+    p.maxSumOrDifference,
+    p.answerType,
+    p.blankCount,
+    p.subjectCategory,
+  ]);
+  return createHash('sha1').update(canonical).digest('hex').slice(0, 16);
+}
+
+/** Everything the authoring form needs to render its controls, in one call. */
+export function getParamCatalog() {
+  return {
+    numeralRange: NUMERAL_RANGES,
+    digitCount: DIGIT_COUNTS,
+    operations: OPERATIONS,
+    carryBehavior: CARRY_BEHAVIORS,
+    borrowBehavior: BORROW_BEHAVIORS,
+    maxSumOrDifference: MAX_SUM_OR_DIFFERENCES,
+    maxOperandCount: MAX_OPERAND_COUNTS,
+    answerType: ANSWER_TYPES,
+    subjectCategory: SUBJECT_CATEGORIES,
+    blankCount: { min: BLANK_COUNT_MIN, max: BLANK_COUNT_MAX },
+    questionCount: { min: QUESTION_COUNT_MIN, max: QUESTION_COUNT_MAX, default: QUESTION_COUNT_DEFAULT },
+    contextRules: {
+      carryBehavior: { requiresOperation: 'add' },
+      borrowBehavior: { requiresOperation: 'subtract' },
+      maxOperandCount: { requiresAnyOperation: ['add', 'subtract'] },
+      maxSumOrDifference: { requiresAnyOperation: ['add', 'subtract'] },
+      blankCount: { requiresAnswerType: 'fill-blanks' },
+    },
+  };
+}

--- a/frontend/src/components/dashboards/SuperadminDashboard.tsx
+++ b/frontend/src/components/dashboards/SuperadminDashboard.tsx
@@ -9,7 +9,7 @@ import { UserCheck, CheckCircle2, XCircle } from 'lucide-react';
 import { Table, Column } from '../Table';
 import { SuperAdminExecutiveDashboard } from '../SuperAdminExecutiveDashboard';
 import { RegionalAnalyticsView } from './RegionalAnalyticsView';
-import { QuestionInterventionPanel } from '../panels/QuestionInterventionPanel';
+import { QuestionTemplatePanel } from '../panels/QuestionTemplatePanel';
 import { CurriculumLevelsPanel } from '../panels/CurriculumLevelsPanel';
 import { QuestionReviewPanel } from '../panels/QuestionReviewPanel';
 
@@ -689,7 +689,7 @@ export const SuperadminDashboard: React.FC<DashboardProps> = ({ user, token }) =
       )}
 
       {activeTab === 'intervention' && (
-        <QuestionInterventionPanel />
+        <QuestionTemplatePanel />
       )}
 
       {activeTab === 'curriculum' && (

--- a/frontend/src/components/panels/QuestionTemplatePanel.tsx
+++ b/frontend/src/components/panels/QuestionTemplatePanel.tsx
@@ -1,0 +1,833 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { FileQuestion, Layers, CheckCircle2, Shapes, Pencil, Trash2, X, Upload, ChevronDown, ChevronRight } from 'lucide-react';
+import { apiFetch } from '../../services/apiClient';
+import type {
+  QuestionTemplate,
+  QuestionTemplateParams,
+  QuestionTemplateStats,
+  LevelMapPayload,
+  ParamCatalog,
+  ImportResult,
+} from '../../types';
+
+const MAX_STEM_CHARS = 2000;
+const MAX_ANSWER_SPEC_CHARS = 500;
+
+const EMPTY_PARAMS: QuestionTemplateParams = {
+  numeralRange: null,
+  digitCount: null,
+  operations: [],
+  maxOperandCount: null,
+  carryBehavior: null,
+  borrowBehavior: null,
+  maxSumOrDifference: null,
+  answerType: null,
+  blankCount: null,
+  questionCount: null,
+  subjectCategory: null,
+};
+
+/**
+ * Superadmin authoring surface for questions.
+ *
+ * Authors write the question itself — the stem a child reads and how the
+ * answer is recorded — plus the constraints that govern the numbers inside
+ * it. The constraint controls render from `/param-catalog` rather than from a
+ * hardcoded list here, so adding a legal value later stays a backend change.
+ *
+ * Deliberately does not derive the variation name client-side. The server
+ * owns that string; a second implementation here would drift from it, and
+ * drifting copies of curriculum logic are the problem this feature exists to
+ * stop. The form shows what the server returned instead of predicting it.
+ */
+export const QuestionTemplatePanel: React.FC = () => {
+  const [levelMap, setLevelMap] = useState<LevelMapPayload | null>(null);
+  const [catalog, setCatalog] = useState<ParamCatalog | null>(null);
+  const [templates, setTemplates] = useState<QuestionTemplate[]>([]);
+  const [stats, setStats] = useState<QuestionTemplateStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Form state
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [level, setLevel] = useState<number | ''>('');
+  const [skills, setSkills] = useState<string[]>([]);
+  const [subskills, setSubskills] = useState<string[]>([]);
+  const [stem, setStem] = useState('');
+  const [answerSpec, setAnswerSpec] = useState('');
+  const [params, setParams] = useState<QuestionTemplateParams>(EMPTY_PARAMS);
+  const [name, setName] = useState('');
+  const [tagsText, setTagsText] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [duplicateWarning, setDuplicateWarning] = useState<string | null>(null);
+
+  // Which constraint groups are expanded. Collapsed by default: most questions
+  // need none of them, and an author who needs one goes looking for it.
+  const [openGroup, setOpenGroup] = useState<Record<string, boolean>>({});
+
+  // CSV import
+  const [showImport, setShowImport] = useState(false);
+  const [csvText, setCsvText] = useState('');
+  const [importResult, setImportResult] = useState<ImportResult | null>(null);
+  const [importing, setImporting] = useState(false);
+
+  // Filters on the list
+  const [filterLevel, setFilterLevel] = useState<number | ''>('');
+  const [filterSkill, setFilterSkill] = useState('');
+  const [filterTag, setFilterTag] = useState('');
+
+  const loadAll = async () => {
+    try {
+      const [mapRes, catRes, listRes, statsRes] = await Promise.all([
+        apiFetch('/api/question-templates/level-map'),
+        apiFetch('/api/question-templates/param-catalog'),
+        apiFetch('/api/question-templates'),
+        apiFetch('/api/question-templates/stats'),
+      ]);
+      if (!mapRes.ok || !catRes.ok || !listRes.ok || !statsRes.ok) {
+        setLoadError('Could not load questions. You may not have superadmin access.');
+        return;
+      }
+      setLevelMap(await mapRes.json());
+      setCatalog(await catRes.json());
+      setTemplates(await listRes.json());
+      setStats(await statsRes.json());
+      setLoadError(null);
+    } catch {
+      setLoadError('Could not reach the server.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { loadAll(); }, []);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 5000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const selectedLevel = useMemo(
+    () => (level === '' ? undefined : levelMap?.levels.find(l => l.levelNumber === level)),
+    [level, levelMap]
+  );
+
+  /** Only skills the chosen level actually maps to are offered. */
+  const availableSkills = useMemo(() => {
+    if (!selectedLevel || !levelMap) return [];
+    return levelMap.skills.filter(s => selectedLevel.skills.includes(s.id));
+  }, [selectedLevel, levelMap]);
+
+  /** Sub-skills are the union across every selected skill. */
+  const availableSubskills = useMemo(() => {
+    if (!levelMap) return [];
+    return levelMap.skills.filter(s => skills.includes(s.id)).flatMap(s => s.subskills);
+  }, [skills, levelMap]);
+
+  const allTags = useMemo(
+    () => Array.from(new Set(templates.flatMap(t => t.tags))).sort(),
+    [templates]
+  );
+
+  const hasAdd = params.operations.includes('add');
+  const hasSubtract = params.operations.includes('subtract');
+  const isFillBlanks = params.answerType === 'fill-blanks';
+
+  const setParam = <K extends keyof QuestionTemplateParams>(key: K, value: QuestionTemplateParams[K]) => {
+    setFormError(null);
+    setParams(prev => {
+      const next = { ...prev, [key]: value };
+      // Clearing the context also clears what it qualified, so the form never
+      // holds a combination the server would reject. Doing this on the way in
+      // is kinder than explaining the rejection afterwards.
+      if (key === 'operations') {
+        const ops = value as string[];
+        if (!ops.includes('add')) next.carryBehavior = null;
+        if (!ops.includes('subtract')) next.borrowBehavior = null;
+        if (!ops.includes('add') && !ops.includes('subtract')) {
+          next.maxOperandCount = null;
+          next.maxSumOrDifference = null;
+        }
+      }
+      if (key === 'answerType' && value !== 'fill-blanks') next.blankCount = null;
+      return next;
+    });
+  };
+
+  const toggleOperation = (op: string) => {
+    const next = params.operations.includes(op)
+      ? params.operations.filter(o => o !== op)
+      : [...params.operations, op];
+    setParam('operations', next);
+  };
+
+  /**
+   * Changing the level re-filters the skill list, so any selection that is no
+   * longer valid has to be dropped — otherwise the form would show a skill the
+   * new level cannot host and the save would fail server-side with a confusing
+   * error. Same for sub-skills whose parent skill is gone.
+   */
+  const onLevelChange = (next: number | '') => {
+    setLevel(next);
+    setFormError(null);
+    if (next === '' || !levelMap) { setSkills([]); setSubskills([]); return; }
+    const lvl = levelMap.levels.find(l => l.levelNumber === next);
+    const stillValidSkills = skills.filter(s => lvl?.skills.includes(s));
+    setSkills(stillValidSkills);
+    setSubskills(prev => prev.filter(ss => stillValidSkills.includes(ss.split('.')[0])));
+  };
+
+  const toggleSkill = (skillId: string) => {
+    setFormError(null);
+    setSkills(prev => {
+      const next = prev.includes(skillId) ? prev.filter(s => s !== skillId) : [...prev, skillId];
+      setSubskills(cur => cur.filter(ss => next.includes(ss.split('.')[0])));
+      return next;
+    });
+  };
+
+  const toggleSubskill = (id: string) => {
+    setFormError(null);
+    setSubskills(prev => (prev.includes(id) ? prev.filter(s => s !== id) : [...prev, id]));
+  };
+
+  const resetForm = () => {
+    setEditingId(null);
+    setLevel('');
+    setSkills([]);
+    setSubskills([]);
+    setStem('');
+    setAnswerSpec('');
+    setParams(EMPTY_PARAMS);
+    setName('');
+    setTagsText('');
+    setFormError(null);
+    setDuplicateWarning(null);
+  };
+
+  const startEdit = (t: QuestionTemplate) => {
+    setEditingId(t.id);
+    setLevel(t.levelNumber);
+    setSkills(t.skills);
+    setSubskills(t.subskills);
+    setStem(t.stem);
+    setAnswerSpec(t.answerSpec);
+    setParams({
+      numeralRange: t.numeralRange,
+      digitCount: t.digitCount,
+      operations: t.operations,
+      maxOperandCount: t.maxOperandCount,
+      carryBehavior: t.carryBehavior,
+      borrowBehavior: t.borrowBehavior,
+      maxSumOrDifference: t.maxSumOrDifference,
+      answerType: t.answerType,
+      blankCount: t.blankCount,
+      questionCount: t.questionCount,
+      subjectCategory: t.subjectCategory,
+    });
+    setName(t.name);
+    setTagsText(t.tags.join(', '));
+    setFormError(null);
+    setDuplicateWarning(null);
+    setOpenGroup({ numbers: true, operations: true, answer: true, subject: true });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const save = async () => {
+    setFormError(null);
+    setDuplicateWarning(null);
+    if (level === '') return setFormError('Pick a level.');
+    if (skills.length === 0) return setFormError('Pick at least one skill.');
+    if (!stem.trim()) return setFormError('Write the question.');
+    if (!selectedLevel) return setFormError('That level is no longer available. Reload the page.');
+
+    setSaving(true);
+    try {
+      // The level picker is a convenience; the concept is what gets stored.
+      const body = {
+        conceptId: selectedLevel.sCode,
+        skills,
+        subskills,
+        stem: stem.trim(),
+        answerSpec: answerSpec.trim(),
+        ...params,
+        name: name.trim(),
+        tags: tagsText.split(',').map(s => s.trim()).filter(Boolean),
+      };
+
+      const res = editingId
+        ? await apiFetch(`/api/question-templates/${editingId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          })
+        : await apiFetch('/api/question-templates', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        setFormError(err.error || 'Save failed.');
+        return;
+      }
+
+      const payload = await res.json();
+      const wasEditing = Boolean(editingId);
+      const saved: QuestionTemplate = wasEditing ? payload : payload.template;
+
+      // Reported, not blocked: two Superadmins may legitimately author the same
+      // variation with different questions. Better seen here than discovered in
+      // a generated paper.
+      if (!wasEditing && payload.duplicateVariants?.length > 0) {
+        setDuplicateWarning(
+          `${payload.duplicateVariants.length} other question(s) already use these same options at this level: ` +
+          payload.duplicateVariants.map((d: { name: string }) => d.name).join('; ')
+        );
+      }
+
+      await loadAll();
+      resetForm();
+      setToast(wasEditing ? 'Updated.' : `Saved as "${saved.name}".`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (t: QuestionTemplate) => {
+    if (!window.confirm(`Delete "${t.name}"? It will no longer be used for question generation.`)) return;
+    const res = await apiFetch(`/api/question-templates/${t.id}`, { method: 'DELETE' });
+    if (!res.ok) { setToast('Delete failed.'); return; }
+    if (editingId === t.id) resetForm();
+    await loadAll();
+    setToast('Deleted.');
+  };
+
+  /**
+   * Dry run first, then the real import.
+   *
+   * Both send the same body; only `dryRun` differs. The preview is therefore
+   * exactly the check the import will run, not an approximation of it.
+   */
+  const runImport = async (dryRun: boolean) => {
+    setImporting(true);
+    setImportResult(null);
+    try {
+      const res = await apiFetch('/api/question-templates/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ csv: csvText, dryRun }),
+      });
+      const payload: ImportResult = await res.json();
+      setImportResult(payload);
+      if (res.ok && !dryRun) {
+        await loadAll();
+        setCsvText('');
+        setToast(`Imported ${payload.imported} question(s).`);
+      }
+    } catch {
+      setImportResult({ imported: 0, rowsRead: 0, errors: [], error: 'Could not reach the server.' });
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  /**
+   * Fetch the header row and hand it to the browser as a file.
+   *
+   * Not a plain link: the API is authenticated with a bearer token from
+   * localStorage, which an <a href> cannot send, so a link would 403. Going
+   * through apiFetch also keeps the deployment's base path applied.
+   */
+  const downloadCsvTemplate = async () => {
+    const res = await apiFetch('/api/question-templates/csv-template');
+    if (!res.ok) { setToast('Could not download the column headings.'); return; }
+    const blob = new Blob([await res.text()], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'question-template-columns.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const onCsvFile = async (file: File | undefined) => {
+    if (!file) return;
+    setImportResult(null);
+    setCsvText(await file.text());
+  };
+
+  const visibleTemplates = useMemo(() => templates.filter(t =>
+    (filterLevel === '' || t.levelNumber === filterLevel) &&
+    (filterSkill === '' || t.skills.includes(filterSkill)) &&
+    (filterTag === '' || t.tags.includes(filterTag))
+  ), [templates, filterLevel, filterSkill, filterTag]);
+
+  if (loading) {
+    return <div className="p-6 text-zinc-500 dark:text-zinc-400">Loading questions…</div>;
+  }
+
+  if (loadError) {
+    return (
+      <div className="p-6">
+        <div className="rounded-lg border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4 text-red-800 dark:text-red-300">
+          {loadError}
+        </div>
+      </div>
+    );
+  }
+
+  const cardCls = 'rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 p-4';
+  const labelCls = 'text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400';
+  const inputCls = 'mt-1 w-full rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-3 py-2 text-sm text-zinc-900 dark:text-white';
+  const chipCls = (on: boolean) =>
+    `rounded-md border px-3 py-1.5 text-sm transition-colors ${
+      on
+        ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200'
+        : 'border-zinc-300 dark:border-zinc-600 text-zinc-700 dark:text-zinc-300 hover:border-zinc-400'
+    }`;
+
+  /** One collapsible constraint group. */
+  const Group: React.FC<{ id: string; title: string; summary: string; children: React.ReactNode }> =
+    ({ id, title, summary, children }) => (
+      <div className="rounded-md border border-zinc-200 dark:border-zinc-700">
+        <button
+          type="button"
+          onClick={() => setOpenGroup(g => ({ ...g, [id]: !g[id] }))}
+          aria-expanded={Boolean(openGroup[id])}
+          className="flex w-full items-center justify-between px-3 py-2 text-left"
+        >
+          <span className="text-sm font-medium text-zinc-800 dark:text-zinc-200">{title}</span>
+          <span className="flex items-center gap-2">
+            <span className="text-xs text-zinc-500 dark:text-zinc-400">{summary}</span>
+            {openGroup[id] ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
+          </span>
+        </button>
+        {openGroup[id] && <div className="space-y-3 border-t border-zinc-200 dark:border-zinc-700 px-3 py-3">{children}</div>}
+      </div>
+    );
+
+  /** A one-of-many picker that can also be cleared back to "not specified". */
+  const EnumRow: React.FC<{ label: string; values: Array<string | number>; value: string | number | null; onPick: (v: any) => void; disabled?: boolean; hint?: string }> =
+    ({ label, values, value, onPick, disabled, hint }) => (
+      <div>
+        <div className={labelCls}>{label}</div>
+        {disabled ? (
+          <p className="mt-1 text-xs text-zinc-400 dark:text-zinc-500">{hint}</p>
+        ) : (
+          <div className="mt-1 flex flex-wrap gap-2">
+            {values.map(v => (
+              <button key={String(v)} type="button" onClick={() => onPick(value === v ? null : v)}
+                aria-pressed={value === v} className={chipCls(value === v)}>
+                {String(v)}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+
+  return (
+    <div className="space-y-6">
+      {/* Header counters */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className={cardCls}>
+          <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400"><FileQuestion size={16} /><span className={labelCls}>Total questions</span></div>
+          <div className="mt-2 text-3xl font-bold text-zinc-900 dark:text-white tabular-nums">{stats?.totalTemplates ?? 0}</div>
+        </div>
+        <div className={cardCls}>
+          <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400"><Layers size={16} /><span className={labelCls}>Total levels</span></div>
+          <div className="mt-2 text-3xl font-bold text-zinc-900 dark:text-white tabular-nums">{stats?.totalLevels ?? 0}</div>
+        </div>
+        <div className={cardCls}>
+          <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400"><CheckCircle2 size={16} /><span className={labelCls}>Levels with a question</span></div>
+          <div className="mt-2 text-3xl font-bold text-zinc-900 dark:text-white tabular-nums">
+            {stats?.levelsWithTemplate ?? 0}
+            <span className="text-lg font-normal text-zinc-400 dark:text-zinc-500"> / {stats?.totalLevels ?? 0}</span>
+          </div>
+        </div>
+        <div className={cardCls}>
+          <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400"><Shapes size={16} /><span className={labelCls}>Distinct variations</span></div>
+          <div className="mt-2 text-3xl font-bold text-zinc-900 dark:text-white tabular-nums">{stats?.distinctVariants ?? 0}</div>
+        </div>
+      </div>
+
+      {toast && (
+        <div className="rounded-lg border border-emerald-300 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 px-4 py-3 text-sm text-emerald-800 dark:text-emerald-300">
+          {toast}
+        </div>
+      )}
+
+      {duplicateWarning && (
+        <div className="rounded-lg border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
+          {duplicateWarning}
+        </div>
+      )}
+
+      {/* Authoring form */}
+      <div className={cardCls}>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">
+            {editingId ? 'Edit question' : 'New question'}
+          </h3>
+          <div className="flex items-center gap-3">
+            <button onClick={() => setShowImport(v => !v)} className="flex items-center gap-1 text-sm text-indigo-600 dark:text-indigo-400 hover:underline">
+              <Upload size={14} /> Bulk upload CSV
+            </button>
+            {editingId && (
+              <button onClick={resetForm} className="flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200">
+                <X size={14} /> Cancel edit
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          {/* Step 1 — level */}
+          <div>
+            <label htmlFor="qt-level" className={labelCls}>Step 1 — Level (required)</label>
+            <select id="qt-level" value={level} className={inputCls}
+              onChange={e => onLevelChange(e.target.value === '' ? '' : Number(e.target.value))}>
+              <option value="">Select a level…</option>
+              {levelMap?.levels.map(l => (
+                <option key={l.levelId} value={l.levelNumber}>{l.stage} · {l.levelId} — {l.capability}</option>
+              ))}
+            </select>
+            {selectedLevel && (
+              <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                Stored against concept {selectedLevel.sCode}. {selectedLevel.stage} · {selectedLevel.skills.length} skill(s) mapped.
+              </p>
+            )}
+          </div>
+
+          {/* Step 2 — skills */}
+          <div>
+            <label className={labelCls}>Step 2 — Skills (required, multi-select)</label>
+            {!selectedLevel ? (
+              <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-500">Pick a level first.</p>
+            ) : availableSkills.length === 0 ? (
+              <p className="mt-1 text-sm text-amber-700 dark:text-amber-400">
+                {selectedLevel.levelId} has no skills mapped to it. A question cannot be authored for this level.
+              </p>
+            ) : (
+              <div className="mt-1 flex flex-wrap gap-2">
+                {availableSkills.map(s => (
+                  <button key={s.id} type="button" onClick={() => toggleSkill(s.id)}
+                    aria-pressed={skills.includes(s.id)} className={chipCls(skills.includes(s.id))}>
+                    {s.id} — {s.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Step 3 — sub-skills */}
+          <div>
+            <label className={labelCls}>Step 3 — Sub-skills (optional)</label>
+            {skills.length === 0 ? (
+              <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-500">Pick at least one skill first.</p>
+            ) : availableSubskills.length === 0 ? (
+              <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">These skills have no observable sub-skills.</p>
+            ) : (
+              <>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {availableSubskills.map(ss => (
+                    <button key={ss.id} type="button" onClick={() => toggleSubskill(ss.id)}
+                      aria-pressed={subskills.includes(ss.id)}
+                      className={`rounded-md border px-2.5 py-1 text-xs transition-colors ${
+                        subskills.includes(ss.id)
+                          ? 'border-teal-500 bg-teal-50 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200'
+                          : 'border-zinc-300 dark:border-zinc-600 text-zinc-600 dark:text-zinc-400 hover:border-zinc-400'
+                      }`}>
+                      {ss.id} · {ss.name}
+                    </button>
+                  ))}
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  {subskills.length} selected. Leaving this empty assesses the skill at full granularity.
+                </p>
+              </>
+            )}
+          </div>
+
+          {/* Step 4 — the question itself */}
+          <div>
+            <label htmlFor="qt-stem" className={labelCls}>Step 4 — The question (required)</label>
+            <textarea id="qt-stem" value={stem} rows={3} className={inputCls}
+              onChange={e => { setStem(e.target.value.slice(0, MAX_STEM_CHARS)); setFormError(null); }}
+              placeholder={'e.g. "{a} + {b} = ___"  or  "Count the apples and write how many."'} />
+            <div className="mt-1 flex justify-between text-xs text-zinc-500 dark:text-zinc-400">
+              <span>Anything in braces, like {'{a}'}, is filled in from the options below. A question with no braces is a fixed question.</span>
+              <span className="tabular-nums">{stem.length} / {MAX_STEM_CHARS}</span>
+            </div>
+
+            <label htmlFor="qt-answer" className={`${labelCls} mt-3 block`}>Answer (optional)</label>
+            <input id="qt-answer" value={answerSpec} className={inputCls}
+              onChange={e => { setAnswerSpec(e.target.value.slice(0, MAX_ANSWER_SPEC_CHARS)); setFormError(null); }}
+              placeholder={'e.g. "{a}+{b}"  or  "7"'} />
+          </div>
+
+          {/* Step 5 — the options that govern the numbers */}
+          <div className="space-y-2">
+            <div className={labelCls}>Step 5 — Options (all optional)</div>
+
+            <Group id="numbers" title="Numbers and range"
+              summary={[params.numeralRange, params.digitCount].filter(Boolean).join(', ') || 'not set'}>
+              <EnumRow label="Number range" values={catalog?.numeralRange ?? []} value={params.numeralRange}
+                onPick={v => setParam('numeralRange', v)} />
+              <EnumRow label="Size of the numbers used" values={catalog?.digitCount ?? []} value={params.digitCount}
+                onPick={v => setParam('digitCount', v)} />
+            </Group>
+
+            <Group id="operations" title="Operations"
+              summary={params.operations.length ? params.operations.join(', ') : 'not set'}>
+              <div>
+                <div className={labelCls}>Operations</div>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {(catalog?.operations ?? []).map(op => (
+                    <button key={op} type="button" onClick={() => toggleOperation(op)}
+                      aria-pressed={params.operations.includes(op)} className={chipCls(params.operations.includes(op))}>
+                      {op}
+                    </button>
+                  ))}
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  Leaving this empty means the operation has not been specified.
+                </p>
+              </div>
+
+              <EnumRow label="Numbers per sum" values={catalog?.maxOperandCount ?? []} value={params.maxOperandCount}
+                onPick={v => setParam('maxOperandCount', v)} disabled={!hasAdd && !hasSubtract}
+                hint="Pick add or subtract first." />
+              <EnumRow label="Carrying" values={catalog?.carryBehavior ?? []} value={params.carryBehavior}
+                onPick={v => setParam('carryBehavior', v)} disabled={!hasAdd} hint="Pick add first." />
+              <EnumRow label="Borrowing" values={catalog?.borrowBehavior ?? []} value={params.borrowBehavior}
+                onPick={v => setParam('borrowBehavior', v)} disabled={!hasSubtract} hint="Pick subtract first." />
+              <EnumRow label="Largest answer" values={catalog?.maxSumOrDifference ?? []} value={params.maxSumOrDifference}
+                onPick={v => setParam('maxSumOrDifference', v)} disabled={!hasAdd && !hasSubtract}
+                hint="Pick add or subtract first." />
+            </Group>
+
+            <Group id="answer" title="Answer shape"
+              summary={[params.answerType, params.blankCount ? `${params.blankCount} blanks` : null].filter(Boolean).join(', ') || 'not set'}>
+              <EnumRow label="How the child answers" values={catalog?.answerType ?? []} value={params.answerType}
+                onPick={v => setParam('answerType', v)} />
+              <div>
+                <div className={labelCls}>Number of blanks</div>
+                {!isFillBlanks ? (
+                  <p className="mt-1 text-xs text-zinc-400 dark:text-zinc-500">Choose "fill-blanks" first.</p>
+                ) : (
+                  <input type="number" className={inputCls} value={params.blankCount ?? ''}
+                    min={catalog?.blankCount.min} max={catalog?.blankCount.max}
+                    onChange={e => setParam('blankCount', e.target.value === '' ? null : Number(e.target.value))} />
+                )}
+              </div>
+              <div>
+                <div className={labelCls}>Questions per paper</div>
+                <input type="number" className={inputCls} value={params.questionCount ?? ''}
+                  min={catalog?.questionCount.min} max={catalog?.questionCount.max}
+                  placeholder={String(catalog?.questionCount.default ?? 10)}
+                  onChange={e => setParam('questionCount', e.target.value === '' ? null : Number(e.target.value))} />
+              </div>
+            </Group>
+
+            <Group id="subject" title="Picture theme" summary={params.subjectCategory ?? 'not set'}>
+              <EnumRow label="Theme for counting questions" values={catalog?.subjectCategory ?? []}
+                value={params.subjectCategory} onPick={v => setParam('subjectCategory', v)} />
+              <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                Chooses the picture theme. The picture library itself is not built yet, so this is recorded but not yet drawn.
+              </p>
+            </Group>
+          </div>
+
+          {/* Step 6 — naming and tags */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label htmlFor="qt-name" className={labelCls}>Step 6 — Name (optional)</label>
+              <input id="qt-name" value={name} className={inputCls} onChange={e => setName(e.target.value)}
+                placeholder="Leave empty to name it from the options above" />
+              <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                Left empty, the name is built from the options, for example "Add, 2-digit, carry required, fruits".
+              </p>
+            </div>
+            <div>
+              <label htmlFor="qt-tags" className={labelCls}>Tags (optional, comma separated)</label>
+              <input id="qt-tags" value={tagsText} className={inputCls} onChange={e => setTagsText(e.target.value)}
+                placeholder="e.g. baseline, revision" />
+            </div>
+          </div>
+
+          {formError && (
+            <div className="rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-800 dark:text-red-300">
+              {formError}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={resetForm} disabled={saving}
+              className="rounded-md border border-zinc-300 dark:border-zinc-600 px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 disabled:opacity-50">
+              Clear
+            </button>
+            <button type="button" onClick={save} disabled={saving}
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50">
+              {saving ? 'Saving…' : editingId ? 'Update' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* CSV import */}
+      {showImport && (
+        <div className={cardCls}>
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">Bulk upload</h3>
+            <button type="button" onClick={downloadCsvTemplate}
+              className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline">
+              Download the column headings
+            </button>
+          </div>
+
+          <p className="text-sm text-zinc-600 dark:text-zinc-300">
+            Every row is checked before anything is saved. If any row has a problem, nothing is imported and
+            the row numbers are listed below. Lists inside a cell are separated with a vertical bar, for
+            example <code className="rounded bg-zinc-100 dark:bg-zinc-900 px-1">SK03|SK07</code>.
+          </p>
+
+          <input type="file" accept=".csv,text/csv" className="mt-3 block text-sm text-zinc-600 dark:text-zinc-300"
+            onChange={e => onCsvFile(e.target.files?.[0])} />
+
+          <textarea value={csvText} rows={6} className={`${inputCls} mt-3 font-mono text-xs`}
+            onChange={e => { setCsvText(e.target.value); setImportResult(null); }}
+            placeholder="…or paste the file contents here." />
+
+          <div className="mt-3 flex justify-end gap-2">
+            <button type="button" onClick={() => runImport(true)} disabled={importing || !csvText.trim()}
+              className="rounded-md border border-zinc-300 dark:border-zinc-600 px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 disabled:opacity-50">
+              {importing ? 'Checking…' : 'Check the file'}
+            </button>
+            <button type="button" onClick={() => runImport(false)}
+              disabled={importing || !csvText.trim() || !importResult?.dryRun || (importResult?.errors?.length ?? 0) > 0}
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50">
+              Import
+            </button>
+          </div>
+
+          {importResult && (
+            <div className="mt-3 space-y-2 text-sm">
+              {importResult.error && (
+                <div className="rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-3 py-2 text-red-800 dark:text-red-300">
+                  {importResult.error}
+                </div>
+              )}
+              {importResult.errors.length > 0 && (
+                <ul className="max-h-48 overflow-y-auto rounded-md border border-zinc-200 dark:border-zinc-700 divide-y divide-zinc-100 dark:divide-zinc-800">
+                  {importResult.errors.map(e => (
+                    <li key={e.row} className="px-3 py-1.5 text-zinc-700 dark:text-zinc-300">
+                      <span className="font-medium">Row {e.row}:</span> {e.error}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {importResult.dryRun && importResult.errors.length === 0 && (
+                <div className="rounded-md border border-emerald-300 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 px-3 py-2 text-emerald-800 dark:text-emerald-300">
+                  {importResult.wouldImport} row(s) are ready to import.
+                  {(importResult.alreadyExists?.length ?? 0) > 0 &&
+                    ` ${importResult.alreadyExists!.length} of them repeat a variation that already exists.`}
+                  {(importResult.repeatedInFile?.length ?? 0) > 0 &&
+                    ` ${importResult.repeatedInFile!.length} variation(s) appear more than once in this file.`}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Existing questions */}
+      <div className={cardCls}>
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+          <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">
+            Existing questions <span className="text-sm font-normal text-zinc-500">({visibleTemplates.length})</span>
+          </h3>
+          <div className="flex gap-2">
+            <select aria-label="Filter by level" value={filterLevel}
+              onChange={e => setFilterLevel(e.target.value === '' ? '' : Number(e.target.value))}
+              className="rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-2 py-1.5 text-sm text-zinc-900 dark:text-white">
+              <option value="">All levels</option>
+              {levelMap?.levels.map(l => <option key={l.levelId} value={l.levelNumber}>{l.levelId}</option>)}
+            </select>
+            <select aria-label="Filter by skill" value={filterSkill} onChange={e => setFilterSkill(e.target.value)}
+              className="rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-2 py-1.5 text-sm text-zinc-900 dark:text-white">
+              <option value="">All skills</option>
+              {levelMap?.skills.map(s => <option key={s.id} value={s.id}>{s.id}</option>)}
+            </select>
+            <select aria-label="Filter by tag" value={filterTag} onChange={e => setFilterTag(e.target.value)}
+              className="rounded-md border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-900 px-2 py-1.5 text-sm text-zinc-900 dark:text-white">
+              <option value="">All tags</option>
+              {allTags.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </div>
+        </div>
+
+        {visibleTemplates.length === 0 ? (
+          <p className="py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">
+            {templates.length === 0
+              ? 'No questions yet. Author the first one above, or upload a CSV.'
+              : 'No questions match these filters.'}
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-200 dark:border-zinc-700 text-left text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  <th className="py-2 pr-3 font-medium">Level</th>
+                  <th className="py-2 pr-3 font-medium">Name</th>
+                  <th className="py-2 pr-3 font-medium">Question</th>
+                  <th className="py-2 pr-3 font-medium">Skills</th>
+                  <th className="py-2 pr-3 font-medium">Tags</th>
+                  <th className="py-2 pr-3 font-medium">Created by</th>
+                  <th className="py-2 font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleTemplates.map(t => (
+                  <tr key={t.id} className="border-b border-zinc-100 dark:border-zinc-800 align-top">
+                    <td className="py-3 pr-3 whitespace-nowrap text-zinc-900 dark:text-white">
+                      L{t.levelNumber}
+                      <div className="text-xs text-zinc-500 dark:text-zinc-400">{t.conceptId}</div>
+                    </td>
+                    <td className="py-3 pr-3 text-zinc-800 dark:text-zinc-200 max-w-xs">{t.name}</td>
+                    <td className="py-3 pr-3 text-zinc-700 dark:text-zinc-300 max-w-md">
+                      {t.stem.length > 70 ? `${t.stem.slice(0, 70)}…` : t.stem}
+                    </td>
+                    <td className="py-3 pr-3 text-zinc-600 dark:text-zinc-300">{t.skills.join(', ')}</td>
+                    <td className="py-3 pr-3 text-zinc-500 dark:text-zinc-400">{t.tags.length ? t.tags.join(', ') : '—'}</td>
+                    <td className="py-3 pr-3 text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+                      {t.createdByEmail}
+                      {t.source === 'csv' && <div className="text-xs">via upload</div>}
+                    </td>
+                    <td className="py-3 whitespace-nowrap">
+                      <button onClick={() => startEdit(t)} aria-label={`Edit ${t.name}`}
+                        className="mr-2 inline-flex items-center gap-1 text-indigo-600 dark:text-indigo-400 hover:underline">
+                        <Pencil size={13} /> Edit
+                      </button>
+                      <button onClick={() => remove(t)} aria-label={`Delete ${t.name}`}
+                        className="inline-flex items-center gap-1 text-red-600 dark:text-red-400 hover:underline">
+                        <Trash2 size={13} /> Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default QuestionTemplatePanel;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -365,6 +365,103 @@ export interface QuestionLogicStats {
   levelsWithLogic: number;
 }
 
+/**
+ * A Superadmin-authored question: the stem a child reads, how the answer is
+ * recorded, and the constraints governing the numbers inside it.
+ * Mirrors `QuestionTemplate` in `backend/src/db.ts`.
+ */
+export interface QuestionTemplate {
+  id: string;
+  /** Canonical curriculum identity, e.g. "S3.4". Level number is a display alias. */
+  conceptId: string;
+  levelNumber: number;
+  levelName: string;
+  skills: string[];
+  subskills: string[];
+  stem: string;
+  answerSpec: string;
+  numeralRange: string | null;
+  digitCount: string | null;
+  /** Empty means "not specified", not "any operation". */
+  operations: string[];
+  maxOperandCount: number | null;
+  carryBehavior: string | null;
+  borrowBehavior: string | null;
+  maxSumOrDifference: string | null;
+  answerType: string | null;
+  blankCount: number | null;
+  questionCount: number | null;
+  subjectCategory: string | null;
+  name: string;
+  variantKey: string;
+  tags: string[];
+  source: 'form' | 'csv';
+  createdBy: string;
+  createdByEmail: string;
+  createdAt: string;
+  updatedAt: string;
+  updatedBy: string;
+  updatedByEmail: string;
+  deletedAt: string | null;
+  deletedBy: string | null;
+}
+
+/** The structured half of a template, as the form holds it before saving. */
+export interface QuestionTemplateParams {
+  numeralRange: string | null;
+  digitCount: string | null;
+  operations: string[];
+  maxOperandCount: number | null;
+  carryBehavior: string | null;
+  borrowBehavior: string | null;
+  maxSumOrDifference: string | null;
+  answerType: string | null;
+  blankCount: number | null;
+  questionCount: number | null;
+  subjectCategory: string | null;
+}
+
+export interface QuestionTemplateStats {
+  totalTemplates: number;
+  totalLevels: number;
+  levelsWithTemplate: number;
+  distinctVariants: number;
+}
+
+/**
+ * Payload of `GET /api/question-templates/param-catalog`.
+ *
+ * The form renders its controls from this rather than from a hardcoded list,
+ * so adding a legal value later is a backend-only change.
+ */
+export interface ParamCatalog {
+  numeralRange: string[];
+  digitCount: string[];
+  operations: string[];
+  carryBehavior: string[];
+  borrowBehavior: string[];
+  maxSumOrDifference: string[];
+  maxOperandCount: number[];
+  answerType: string[];
+  subjectCategory: string[];
+  blankCount: { min: number; max: number };
+  questionCount: { min: number; max: number; default: number };
+  contextRules: Record<string, { requiresOperation?: string; requiresAnyOperation?: string[]; requiresAnswerType?: string }>;
+}
+
+/** Result of `POST /api/question-templates/import`, for both the dry run and the real one. */
+export interface ImportResult {
+  dryRun?: boolean;
+  imported: number;
+  rowsRead: number;
+  wouldImport?: number;
+  errors: Array<{ row: number; error: string }>;
+  error?: string;
+  repeatedInFile?: Array<{ variantKey: string; count: number }>;
+  alreadyExists?: string[];
+  preview?: Array<{ conceptId: string; name: string; stem: string }>;
+}
+
 /** Payload of `GET /api/question-logics/level-map` — drives the cascading dropdowns. */
 export interface LevelMapPayload {
   levelCount: number;


### PR DESCRIPTION
Superadmins can now author questions directly, one at a time in the panel or in bulk from a CSV, instead of writing a prose instruction and leaving the generator to interpret it.

## What changed

A new `questionTemplates` collection holds the question itself: the stem a child reads, how the answer is derived, and the structured options that govern the numbers inside it (range, digit size, operations, carry and borrow, largest answer, answer shape, blanks, questions per paper, picture theme). Each row also carries a name, a variation fingerprint and free-form tags.

The Superadmin dashboard's Question Intervention tab now renders the new panel. `questionLogics` is untouched: the collection, its routes and its data all stay exactly as they were, and the old panel file remains in the repo, unrouted. Nothing is deleted and nothing is migrated.

## Two decisions worth reviewing

**Templates are keyed by `conceptId`, never by level number.** The level number is stored beside it as a display alias and recomputed on write. This matters because level numbers are about to become insertable and re-orderable, and they cannot be renumbered: `questionBankId()` bakes the level integer into stored question ids, and `Student.currentLevel`, `targetLevel` and `levelHistory` all hold it too. Addressing by concept means the coming insertion work cannot orphan anything authored here.

**Empty `operations` means "not specified", not "any operation".** The spec this came from used both readings, which conflict as soon as the context rules reject `carryBehavior` without an explicit `add`. One reading had to win.

## The CSV import is all or nothing

Every row is validated before anything is written. If one row fails, nothing is imported and the failing row numbers come back. A partial import leaves the author reconciling a half-written file against an error list by hand, which is harder than fixing the file and trying again. `dryRun` runs exactly the same checks and writes nothing, so the preview is the import rather than an approximation of it.

## Naming

The variation name is derived from the options, so nobody names variations by hand and two authors setting the same options get the same name. An author who edits the name keeps their edit; re-deriving it is an explicit `regenerateName` flag. The derivation lives only on the server. The panel deliberately does not reimplement it, because a second copy would drift, and drifting copies of curriculum logic are the problem this feature exists to reduce.

## Also here

- The superadmin guard moves to a shared module. Two copies drift, and a guard that is 403 in one file and 401 in another is a real access bug.
- `questionLogics` gains the unique `id` index it has never had, which `getQuestionLogicById` has been querying without.
- `questionTemplates` gets indexes on `conceptId`, `variantKey` and `tags`.

## Testing

Verified end to end against a local MongoDB with seeded data, then the scratch database was dropped:

- 403 for a non-superadmin and for an unauthenticated request, on both the new and existing routes.
- All seven validation rejections return the intended message: carry without add, unknown concept, skill not mapped to the level, orphaned sub-skill, empty stem, blanks without fill-blanks, and out-of-range question count.
- Duplicate variations are reported on create, not blocked.
- Tags normalise: `["Baseline", " baseline ", "Revision"]` stores as `['baseline', 'revision']`.
- Dry run leaves the count unchanged; the real import writes; a quoted comma inside a stem survives the round trip.
- PATCH preserves a hand-written name, `regenerateName` rebuilds it, and changing only the concept returns an actionable error naming the skills that would not fit.
- Soft delete removes the row from the live list.
- `questionLogics` create and stats still work after the guard extraction.

Also 17 assertions on the parameter validators, naming and fingerprint, and 8 on the CSV reader covering quoted commas, escaped quotes, newlines inside quotes, CRLF and blank lines. Both packages typecheck and build.

## Not in this PR

- **Nothing reads the templates yet.** No generator consumes them: `paperGenerator.ts` and `levelGenerator.ts` are untouched. This is authoring only, by design.
- **Inserting levels between existing levels, and sub-levels.** These need the curriculum moved off the build-time `skillLevelMap.json` snapshot onto the `curriculumLevels` collection first, plus an explicit `sortOrder`. Separate PR.
- **The picture library** behind the theme setting. The setting is recorded; the assets are a separate piece of work.

## One thing to flag

The source spec describes the eleven options but contains no question format: no stem, no answer, no naming scheme. `stem`, `answerSpec` and `name` are therefore our design rather than the spec's. If there is an intended format, those three fields are where it lands, and changing them after rows exist means a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
