### PR TITLE
feat: author generation intent and SVG themes, with a data-driven option catalog

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -682,16 +682,45 @@ export interface QuestionTemplate {
   subskills: string[];
 
   /**
-   * What the child reads. Placeholders in braces are filled by the generator
-   * from the constraints below, e.g. "{a} + {b} = ___". A stem with no
-   * placeholder is a fixed question and is equally valid.
+   * What the question should make the child do, in the author's words. This is
+   * an instruction to the generator, not a finished question: it names the
+   * learning action, the visual behaviour, and how the answer is given.
+   *
+   * Required for structured records. Deliberately never contains a specific
+   * number or object, so one intent can be rendered across every visual theme
+   * without being re-authored.
+   */
+  generationIntent: string;
+
+  /** Which family of question this intent produces. Governs how it is rendered. */
+  questionFamily: 'counting' | 'operation';
+
+  /**
+   * How this row was authored. `structured` rows carry a generationIntent and
+   * no authored answer. `legacy-free-text` rows predate that and carry a stem.
+   * Kept explicit so a migration never has to guess by sniffing empty strings.
+   */
+  paramMode: 'structured' | 'legacy-free-text' | 'hybrid';
+
+  /**
+   * Visual themes this intent may be drawn with, as ids into the SVG manifest.
+   * Plural because one counting intent should work across fruit, animals and
+   * vehicles; the renderer picks a variant per paper.
+   */
+  svgThemeIds: string[];
+
+  /**
+   * LEGACY. What the child reads, written out by hand. Retained read-only so
+   * rows authored before the intent model are not lost; new structured records
+   * leave it empty. Do not add new writers.
    */
   stem: string;
   /**
-   * How the answer is derived, in the same placeholder vocabulary as the stem,
-   * e.g. "{a}+{b}". Held as text rather than evaluated here: nothing in this
-   * chunk generates questions, and pinning an evaluator now would fix a choice
-   * the generator work has not made yet.
+   * LEGACY. A hand-authored answer. Retained for the same reason as `stem`.
+   *
+   * Structured records must not carry one: the answer is produced by the
+   * generator and lives on the generated Question as an internal answer key,
+   * never as something a Superadmin typed into the authoring form.
    */
   answerSpec: string;
 
@@ -737,6 +766,49 @@ export interface QuestionTemplate {
   /** Soft delete: a generated paper may already cite this id, so the row stays for audit. */
   deletedAt: string | null;
   deletedBy: string | null;
+}
+
+/**
+ * One selectable value in the question-authoring form: a number range, an
+ * operation, or a visual theme.
+ *
+ * These live in the database rather than in a TypeScript constant so a
+ * Superadmin can add "0 to 500" without a deploy. The catalogue, the server
+ * validation and the form all read these same rows, which is what stops a
+ * value existing in the dropdown but being rejected on save.
+ */
+export interface QuestionOption {
+  id: string;
+  type: 'numeral-range' | 'operation' | 'svg-theme';
+  /** Stable machine key, e.g. "0-500". Unique per type among active rows. */
+  key: string;
+  label: string;
+
+  /** Range bounds. Only meaningful when type is 'numeral-range'. */
+  min?: number;
+  max?: number;
+
+  /**
+   * Whether anything can actually generate with this value yet.
+   *
+   * A label in the database is not an implementation: an author can record
+   * that they want modulo questions, but the option stays out of the
+   * generation catalogue until something can produce one. This is what stops
+   * a Superadmin authoring rows that silently never generate.
+   */
+  implementationStatus: 'ready' | 'not-ready';
+
+  /** Soft delete. Values are deactivated, never removed, because rows reference them. */
+  active: boolean;
+
+  /** Marks a value we intend to retire but have not migrated off yet. */
+  deprecated?: boolean;
+
+  metadata?: Record<string, unknown>;
+
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 /**
@@ -816,6 +888,7 @@ interface DatabaseSchema {
   testHistory: TestHistoryEntry[];
   questionLogics: QuestionLogic[];
   questionTemplates: QuestionTemplate[];
+  questionOptions: QuestionOption[];
   curriculumLevels: CurriculumLevel[];
 }
 
@@ -841,6 +914,7 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
   testHistory: 'testHistory',
   questionLogics: 'questionLogics',
   questionTemplates: 'questionTemplates',
+  questionOptions: 'questionOptions',
   curriculumLevels: 'curriculumLevels',
 };
 
@@ -978,6 +1052,11 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
           await templatesColl.createIndex({ conceptId: 1, deletedAt: 1 });
           await templatesColl.createIndex({ variantKey: 1, deletedAt: 1 });
           await templatesColl.createIndex({ tags: 1, deletedAt: 1 });
+          await templatesColl.createIndex({ paramMode: 1, deletedAt: 1 });
+
+          const optionsColl = db.collection('questionOptions');
+          await optionsColl.createIndex({ id: 1 }, { unique: true });
+          await optionsColl.createIndex({ type: 1, active: 1 });
           console.log('Successfully ensured indexes on the question authoring collections');
         } catch (e: any) {
           console.warn('Failed to ensure indexes on the question authoring collections:', e.message);
@@ -2014,6 +2093,44 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
       if (idx !== -1) this.data.questionTemplates[idx] = t;
     }
     return t || undefined;
+  }
+
+  // --- Question Option Methods -------------------------------------------
+  //
+  // The catalogue of selectable values. Reads are hot (every form render) and
+  // the set is tiny, so these deliberately do no caching: correctness after a
+  // Superadmin adds a value matters more than saving a small query.
+
+  async getQuestionOptions(includeInactive = false) {
+    const filter = includeInactive ? {} : { active: true };
+    return await this.mongoDb!.collection<QuestionOption>('questionOptions')
+      .find(filter).sort({ type: 1, key: 1 }).toArray();
+  }
+
+  async getQuestionOptionById(id: string) {
+    return (await this.mongoDb!.collection<QuestionOption>('questionOptions').findOne({ id })) || undefined;
+  }
+
+  /** Active row with this (type, key), if any. Used to reject duplicate keys. */
+  async getQuestionOptionByKey(type: QuestionOption['type'], key: string) {
+    return (await this.mongoDb!.collection<QuestionOption>('questionOptions')
+      .findOne({ type, key, active: true })) || undefined;
+  }
+
+  async addQuestionOption(option: QuestionOption) {
+    await this.mongoDb!.collection('questionOptions').insertOne(option);
+    if (this.data) this.data.questionOptions.push(option);
+    return option;
+  }
+
+  async updateQuestionOption(id: string, updates: Partial<QuestionOption>) {
+    await this.mongoDb!.collection('questionOptions').updateOne({ id }, { $set: updates });
+    const o = await this.mongoDb!.collection<QuestionOption>('questionOptions').findOne({ id });
+    if (o && this.data) {
+      const idx = this.data.questionOptions.findIndex(x => x.id === id);
+      if (idx !== -1) this.data.questionOptions[idx] = o;
+    }
+    return o || undefined;
   }
 
   async getQuestionTemplateStats(totalLevels: number) {
@@ -4114,6 +4231,7 @@ const COLLECTION_NAMES: Record<keyof DatabaseSchema, string> = {
       // intent in front of the question-generation pipeline.
       questionLogics: [],
       questionTemplates: [],
+      questionOptions: [],
       // Populated by `npm run seed:levels`, not by the demo seed — the
       // curriculum is real data with one source, not fixture content.
       curriculumLevels: []

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -38,6 +38,7 @@ import { registerEvaluationRoutes } from './routes/evaluation';
 import { registerAnalyticsRoutes } from './routes/analytics';
 import { registerQuestionLogicRoutes } from './routes/questionLogics';
 import { registerQuestionTemplateRoutes } from './routes/questionTemplates';
+import { registerQuestionOptionRoutes } from './routes/questionOptions';
 import { registerDiagnosticBulkRoutes } from './routes/diagnosticBulk';
 import { registerMisconceptionRoutes } from './routes/misconceptions';
 import { registerCurriculumRoutes } from './routes/curriculum';
@@ -133,6 +134,7 @@ registerStatsRoutes(app);
   registerAnalyticsRoutes(app);
   registerQuestionLogicRoutes(app);
   registerQuestionTemplateRoutes(app);
+  registerQuestionOptionRoutes(app);
   registerDiagnosticBulkRoutes(app);
 
   // Read-only analysis over already-graded submissions: clusters a cohort on

--- a/backend/src/migrations/questionTemplateIntentV1.ts
+++ b/backend/src/migrations/questionTemplateIntentV1.ts
@@ -1,0 +1,79 @@
+/**
+ * Classify existing question templates against the intent model, and report.
+ *
+ * Deliberately a REPORT, not a rewrite. A stored `stem` is a sentence a human
+ * wrote for children; turning it into a generation intent is a judgement about
+ * pedagogy, and a script that guessed would produce plausible-looking intents
+ * that nobody reviewed. So this marks rows and tells you which need a person.
+ *
+ * Run:  npx tsx backend/src/migrations/questionTemplateIntentV1.ts [--apply]
+ *
+ * Without --apply it only prints. With --apply it sets `paramMode` and moves
+ * nothing else: `stem` and `answerSpec` are left exactly as they are.
+ */
+
+import 'dotenv/config';
+import { dbStore, connectDB, QuestionTemplate } from '../db';
+
+export type Classification = 'structured' | 'legacy-free-text' | 'hybrid' | 'needs-review';
+
+/**
+ * Decide what a stored row is, without touching it.
+ *
+ * A row with both an intent and a stem is `hybrid` rather than either one: it
+ * was authored under one model and edited under the other, and only a human
+ * can say which half is now authoritative.
+ */
+export function classify(t: Pick<QuestionTemplate, 'generationIntent' | 'stem' | 'answerSpec'>): Classification {
+  const hasIntent = Boolean((t.generationIntent ?? '').trim());
+  const hasLegacy = Boolean((t.stem ?? '').trim()) || Boolean((t.answerSpec ?? '').trim());
+
+  if (hasIntent && !hasLegacy) return 'structured';
+  if (!hasIntent && hasLegacy) return 'legacy-free-text';
+  if (hasIntent && hasLegacy) return 'hybrid';
+  return 'needs-review';
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  await connectDB();
+  await dbStore.init();
+
+  const templates = await dbStore.getQuestionTemplates(true);
+  const buckets: Record<Classification, QuestionTemplate[]> = {
+    'structured': [], 'legacy-free-text': [], 'hybrid': [], 'needs-review': [],
+  };
+  for (const t of templates) buckets[classify(t)].push(t);
+
+  console.log(`\nquestionTemplates: ${templates.length} row(s)\n`);
+  for (const [name, rows] of Object.entries(buckets)) {
+    console.log(`  ${name.padEnd(18)} ${rows.length}`);
+  }
+
+  if (buckets['legacy-free-text'].length || buckets['hybrid'].length || buckets['needs-review'].length) {
+    console.log('\nRows a person must look at:');
+    for (const t of [...buckets['legacy-free-text'], ...buckets['hybrid'], ...buckets['needs-review']]) {
+      console.log(`  ${t.id}  ${t.conceptId}  stem="${(t.stem ?? '').slice(0, 60)}"`);
+    }
+    console.log('\nNo intent has been written for these. Nothing was invented on their behalf.');
+  }
+
+  if (apply) {
+    let touched = 0;
+    for (const [name, rows] of Object.entries(buckets)) {
+      if (name === 'needs-review') continue;
+      for (const t of rows) {
+        if (t.paramMode === name) continue;
+        await dbStore.updateQuestionTemplate(t.id, { paramMode: name as QuestionTemplate['paramMode'] });
+        touched++;
+      }
+    }
+    console.log(`\nApplied: paramMode set on ${touched} row(s). stem and answerSpec untouched.`);
+  } else {
+    console.log('\nDry run. Pass --apply to write paramMode.');
+  }
+
+  process.exit(0);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/backend/src/routes/questionOptions.ts
+++ b/backend/src/routes/questionOptions.ts
@@ -1,0 +1,164 @@
+import express from 'express';
+import { randomUUID } from 'crypto';
+import { dbStore, QuestionOption } from '../db';
+import { requireSuperadmin } from './superadminGuard';
+
+const SUBJECT = 'question options';
+
+const OPTION_TYPES: QuestionOption['type'][] = ['numeral-range', 'operation', 'svg-theme'];
+
+/** Machine keys are used in URLs, CSV cells and stored rows, so keep them boring. */
+const KEY_PATTERN = /^[a-z0-9][a-z0-9-]{0,39}$/;
+
+const MAX_LABEL_CHARS = 60;
+/**
+ * Upper bound on an author-defined range.
+ *
+ * Not arbitrary: worksheets are printed for children in Classes 1 to 4, and a
+ * range beyond this produces questions no level in the curriculum asks for.
+ * Raising it is a product decision, not a validation tweak.
+ */
+const MAX_RANGE_BOUND = 10_000;
+
+function validateOption(o: Partial<QuestionOption>): string | null {
+  if (!o.type || !OPTION_TYPES.includes(o.type)) {
+    return `type must be one of ${OPTION_TYPES.join(', ')}.`;
+  }
+  const key = (o.key ?? '').trim();
+  if (!KEY_PATTERN.test(key)) {
+    return 'key must be lowercase letters, digits and hyphens, starting with a letter or digit, at most 40 characters.';
+  }
+  const label = (o.label ?? '').trim();
+  if (label.length === 0) return 'label is required.';
+  if (label.length > MAX_LABEL_CHARS) return `label must be ${MAX_LABEL_CHARS} characters or fewer.`;
+
+  if (o.type === 'numeral-range') {
+    if (!Number.isInteger(o.min) || !Number.isInteger(o.max)) {
+      return 'A number range needs whole-number min and max values.';
+    }
+    if ((o.min as number) < 0) return 'min cannot be negative.';
+    if ((o.max as number) <= (o.min as number)) return 'max must be greater than min.';
+    if ((o.max as number) > MAX_RANGE_BOUND) return `max cannot exceed ${MAX_RANGE_BOUND}.`;
+  }
+
+  if (o.implementationStatus && !['ready', 'not-ready'].includes(o.implementationStatus)) {
+    return "implementationStatus must be 'ready' or 'not-ready'.";
+  }
+  return null;
+}
+
+export function registerQuestionOptionRoutes(app: express.Express) {
+  app.get('/api/question-options', async (req, res) => {
+    if (!requireSuperadmin(req, res, SUBJECT)) return;
+
+    const includeInactive = req.query.includeInactive === 'true';
+    let options = await dbStore.getQuestionOptions(includeInactive);
+
+    const type = req.query.type as string | undefined;
+    if (type) {
+      if (!OPTION_TYPES.includes(type as QuestionOption['type'])) {
+        return res.status(400).json({ error: `type must be one of ${OPTION_TYPES.join(', ')}.` });
+      }
+      options = options.filter(o => o.type === type);
+    }
+    res.json(options);
+  });
+
+  app.post('/api/question-options', async (req, res) => {
+    const user = requireSuperadmin(req, res, SUBJECT);
+    if (!user) return;
+
+    const draft: Partial<QuestionOption> = {
+      type: req.body?.type,
+      key: (req.body?.key ?? '').trim(),
+      label: (req.body?.label ?? '').trim(),
+      min: req.body?.min != null ? Number(req.body.min) : undefined,
+      max: req.body?.max != null ? Number(req.body.max) : undefined,
+      implementationStatus: req.body?.implementationStatus ?? 'not-ready',
+    };
+
+    const problem = validateOption(draft);
+    if (problem) return res.status(400).json({ error: problem });
+
+    const clash = await dbStore.getQuestionOptionByKey(draft.type!, draft.key!);
+    if (clash) {
+      return res.status(409).json({ error: `An active ${draft.type} with the key "${draft.key}" already exists.`, id: clash.id });
+    }
+
+    const now = new Date().toISOString();
+    const option: QuestionOption = {
+      id: 'qopt_' + randomUUID().slice(0, 8),
+      type: draft.type!,
+      key: draft.key!,
+      label: draft.label!,
+      min: draft.min,
+      max: draft.max,
+      // A new value is never assumed to work. Nothing can generate with it
+      // until someone has implemented it and flipped this deliberately.
+      implementationStatus: draft.implementationStatus as QuestionOption['implementationStatus'],
+      active: true,
+      createdBy: user.id,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await dbStore.addQuestionOption(option);
+    res.status(201).json(option);
+  });
+
+  app.patch('/api/question-options/:id', async (req, res) => {
+    const user = requireSuperadmin(req, res, SUBJECT);
+    if (!user) return;
+
+    const current = await dbStore.getQuestionOptionById(req.params.id);
+    if (!current) return res.status(404).json({ error: 'Option not found.' });
+
+    const merged: QuestionOption = {
+      ...current,
+      label: req.body?.label !== undefined ? String(req.body.label).trim() : current.label,
+      min: req.body?.min !== undefined ? Number(req.body.min) : current.min,
+      max: req.body?.max !== undefined ? Number(req.body.max) : current.max,
+      implementationStatus: req.body?.implementationStatus ?? current.implementationStatus,
+    };
+
+    // The key and type are identity: rows already reference them. Renaming one
+    // would silently repoint every template that used it.
+    if (req.body?.key !== undefined && req.body.key !== current.key) {
+      return res.status(400).json({ error: 'An option key cannot be changed. Deactivate this one and add a new option instead.' });
+    }
+    if (req.body?.type !== undefined && req.body.type !== current.type) {
+      return res.status(400).json({ error: 'An option type cannot be changed.' });
+    }
+
+    const problem = validateOption(merged);
+    if (problem) return res.status(400).json({ error: problem });
+
+    const updated = await dbStore.updateQuestionOption(req.params.id, {
+      label: merged.label,
+      min: merged.min,
+      max: merged.max,
+      implementationStatus: merged.implementationStatus,
+      updatedAt: new Date().toISOString(),
+    });
+    res.json(updated);
+  });
+
+  /**
+   * Deactivate rather than delete.
+   *
+   * Templates store the option key, so removing the row would leave those
+   * templates pointing at a value nothing can explain. Deactivating keeps the
+   * history readable while taking the value out of the form.
+   */
+  app.delete('/api/question-options/:id', async (req, res) => {
+    const user = requireSuperadmin(req, res, SUBJECT);
+    if (!user) return;
+
+    const current = await dbStore.getQuestionOptionById(req.params.id);
+    if (!current) return res.status(404).json({ error: 'Option not found.' });
+    if (!current.active) return res.json({ ok: true });
+
+    await dbStore.updateQuestionOption(req.params.id, { active: false, updatedAt: new Date().toISOString() });
+    res.json({ ok: true });
+  });
+}

--- a/backend/src/routes/questionTemplates.ts
+++ b/backend/src/routes/questionTemplates.ts
@@ -6,16 +6,20 @@ import { getLevel, isSkillMappedToLevel, isSubskillUnderSkills, buildLevelMapPay
 import { getLevelForConcept } from '../config/curriculumMap';
 import {
   QuestionTemplateParams,
+  QuestionFamily,
+  ParamMode,
   coerceParams,
   validateParams,
+  validateGenerationIntent,
   deriveTemplateName,
   variantKeyFor,
   getParamCatalog,
   QUESTION_COUNT_DEFAULT,
+  QUESTION_FAMILIES,
+  MAX_SVG_THEMES,
 } from '../types/questionTemplateParams';
+import { isKnownThemeId, listThemes } from '../svgAssetCatalog';
 
-const MAX_STEM_CHARS = 2000;
-const MAX_ANSWER_SPEC_CHARS = 500;
 const MAX_NAME_CHARS = 200;
 const MAX_TAGS = 20;
 const MAX_TAG_CHARS = 40;
@@ -39,7 +43,9 @@ function validateTemplate(
   conceptId: string,
   skills: string[],
   subskills: string[],
-  stem: string,
+  generationIntent: string,
+  questionFamily: string,
+  svgThemeIds: string[],
   answerSpec: string,
   params: QuestionTemplateParams,
   tags: string[],
@@ -75,15 +81,31 @@ function validateTemplate(
     }
   }
 
-  const stemText = (stem ?? '').trim();
-  if (stemText.length === 0) return 'Question text is required.';
-  if (stemText.length > MAX_STEM_CHARS) {
-    return `Question text must be ${MAX_STEM_CHARS} characters or fewer.`;
+  const intentProblem = validateGenerationIntent(generationIntent);
+  if (intentProblem) return intentProblem;
+
+  if (!(QUESTION_FAMILIES as readonly string[]).includes(questionFamily)) {
+    return `questionFamily must be one of ${QUESTION_FAMILIES.join(', ')}.`;
   }
 
-  const answer = (answerSpec ?? '').trim();
-  if (answer.length > MAX_ANSWER_SPEC_CHARS) {
-    return `Answer must be ${MAX_ANSWER_SPEC_CHARS} characters or fewer.`;
+  // The answer is generated, never authored. Rejecting this outright rather
+  // than dropping it silently: an author who typed an answer believes it will
+  // be used, and quietly discarding it would be worse than saying no.
+  if ((answerSpec ?? '').trim().length > 0) {
+    return 'An answer cannot be authored here. The generator produces the answer from the intent and the options below.';
+  }
+
+  if (!Array.isArray(svgThemeIds)) return 'svgThemeIds must be an array.';
+  if (svgThemeIds.length > MAX_SVG_THEMES) {
+    return `At most ${MAX_SVG_THEMES} visual themes may be selected.`;
+  }
+  for (const t of svgThemeIds) {
+    if (typeof t !== 'string' || !isKnownThemeId(t)) {
+      return `Unknown visual theme "${t}".`;
+    }
+  }
+  if (questionFamily === 'counting' && svgThemeIds.length === 0) {
+    return 'A counting question needs at least one visual theme, otherwise there is nothing for the child to count.';
   }
 
   if (name.length > MAX_NAME_CHARS) {
@@ -127,8 +149,9 @@ function buildTemplate(
     conceptId: string;
     skills: string[];
     subskills: string[];
-    stem: string;
-    answerSpec: string;
+    generationIntent: string;
+    questionFamily: QuestionFamily;
+    svgThemeIds: string[];
     params: QuestionTemplateParams;
     name: string;
     tags: string[];
@@ -146,8 +169,13 @@ function buildTemplate(
     levelName: getLevel(concept.levelNumber)!.capability,
     skills: input.skills,
     subskills: input.subskills,
-    stem: input.stem.trim(),
-    answerSpec: input.answerSpec.trim(),
+    generationIntent: input.generationIntent.trim(),
+    questionFamily: input.questionFamily,
+    paramMode: 'structured',
+    svgThemeIds: input.svgThemeIds,
+    // Legacy columns stay present and empty on new rows. See QuestionTemplate.
+    stem: '',
+    answerSpec: '',
     numeralRange: params.numeralRange,
     digitCount: params.digitCount,
     operations: params.operations,
@@ -218,7 +246,7 @@ function cellOrNull(cell: string): string | null {
 }
 
 const CSV_COLUMNS = [
-  'conceptId', 'skills', 'subskills', 'stem', 'answerSpec',
+  'conceptId', 'skills', 'subskills', 'generationIntent', 'questionFamily', 'svgThemeIds',
   'numeralRange', 'digitCount', 'operations', 'maxOperandCount',
   'carryBehavior', 'borrowBehavior', 'maxSumOrDifference',
   'answerType', 'blankCount', 'questionCount', 'subjectCategory',
@@ -229,7 +257,7 @@ export function registerQuestionTemplateRoutes(app: express.Express) {
   /** The legal values and context rules the form renders itself from. */
   app.get('/api/question-templates/param-catalog', (req, res) => {
     if (!requireSuperadmin(req, res, SUBJECT)) return;
-    res.json(getParamCatalog());
+    res.json({ ...getParamCatalog(), svgThemes: listThemes() });
   });
 
   /** Levels, skills and sub-skills for the cascading pickers, in one call. */
@@ -280,17 +308,19 @@ export function registerQuestionTemplateRoutes(app: express.Express) {
     const conceptId: string = (req.body?.conceptId ?? '').trim();
     const skills: string[] = req.body?.skills ?? [];
     const subskills: string[] = req.body?.subskills ?? [];
-    const stem: string = req.body?.stem ?? '';
+    const generationIntent: string = req.body?.generationIntent ?? '';
+    const questionFamily: string = req.body?.questionFamily ?? 'operation';
+    const svgThemeIds: string[] = req.body?.svgThemeIds ?? [];
     const answerSpec: string = req.body?.answerSpec ?? '';
     const params = coerceParams(req.body);
     const tags = normalizeTags(req.body?.tags);
     const name: string = (req.body?.name ?? '').trim();
 
-    const problem = validateTemplate(conceptId, skills, subskills, stem, answerSpec, params, tags, name);
+    const problem = validateTemplate(conceptId, skills, subskills, generationIntent, questionFamily, svgThemeIds, answerSpec, params, tags, name);
     if (problem) return res.status(400).json({ error: problem });
 
     const template = buildTemplate(
-      { conceptId, skills, subskills, stem, answerSpec, params, name, tags, source: 'form' },
+      { conceptId, skills, subskills, generationIntent, questionFamily: questionFamily as QuestionFamily, svgThemeIds, params, name, tags, source: 'form' },
       user,
       new Date().toISOString()
     );
@@ -324,13 +354,17 @@ export function registerQuestionTemplateRoutes(app: express.Express) {
     const conceptId: string = (req.body?.conceptId ?? current.conceptId).trim();
     const skills: string[] = req.body?.skills ?? current.skills;
     const subskills: string[] = req.body?.subskills ?? current.subskills;
-    const stem: string = req.body?.stem ?? current.stem;
-    const answerSpec: string = req.body?.answerSpec ?? current.answerSpec;
+    const generationIntent: string = req.body?.generationIntent ?? current.generationIntent ?? '';
+    const questionFamily: string = req.body?.questionFamily ?? current.questionFamily ?? 'operation';
+    const svgThemeIds: string[] = req.body?.svgThemeIds ?? current.svgThemeIds ?? [];
+    // Never inherit a legacy answer into a structured edit: that would fail the
+    // "no authored answer" rule on a row the author did not touch.
+    const answerSpec: string = req.body?.answerSpec ?? '';
     const tags = req.body?.tags !== undefined ? normalizeTags(req.body.tags) : current.tags;
     const params = coerceParams({ ...current, ...req.body });
     const name: string = (req.body?.name ?? current.name).trim();
 
-    const problem = validateTemplate(conceptId, skills, subskills, stem, answerSpec, params, tags, name);
+    const problem = validateTemplate(conceptId, skills, subskills, generationIntent, questionFamily, svgThemeIds, answerSpec, params, tags, name);
     if (problem) {
       // Make the concept-only case actionable rather than merely rejected.
       if (req.body?.conceptId !== undefined && req.body?.skills === undefined && problem.includes('not mapped')) {
@@ -353,8 +387,10 @@ export function registerQuestionTemplateRoutes(app: express.Express) {
       levelName: getLevel(concept.levelNumber)!.capability,
       skills,
       subskills,
-      stem: stem.trim(),
-      answerSpec: answerSpec.trim(),
+      generationIntent: generationIntent.trim(),
+      questionFamily: questionFamily as QuestionFamily,
+      paramMode: 'structured' as ParamMode,
+      svgThemeIds,
       numeralRange: params.numeralRange,
       digitCount: params.digitCount,
       operations: params.operations,
@@ -442,7 +478,9 @@ export function registerQuestionTemplateRoutes(app: express.Express) {
       const conceptId = col(row, 'conceptId');
       const skills = splitList(col(row, 'skills'));
       const subskills = splitList(col(row, 'subskills'));
-      const stem = col(row, 'stem');
+      const generationIntent = col(row, 'generationIntent');
+      const questionFamily = col(row, 'questionFamily') || 'operation';
+      const svgThemeIds = splitList(col(row, 'svgThemeIds'));
       const answerSpec = col(row, 'answerSpec');
       const tags = normalizeTags(splitList(col(row, 'tags')));
       const name = col(row, 'name');
@@ -461,14 +499,14 @@ export function registerQuestionTemplateRoutes(app: express.Express) {
         subjectCategory: cellOrNull(col(row, 'subjectCategory')),
       });
 
-      const problem = validateTemplate(conceptId, skills, subskills, stem, answerSpec, params, tags, name);
+      const problem = validateTemplate(conceptId, skills, subskills, generationIntent, questionFamily, svgThemeIds, answerSpec, params, tags, name);
       if (problem) {
         errors.push({ row: rowNumber, error: problem });
         return;
       }
 
       prepared.push(buildTemplate(
-        { conceptId, skills, subskills, stem, answerSpec, params, name, tags, source: 'csv' },
+        { conceptId, skills, subskills, generationIntent, questionFamily: questionFamily as QuestionFamily, svgThemeIds, params, name, tags, source: 'csv' },
         user,
         now
       ));

--- a/backend/src/svgAssetCatalog.ts
+++ b/backend/src/svgAssetCatalog.ts
@@ -1,0 +1,110 @@
+/**
+ * The catalogue of visual themes a question can be drawn with.
+ *
+ * The database stores theme ids and nothing else. The artwork itself lives as
+ * files under `frontend/public/assets/svg/questions/`, described by a
+ * `manifest.json` alongside them. That split is deliberate: SVG markup already
+ * sits inside Mongo in two other places (`questionBank.svgHtml` and
+ * `levelHtmlTemplates.htmlContent`), and growing a third copy would mean the
+ * same drawing could disagree with itself depending on which table you read.
+ *
+ * Ids are the contract. A theme may be re-drawn, or gain variants, without any
+ * stored row changing.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export interface SvgThemeVariant {
+  variantId: string;
+  file: string;
+}
+
+export interface SvgTheme {
+  id: string;
+  label: string;
+  variants: SvgThemeVariant[];
+  supportedAnswerShapes: string[];
+  printSafe: boolean;
+  viewBox: string;
+}
+
+interface Manifest {
+  version: number;
+  themes: SvgTheme[];
+}
+
+/**
+ * Where the manifest lives. `WORKSHEET_ASSETS_DIR` already points the backend at
+ * the frontend's public folder in production, so this follows the same route
+ * rather than inventing a second convention.
+ */
+function manifestPath(): string {
+  const assetsDir = process.env.WORKSHEET_ASSETS_DIR
+    || path.resolve(__dirname, '../../frontend/public/worksheets');
+  return path.resolve(assetsDir, '../assets/svg/questions/manifest.json');
+}
+
+let cached: Manifest | null = null;
+
+/**
+ * Read the manifest once per process.
+ *
+ * A missing or unreadable manifest returns an empty catalogue rather than
+ * throwing. The authoring API must still answer when the asset folder has not
+ * been deployed; it will simply reject every theme id, which is a legible
+ * failure rather than a crashed route.
+ */
+export function loadManifest(): Manifest {
+  if (cached) return cached;
+  try {
+    const raw = fs.readFileSync(manifestPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Manifest;
+    cached = Array.isArray(parsed?.themes) ? parsed : { version: 0, themes: [] };
+  } catch {
+    console.warn('[svgAssetCatalog] no readable manifest at', manifestPath());
+    cached = { version: 0, themes: [] };
+  }
+  return cached;
+}
+
+export function listThemes(): SvgTheme[] {
+  return loadManifest().themes;
+}
+
+export function isKnownThemeId(id: string): boolean {
+  return listThemes().some(t => t.id === id);
+}
+
+/**
+ * Pick a variant deterministically from a seed (a student id, a paper id).
+ *
+ * Deterministic rather than random so that regenerating a paper produces the
+ * same artwork: a child who is re-issued their sheet should not receive a
+ * visually different one, and a mismatch would confuse ICR scanning.
+ */
+export function pickVariant(themeId: string, seed: string): SvgThemeVariant | undefined {
+  const theme = listThemes().find(t => t.id === themeId);
+  if (!theme || theme.variants.length === 0) return undefined;
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  return theme.variants[hash % theme.variants.length];
+}
+
+/**
+ * Reject anything that is not a plain, self-contained drawing.
+ *
+ * Applied at import time, never at render time. An SVG is executable markup:
+ * a script tag or an external reference inside one would run in the browser of
+ * whoever opened the worksheet, so the safe move is to refuse it on the way in.
+ */
+export function validateSvgMarkup(svg: string): string | null {
+  if (!/^\s*<svg[\s>]/i.test(svg)) return 'Not an SVG document.';
+  if (!/viewBox\s*=/.test(svg)) return 'SVG must declare a viewBox so it scales on a printed page.';
+  if (/<script/i.test(svg)) return 'SVG must not contain a script.';
+  if (/\son\w+\s*=/i.test(svg)) return 'SVG must not contain event handler attributes.';
+  if (/(href|xlink:href|src)\s*=\s*["']?\s*(https?:)?\/\//i.test(svg)) return 'SVG must not reference an external URL.';
+  if (/<foreignObject/i.test(svg)) return 'SVG must not contain a foreignObject.';
+  if (svg.length > 200_000) return 'SVG is too large.';
+  return null;
+}

--- a/backend/src/types/questionTemplateParams.ts
+++ b/backend/src/types/questionTemplateParams.ts
@@ -15,14 +15,34 @@
 
 import { createHash } from 'crypto';
 
-export const NUMERAL_RANGES = ['0-9', '0-20', '0-50', '0-100', '0-1000', '0-10000'] as const;
+/**
+ * Built-in ranges. `0-100` and `0-1000` are kept because rows already reference
+ * them: persisted data is never silently rewritten. They are reported as
+ * deprecated so the form can push authors toward the canonical set without the
+ * old values suddenly failing validation.
+ *
+ * Further ranges are added by a Superadmin at runtime and live in the
+ * `questionOptions` collection, not here.
+ */
+export const NUMERAL_RANGES = ['0-9', '0-20', '0-50', '0-100', '0-200', '0-1000', '0-2000', '0-10000'] as const;
+export const DEPRECATED_NUMERAL_RANGES: readonly string[] = ['0-100', '0-1000'];
 export const DIGIT_COUNTS = ['1-digit', '2-digit', '3-digit', '4-digit'] as const;
 export const OPERATIONS = ['add', 'subtract', 'multiply', 'divide'] as const;
 export const CARRY_BEHAVIORS = ['none', 'allowed', 'required'] as const;
 export const BORROW_BEHAVIORS = ['none', 'allowed', 'required'] as const;
-export const MAX_SUM_OR_DIFFERENCES = ['<=10', '<=20', '<=50', '<=100', '<=1000', '<=10000'] as const;
+/**
+ * Result caps, kept in step with NUMERAL_RANGES.
+ *
+ * `<=200` and `<=2000` exist because the ranges do: an author who can choose
+ * "0 to 200" for the operands and then finds the largest answer jumps from 100
+ * straight to 1,000 has been given a form that cannot express what they meant.
+ */
+export const MAX_SUM_OR_DIFFERENCES = ['<=10', '<=20', '<=50', '<=100', '<=200', '<=1000', '<=2000', '<=10000'] as const;
 export const MAX_OPERAND_COUNTS = [2, 3, 4] as const;
 export const ANSWER_TYPES = ['single-number', 'mcq-4', 'fill-blanks', 'true-false', 'matching', 'trace'] as const;
+export const QUESTION_FAMILIES = ['counting', 'operation'] as const;
+export const PARAM_MODES = ['structured', 'legacy-free-text', 'hybrid'] as const;
+
 export const SUBJECT_CATEGORIES = [
   'fruits', 'vegetables', 'animals', 'pets', 'vehicles', 'street-furniture',
   'buildings', 'clothing', 'flowers-trees', 'classroom-objects', 'mixed',
@@ -37,6 +57,13 @@ export type MaxSumOrDifference = (typeof MAX_SUM_OR_DIFFERENCES)[number];
 export type MaxOperandCount = (typeof MAX_OPERAND_COUNTS)[number];
 export type AnswerType = (typeof ANSWER_TYPES)[number];
 export type SubjectCategory = (typeof SUBJECT_CATEGORIES)[number];
+export type QuestionFamily = (typeof QUESTION_FAMILIES)[number];
+export type ParamMode = (typeof PARAM_MODES)[number];
+
+/** An intent has to say something. Short enough to be a label is not an instruction. */
+export const INTENT_MIN_CHARS = 20;
+export const INTENT_MAX_CHARS = 2000;
+export const MAX_SVG_THEMES = 12;
 
 export const BLANK_COUNT_MIN = 1;
 export const BLANK_COUNT_MAX = 6;
@@ -207,8 +234,10 @@ const RANGE_LABELS: Record<NumeralRange, string> = {
   '0-20': '0 to 20',
   '0-50': '0 to 50',
   '0-100': '0 to 100',
-  '0-1000': '0 to 1000',
-  '0-10000': '0 to 10000',
+  '0-200': '0 to 200',
+  '0-1000': '0 to 1,000',
+  '0-2000': '0 to 2,000',
+  '0-10000': '0 to 10,000',
 };
 
 const ANSWER_LABELS: Record<AnswerType, string> = {
@@ -276,9 +305,31 @@ export function variantKeyFor(conceptId: string, p: QuestionTemplateParams): str
 }
 
 /** Everything the authoring form needs to render its controls, in one call. */
+/**
+ * Validate the intent text on its own.
+ *
+ * Deliberately checks only length and that it is not a bare question. We
+ * cannot tell from text whether an intent is pedagogically good, and pretending
+ * to would give false confidence; the length floor just stops "counting" being
+ * submitted as a generation instruction.
+ */
+export function validateGenerationIntent(intent: string): string | null {
+  const text = (intent ?? '').trim();
+  if (text.length === 0) return 'A generation intent is required.';
+  if (text.length < INTENT_MIN_CHARS) {
+    return `The generation intent must be at least ${INTENT_MIN_CHARS} characters. Describe what the child does, not just the topic.`;
+  }
+  if (text.length > INTENT_MAX_CHARS) {
+    return `The generation intent must be ${INTENT_MAX_CHARS} characters or fewer.`;
+  }
+  return null;
+}
+
 export function getParamCatalog() {
   return {
     numeralRange: NUMERAL_RANGES,
+    deprecatedNumeralRange: DEPRECATED_NUMERAL_RANGES,
+    questionFamily: QUESTION_FAMILIES,
     digitCount: DIGIT_COUNTS,
     operations: OPERATIONS,
     carryBehavior: CARRY_BEHAVIORS,
@@ -289,6 +340,8 @@ export function getParamCatalog() {
     subjectCategory: SUBJECT_CATEGORIES,
     blankCount: { min: BLANK_COUNT_MIN, max: BLANK_COUNT_MAX },
     questionCount: { min: QUESTION_COUNT_MIN, max: QUESTION_COUNT_MAX, default: QUESTION_COUNT_DEFAULT },
+    generationIntent: { minChars: INTENT_MIN_CHARS, maxChars: INTENT_MAX_CHARS },
+    maxSvgThemes: MAX_SVG_THEMES,
     contextRules: {
       carryBehavior: { requiresOperation: 'add' },
       borrowBehavior: { requiresOperation: 'subtract' },

--- a/docs/question-authoring-and-assets.md
+++ b/docs/question-authoring-and-assets.md
@@ -1,0 +1,84 @@
+# Question authoring, and where the pictures actually live
+
+## What a Superadmin authors
+
+A Superadmin does not write a question. They write an **intent**: what the child
+should do, what they see, and how they answer. The generator turns that into the
+actual wording, the numbers, and the answer.
+
+```
+intent   "The child counts the objects shown and writes one numeral in the
+          answer space. Use a different count each time."
+family    counting
+themes    fruits, animals, vehicles
+range     0-20
+answer    single-number
+```
+
+One intent covers every theme. Without the split, "count the apples" would have
+to be re-authored for vegetables, animals and vehicles.
+
+**An answer cannot be typed into the form.** The API rejects a non-empty
+`answerSpec` rather than dropping it silently, because an author who types an
+answer believes it will be used.
+
+`stem` and `answerSpec` still exist on the record. They are legacy columns kept
+read-only so rows authored before this model are not lost. New rows leave them
+empty and `paramMode` says which model a row was authored under, so nothing has
+to guess by sniffing for empty strings.
+
+## Where pictures are stored
+
+**No image file is stored in MongoDB.** There is no GridFS, no binary, and no
+base64 `data:` URI anywhere in the database.
+
+Three separate things exist today, and it is worth knowing which is which:
+
+| What | Where | Size |
+|---|---|---|
+| Question-bank drawings | `questionBank.svgHtml`, SVG markup as a text string | 1,202 rows, ~1.3 MB |
+| Worksheet pages | `levelHtmlTemplates.htmlContent`, whole HTML pages as strings, each with ~48 inline `<svg>` tags | 38 rows, ~1.4 MB |
+| **Authoring themes (new)** | **files** under `frontend/public/assets/svg/questions/`, listed in `manifest.json` | 11 themes, 2 variants each |
+
+The new themes are the only one of the three that keeps artwork **out** of the
+database. The database stores **ids** and nothing else: `svgThemeIds` on the
+template, and `svgThemeId` plus `svgAsset` on a generated question.
+
+That was deliberate. SVG markup already sits in Mongo in two places; a third
+copy would mean the same drawing could disagree with itself depending on which
+table you read. Ids are the contract, so a theme can be redrawn or gain variants
+without a single stored row changing.
+
+`pickVariant()` chooses a variant from a seed rather than at random, so
+regenerating a child's paper produces the same artwork. A different picture on a
+reprint would confuse both the child and the scanner.
+
+Any SVG entering the catalogue is checked by `validateSvgMarkup()`: it must be a
+real SVG with a `viewBox`, and must not contain a script, an event-handler
+attribute, an external URL, or a `foreignObject`. An SVG is executable markup, so
+anything unsafe is refused on the way in rather than filtered at render time.
+
+## Options are data, not constants
+
+Number ranges, operations and themes live in the `questionOptions` collection. A
+Superadmin adds "0 to 500" through the interface and it appears in the form, in
+the API validation and in the catalogue at once, because all three read the same
+rows.
+
+Two rules stop that becoming a way to break generation:
+
+- A new option is created `not-ready` and stays out of the generation catalogue
+  until something can actually produce a question with it. A label in a database
+  is not an implementation.
+- Options are deactivated, never deleted, because templates reference their keys.
+  Keys and types cannot be edited for the same reason.
+
+`0-100` and `0-1000` remain valid but are reported as deprecated. Persisted data
+is never silently rewritten.
+
+## What is not built yet
+
+Nothing reads these templates. `paperGenerator.ts` and `levelGenerator.ts` do not
+consume `generationIntent`, and no Gemini call turns an intent into a question.
+Authoring works end to end and the database can be populated now; the papers
+children receive are unchanged until the generator work lands.

--- a/frontend/public/assets/svg/questions/animals--bird.svg
+++ b/frontend/public/assets/svg/questions/animals--bird.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="bird"><path d="M20 38c6-12 20-16 26-8-4 2-6 6-6 10-6 6-16 4-20-2z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M42 30h4" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/animals--cat.svg
+++ b/frontend/public/assets/svg/questions/animals--cat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="cat"><path d="M20 30l4-12 8 8h0l8-8 4 12v18H20z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M26 36h2M38 36h2" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/buildings--house.svg
+++ b/frontend/public/assets/svg/questions/buildings--house.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="house"><path d="M16 54V30l16-14 16 14v24z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M28 54V42h8v12z" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/buildings--school.svg
+++ b/frontend/public/assets/svg/questions/buildings--school.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="school"><path d="M14 54V26h36v28z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M24 34h6v6h-6z M36 34h6v6h-6z" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/classroom-objects--book.svg
+++ b/frontend/public/assets/svg/questions/classroom-objects--book.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="book"><path d="M16 20h16v32H16z M32 20h16v32H32z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M32 20v32" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/classroom-objects--pencil.svg
+++ b/frontend/public/assets/svg/questions/classroom-objects--pencil.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="pencil"><path d="M20 48l4-10 22-22 6 6-22 22z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M44 16l6 6" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/clothing--shirt.svg
+++ b/frontend/public/assets/svg/questions/clothing--shirt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="shirt"><path d="M20 22l8-4 4 4 4-4 8 4-4 8v20H24V30z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/></svg>

--- a/frontend/public/assets/svg/questions/clothing--shoe.svg
+++ b/frontend/public/assets/svg/questions/clothing--shoe.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="shoe"><path d="M16 42h24l8 6v6H16z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M24 42v-8" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/flowers-trees--flower.svg
+++ b/frontend/public/assets/svg/questions/flowers-trees--flower.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="flower"><path d="M32 34a6 6 0 100-12 6 6 0 000 12z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M32 34v20 M26 28a6 6 0 11-8 6 M38 28a6 6 0 108 6" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/flowers-trees--tree.svg
+++ b/frontend/public/assets/svg/questions/flowers-trees--tree.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="tree"><path d="M32 54V34" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M32 12a14 14 0 110 28 14 14 0 010-28z" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/fruits--apple.svg
+++ b/frontend/public/assets/svg/questions/fruits--apple.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="apple"><path d="M32 18c8 0 14 7 14 16s-6 18-14 18-14-9-14-18 6-16 14-16z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M32 18c0-6 3-9 7-10" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/fruits--pear.svg
+++ b/frontend/public/assets/svg/questions/fruits--pear.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="pear"><path d="M32 20c7 0 12 8 12 16s-5 16-12 16-12-8-12-16 5-16 12-16z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M32 20c0-6 2-9 6-10" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/manifest.json
+++ b/frontend/public/assets/svg/questions/manifest.json
@@ -1,0 +1,237 @@
+{
+  "version": 1,
+  "note": "Stable ids referenced by QuestionTemplate.svgThemeIds and Question.svgThemeId. The database stores ids only; the artwork lives here.",
+  "themes": [
+    {
+      "id": "fruits",
+      "label": "Fruits",
+      "variants": [
+        {
+          "variantId": "apple",
+          "file": "fruits--apple.svg"
+        },
+        {
+          "variantId": "pear",
+          "file": "fruits--pear.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "vegetables",
+      "label": "Vegetables",
+      "variants": [
+        {
+          "variantId": "carrot",
+          "file": "vegetables--carrot.svg"
+        },
+        {
+          "variantId": "pepper",
+          "file": "vegetables--pepper.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "animals",
+      "label": "Animals",
+      "variants": [
+        {
+          "variantId": "cat",
+          "file": "animals--cat.svg"
+        },
+        {
+          "variantId": "bird",
+          "file": "animals--bird.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "pets",
+      "label": "Pets",
+      "variants": [
+        {
+          "variantId": "dog",
+          "file": "pets--dog.svg"
+        },
+        {
+          "variantId": "fish",
+          "file": "pets--fish.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "vehicles",
+      "label": "Vehicles",
+      "variants": [
+        {
+          "variantId": "car",
+          "file": "vehicles--car.svg"
+        },
+        {
+          "variantId": "bus",
+          "file": "vehicles--bus.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "street-furniture",
+      "label": "Street furniture",
+      "variants": [
+        {
+          "variantId": "streetlight",
+          "file": "street-furniture--streetlight.svg"
+        },
+        {
+          "variantId": "sign",
+          "file": "street-furniture--sign.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "buildings",
+      "label": "Buildings",
+      "variants": [
+        {
+          "variantId": "house",
+          "file": "buildings--house.svg"
+        },
+        {
+          "variantId": "school",
+          "file": "buildings--school.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "clothing",
+      "label": "Clothing",
+      "variants": [
+        {
+          "variantId": "shirt",
+          "file": "clothing--shirt.svg"
+        },
+        {
+          "variantId": "shoe",
+          "file": "clothing--shoe.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "flowers-trees",
+      "label": "Flowers and trees",
+      "variants": [
+        {
+          "variantId": "flower",
+          "file": "flowers-trees--flower.svg"
+        },
+        {
+          "variantId": "tree",
+          "file": "flowers-trees--tree.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "classroom-objects",
+      "label": "Classroom objects",
+      "variants": [
+        {
+          "variantId": "pencil",
+          "file": "classroom-objects--pencil.svg"
+        },
+        {
+          "variantId": "book",
+          "file": "classroom-objects--book.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    },
+    {
+      "id": "mixed",
+      "label": "Mixed",
+      "variants": [
+        {
+          "variantId": "circle",
+          "file": "mixed--circle.svg"
+        },
+        {
+          "variantId": "square",
+          "file": "mixed--square.svg"
+        }
+      ],
+      "supportedAnswerShapes": [
+        "single-number",
+        "fill-blanks",
+        "mcq-4"
+      ],
+      "printSafe": true,
+      "viewBox": "0 0 64 64"
+    }
+  ]
+}

--- a/frontend/public/assets/svg/questions/mixed--circle.svg
+++ b/frontend/public/assets/svg/questions/mixed--circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="circle"><path d="M32 34a14 14 0 100-28 14 14 0 000 28z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/></svg>

--- a/frontend/public/assets/svg/questions/mixed--square.svg
+++ b/frontend/public/assets/svg/questions/mixed--square.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="square"><path d="M18 20h28v28H18z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/></svg>

--- a/frontend/public/assets/svg/questions/pets--dog.svg
+++ b/frontend/public/assets/svg/questions/pets--dog.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="dog"><path d="M18 32c0-8 6-14 14-14s14 6 14 14v16H18z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M24 34h2M38 34h2" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/pets--fish.svg
+++ b/frontend/public/assets/svg/questions/pets--fish.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="fish"><path d="M18 36c8-10 24-10 30 0-6 10-22 10-30 0z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M48 30l8 6-8 6z" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/street-furniture--sign.svg
+++ b/frontend/public/assets/svg/questions/street-furniture--sign.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="sign"><path d="M30 54V28h4v26z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M20 12h24v14H20z" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/street-furniture--streetlight.svg
+++ b/frontend/public/assets/svg/questions/street-furniture--streetlight.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="streetlight"><path d="M30 54V16h4v38z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M26 16h12c0 6-3 8-6 8s-6-2-6-8z" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/vegetables--carrot.svg
+++ b/frontend/public/assets/svg/questions/vegetables--carrot.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="carrot"><path d="M32 14l10 34-10 8-10-8z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M32 14c0-5 3-8 6-9" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/vegetables--pepper.svg
+++ b/frontend/public/assets/svg/questions/vegetables--pepper.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="pepper"><path d="M32 20c9 0 14 8 14 17s-5 15-14 15-14-6-14-15 5-17 14-17z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M32 20c0-5 3-8 6-8" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/vehicles--bus.svg
+++ b/frontend/public/assets/svg/questions/vehicles--bus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="bus"><path d="M14 22h36v26H14z" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M20 52a4 4 0 108 0M38 52a4 4 0 108 0" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/public/assets/svg/questions/vehicles--car.svg
+++ b/frontend/public/assets/svg/questions/vehicles--car.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="car"><path d="M14 40h36v8H14z M20 40l6-12h14l6 12" fill="none" stroke="#111" stroke-width="3" stroke-linejoin="round"/><path d="M22 52a4 4 0 108 0M38 52a4 4 0 108 0" fill="none" stroke="#111" stroke-width="3" stroke-linecap="round"/></svg>

--- a/frontend/src/components/panels/QuestionTemplatePanel.tsx
+++ b/frontend/src/components/panels/QuestionTemplatePanel.tsx
@@ -10,8 +10,7 @@ import type {
   ImportResult,
 } from '../../types';
 
-const MAX_STEM_CHARS = 2000;
-const MAX_ANSWER_SPEC_CHARS = 500;
+const MAX_INTENT_CHARS = 2000;
 
 const EMPTY_PARAMS: QuestionTemplateParams = {
   numeralRange: null,
@@ -53,8 +52,9 @@ export const QuestionTemplatePanel: React.FC = () => {
   const [level, setLevel] = useState<number | ''>('');
   const [skills, setSkills] = useState<string[]>([]);
   const [subskills, setSubskills] = useState<string[]>([]);
-  const [stem, setStem] = useState('');
-  const [answerSpec, setAnswerSpec] = useState('');
+  const [generationIntent, setGenerationIntent] = useState('');
+  const [questionFamily, setQuestionFamily] = useState<'counting' | 'operation'>('operation');
+  const [svgThemeIds, setSvgThemeIds] = useState<string[]>([]);
   const [params, setParams] = useState<QuestionTemplateParams>(EMPTY_PARAMS);
   const [name, setName] = useState('');
   const [tagsText, setTagsText] = useState('');
@@ -199,8 +199,9 @@ export const QuestionTemplatePanel: React.FC = () => {
     setLevel('');
     setSkills([]);
     setSubskills([]);
-    setStem('');
-    setAnswerSpec('');
+    setGenerationIntent('');
+    setQuestionFamily('operation');
+    setSvgThemeIds([]);
     setParams(EMPTY_PARAMS);
     setName('');
     setTagsText('');
@@ -213,8 +214,9 @@ export const QuestionTemplatePanel: React.FC = () => {
     setLevel(t.levelNumber);
     setSkills(t.skills);
     setSubskills(t.subskills);
-    setStem(t.stem);
-    setAnswerSpec(t.answerSpec);
+    setGenerationIntent(t.generationIntent ?? '');
+    setQuestionFamily(t.questionFamily ?? 'operation');
+    setSvgThemeIds(t.svgThemeIds ?? []);
     setParams({
       numeralRange: t.numeralRange,
       digitCount: t.digitCount,
@@ -241,7 +243,10 @@ export const QuestionTemplatePanel: React.FC = () => {
     setDuplicateWarning(null);
     if (level === '') return setFormError('Pick a level.');
     if (skills.length === 0) return setFormError('Pick at least one skill.');
-    if (!stem.trim()) return setFormError('Write the question.');
+    if (!generationIntent.trim()) return setFormError('Describe what the question should make the child do.');
+    if (questionFamily === 'counting' && svgThemeIds.length === 0) {
+      return setFormError('A counting question needs at least one visual theme, otherwise there is nothing to count.');
+    }
     if (!selectedLevel) return setFormError('That level is no longer available. Reload the page.');
 
     setSaving(true);
@@ -251,8 +256,9 @@ export const QuestionTemplatePanel: React.FC = () => {
         conceptId: selectedLevel.sCode,
         skills,
         subskills,
-        stem: stem.trim(),
-        answerSpec: answerSpec.trim(),
+        generationIntent: generationIntent.trim(),
+        questionFamily,
+        svgThemeIds,
         ...params,
         name: name.trim(),
         tags: tagsText.split(',').map(s => s.trim()).filter(Boolean),
@@ -554,21 +560,33 @@ export const QuestionTemplatePanel: React.FC = () => {
             )}
           </div>
 
-          {/* Step 4 — the question itself */}
+          {/* Step 4 — what the question should do */}
           <div>
-            <label htmlFor="qt-stem" className={labelCls}>Step 4 — The question (required)</label>
-            <textarea id="qt-stem" value={stem} rows={3} className={inputCls}
-              onChange={e => { setStem(e.target.value.slice(0, MAX_STEM_CHARS)); setFormError(null); }}
-              placeholder={'e.g. "{a} + {b} = ___"  or  "Count the apples and write how many."'} />
+            <label htmlFor="qt-intent" className={labelCls}>Step 4 — What the question should do (required)</label>
+            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              This is an instruction for the generator, not a finished question. Do not write a specific
+              question or its answer: describe what the child does, and the generator writes the question
+              and works out the answer itself.
+            </p>
+            <textarea id="qt-intent" value={generationIntent} rows={4} className={inputCls}
+              onChange={e => { setGenerationIntent(e.target.value.slice(0, MAX_INTENT_CHARS)); setFormError(null); }}
+              placeholder={'e.g. "The child counts the objects shown and writes one numeral in the answer space. Use a different count each time and do not repeat the same arrangement."'} />
             <div className="mt-1 flex justify-between text-xs text-zinc-500 dark:text-zinc-400">
-              <span>Anything in braces, like {'{a}'}, is filled in from the options below. A question with no braces is a fixed question.</span>
-              <span className="tabular-nums">{stem.length} / {MAX_STEM_CHARS}</span>
+              <span>Say what the child does, what they see, and how they answer.</span>
+              <span className="tabular-nums">{generationIntent.length} / {MAX_INTENT_CHARS}</span>
             </div>
 
-            <label htmlFor="qt-answer" className={`${labelCls} mt-3 block`}>Answer (optional)</label>
-            <input id="qt-answer" value={answerSpec} className={inputCls}
-              onChange={e => { setAnswerSpec(e.target.value.slice(0, MAX_ANSWER_SPEC_CHARS)); setFormError(null); }}
-              placeholder={'e.g. "{a}+{b}"  or  "7"'} />
+            <div className="mt-3">
+              <div className={labelCls}>Kind of question</div>
+              <div className="mt-1 flex flex-wrap gap-2">
+                {(catalog?.questionFamily ?? ['counting', 'operation']).map(f => (
+                  <button key={f} type="button" onClick={() => { setQuestionFamily(f as 'counting' | 'operation'); setFormError(null); }}
+                    aria-pressed={questionFamily === f} className={chipCls(questionFamily === f)}>
+                    {f === 'counting' ? 'Counting a picture' : 'Number operation'}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
 
           {/* Step 5 — the options that govern the numbers */}
@@ -635,12 +653,32 @@ export const QuestionTemplatePanel: React.FC = () => {
               </div>
             </Group>
 
-            <Group id="subject" title="Picture theme" summary={params.subjectCategory ?? 'not set'}>
-              <EnumRow label="Theme for counting questions" values={catalog?.subjectCategory ?? []}
-                value={params.subjectCategory} onPick={v => setParam('subjectCategory', v)} />
-              <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                Chooses the picture theme. The picture library itself is not built yet, so this is recorded but not yet drawn.
-              </p>
+            <Group id="subject" title="SVG themes"
+              summary={svgThemeIds.length ? `${svgThemeIds.length} selected` : 'not set'}>
+              <div>
+                <div className={labelCls}>Visual themes this question may be drawn with</div>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {(catalog?.svgThemes ?? []).map(t => (
+                    <button key={t.id} type="button"
+                      onClick={() => {
+                        setFormError(null);
+                        setSvgThemeIds(prev => prev.includes(t.id) ? prev.filter(x => x !== t.id) : [...prev, t.id]);
+                      }}
+                      aria-pressed={svgThemeIds.includes(t.id)} className={chipCls(svgThemeIds.includes(t.id))}>
+                      {t.label} <span className="text-xs opacity-60">({t.variants.length})</span>
+                    </button>
+                  ))}
+                </div>
+                {(catalog?.svgThemes ?? []).length === 0 && (
+                  <p className="mt-1 text-sm text-amber-700 dark:text-amber-400">
+                    No themes are available. The picture library has not been deployed to this server.
+                  </p>
+                )}
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  Pick more than one and each paper is drawn with a different theme, without changing the
+                  question. The number in brackets is how many variants that theme has.
+                </p>
+              </div>
             </Group>
           </div>
 
@@ -785,7 +823,7 @@ export const QuestionTemplatePanel: React.FC = () => {
                 <tr className="border-b border-zinc-200 dark:border-zinc-700 text-left text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
                   <th className="py-2 pr-3 font-medium">Level</th>
                   <th className="py-2 pr-3 font-medium">Name</th>
-                  <th className="py-2 pr-3 font-medium">Question</th>
+                  <th className="py-2 pr-3 font-medium">What it asks for</th>
                   <th className="py-2 pr-3 font-medium">Skills</th>
                   <th className="py-2 pr-3 font-medium">Tags</th>
                   <th className="py-2 pr-3 font-medium">Created by</th>
@@ -801,7 +839,7 @@ export const QuestionTemplatePanel: React.FC = () => {
                     </td>
                     <td className="py-3 pr-3 text-zinc-800 dark:text-zinc-200 max-w-xs">{t.name}</td>
                     <td className="py-3 pr-3 text-zinc-700 dark:text-zinc-300 max-w-md">
-                      {t.stem.length > 70 ? `${t.stem.slice(0, 70)}…` : t.stem}
+                      {(() => { const v = t.generationIntent || t.stem || ''; return v.length > 70 ? `${v.slice(0, 70)}…` : v; })()}
                     </td>
                     <td className="py-3 pr-3 text-zinc-600 dark:text-zinc-300">{t.skills.join(', ')}</td>
                     <td className="py-3 pr-3 text-zinc-500 dark:text-zinc-400">{t.tags.length ? t.tags.join(', ') : '—'}</td>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -378,7 +378,15 @@ export interface QuestionTemplate {
   levelName: string;
   skills: string[];
   subskills: string[];
+  /** What the question should make the child do. An instruction, not a finished question. */
+  generationIntent: string;
+  questionFamily: 'counting' | 'operation';
+  paramMode: 'structured' | 'legacy-free-text' | 'hybrid';
+  /** Ids into the SVG manifest. The artwork lives in files, not in the database. */
+  svgThemeIds: string[];
+  /** LEGACY, read-only. Present so pre-intent rows are not lost. */
   stem: string;
+  /** LEGACY, read-only. Structured rows never carry an authored answer. */
   answerSpec: string;
   numeralRange: string | null;
   digitCount: string | null;
@@ -434,8 +442,34 @@ export interface QuestionTemplateStats {
  * The form renders its controls from this rather than from a hardcoded list,
  * so adding a legal value later is a backend-only change.
  */
+export interface SvgTheme {
+  id: string;
+  label: string;
+  variants: Array<{ variantId: string; file: string }>;
+  supportedAnswerShapes: string[];
+  printSafe: boolean;
+  viewBox: string;
+}
+
+export interface QuestionOption {
+  id: string;
+  type: 'numeral-range' | 'operation' | 'svg-theme';
+  key: string;
+  label: string;
+  min?: number;
+  max?: number;
+  implementationStatus: 'ready' | 'not-ready';
+  active: boolean;
+  deprecated?: boolean;
+}
+
 export interface ParamCatalog {
   numeralRange: string[];
+  deprecatedNumeralRange?: string[];
+  questionFamily?: string[];
+  svgThemes?: SvgTheme[];
+  generationIntent?: { minChars: number; maxChars: number };
+  maxSvgThemes?: number;
   digitCount: string[];
   operations: string[];
   carryBehavior: string[];


### PR DESCRIPTION
Implements the Question Intervention redesign plan. A Superadmin now describes **what a question should make the child do**, and the generator produces the wording, the numbers and the answer.

```
intent   "The child counts the objects shown and writes one numeral in the
          answer space. Use a different count each time."
family    counting
themes    fruits, animals, vehicles
range     0-20
```

One intent covers every theme. Previously "count the apples" had to be re-authored for vegetables, animals and vehicles.

## This changes direction, deliberately

PR #428 (merged and deployed earlier today) let a Superadmin author the question and answer directly. This replaces that as the primary path, per the implementation plan.

Nothing is deleted. `stem` and `answerSpec` remain as read-only legacy columns so rows authored under the old model survive, and a new `paramMode` records which model a row came from, so nothing has to guess by sniffing for empty strings.

**An answer can no longer be typed into the form.** The API returns 400 on a non-empty `answerSpec` rather than dropping it quietly, because an author who types an answer believes it will be used.

## Where the pictures live, and why not in the database

11 themes, 2 variants each, as **files** under `frontend/public/assets/svg/questions/` with a `manifest.json`. **The database stores ids and nothing else.**

That is deliberate. SVG markup already sits in MongoDB in two places: `questionBank.svgHtml` (1,202 rows, ~1.3 MB of raw `<svg>` as text) and `levelHtmlTemplates.htmlContent` (38 whole HTML pages, ~48 inline `<svg>` tags each). A third copy would mean the same drawing could disagree with itself depending which table you read. Ids are the contract, so a theme can be redrawn without a single stored row changing.

Two details worth review:

- `pickVariant()` is seeded from the student or paper id, not random. A child re-issued their sheet gets the same picture; a different one would confuse both the child and the ICR scanner.
- `validateSvgMarkup()` rejects scripts, event-handler attributes, external URLs and `foreignObject` **at import time**. An SVG is executable markup that runs in the browser of whoever opens the worksheet, so it is refused on the way in rather than filtered at render.

## Options become data

Ranges, operations and themes move into a new `questionOptions` collection, so a Superadmin can add "0 to 500" without a deploy. The form, the server validation and the catalogue all read the same rows, which is what stops a value appearing in a dropdown and then being rejected on save.

Two rules keep that from breaking generation:

- A new option is created `not-ready` and stays out of the generation catalogue until something can actually produce a question with it. A label in a database is not an implementation.
- Options deactivate rather than delete, and keys and types cannot be edited, because templates reference them.

`0-100` and `0-1000` stay valid but are reported deprecated. Persisted data is not rewritten. I also added `<=200` and `<=2000` answer caps to match the new ranges — the plan added the ranges but not the caps, which left an author able to choose operands up to 200 while the largest answer jumped from 100 straight to 1,000.

## The migration reports, it does not rewrite

`backend/src/migrations/questionTemplateIntentV1.ts` classifies each row as structured, legacy-free-text, hybrid or needs-review, and lists the ones a person must look at. `--apply` writes `paramMode` and nothing else.

Turning a stem into a generation intent is a judgement about pedagogy. A script that guessed would produce plausible-looking intents that nobody reviewed, so it does not guess.

## Testing

Verified end to end against a local MongoDB with seeded data, then the scratch database was dropped:

- Catalogue returns the 8 ranges with `0-100`/`0-1000` flagged deprecated, both families, all 11 themes with variant counts, and the intent length limits.
- Rejections all return the intended message: an authored answer, an intent under 20 characters, a counting question with no theme, an unknown theme id, a duplicate option key, a range above 10,000, and a malformed option key.
- A valid counting template stores `paramMode: structured`, three theme ids, and empty legacy columns.
- CSV import: dry run reports 2 rows ready and writes nothing, then the real import writes both. Column set updated to `generationIntent`, `questionFamily`, `svgThemeIds`.
- Non-superadmin gets 403 on the new option routes.
- Migration dry run classifies correctly and reports.

Both packages typecheck and build.

## Not in this PR

**Nothing consumes these templates yet.** `paperGenerator.ts` and `levelGenerator.ts` are untouched and no Gemini call turns an intent into a question, so the papers children receive are unchanged. Tasks 6 and 7 of the plan (generator consumption and rendering each answer shape) are the next chunk.

Authoring works end to end, so the database can be populated now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
