### PR TITLE
fix(placement): cap level recommendations at 59, not 93 (PR #420 finding 5)

### DIFF
--- a/backend/src/gemini.ts
+++ b/backend/src/gemini.ts
@@ -496,9 +496,11 @@ Provide a clean narrative feedback summary.`;
   if (failedLevels.length > 0) {
     recommendedLevel = Math.min(...failedLevels);
   } else {
-    // If they got all questions correct, place them at highest level + 1 (capped at 93)
+    // If they got all questions correct, place them at highest level + 1.
+    // Capped at 59, not 93: worksheet generation (levels_main.html) still
+    // throws UnknownLevelError above 59 until the 59->93 migration finishes.
     const maxLevel = Math.max(...questions.map(q => q.source_level), 0);
-    recommendedLevel = Math.min(93, maxLevel + 1);
+    recommendedLevel = Math.min(59, maxLevel + 1);
   }
 
   return {
@@ -623,7 +625,7 @@ Answers submitted: ${JSON.stringify(submittedAnswers)}
 
 Grade the student's submission. Evaluate each concept topic.
 Recommended Level progression rules:
-- If score is 80%+ (e.g. 3/3 or near perfect): Recommend Level ${Math.min(93, level + 1)}.
+- If score is 80%+ (e.g. 3/3 or near perfect): Recommend Level ${Math.min(59, level + 1)}.
 - If score is 50%-80%: Retain at Level ${level}.
 - If score is < 50%: Retain at Level ${level} or suggest review at Level ${Math.max(1, level - 1)}.
 Generate a narrative report summarizing strengths and learning gaps.`;
@@ -684,7 +686,8 @@ Generate a narrative report summarizing strengths and learning gaps.`;
   });
 
   const percent = (score / questions.length) * 100;
-  const recommendedLevel = percent >= 80 ? Math.min(93, level + 1) : level;
+  // Capped at 59, not 93 — see the Weakest-Level Mapping cap above.
+  const recommendedLevel = percent >= 80 ? Math.min(59, level + 1) : level;
 
   return {
     score,

--- a/backend/src/routes/evaluation.ts
+++ b/backend/src/routes/evaluation.ts
@@ -1218,7 +1218,8 @@ export function registerEvaluationRoutes(app: express.Express) {
     await dbStore.updateStudent(student.id, {
       currentLevel: evaluation.recommendedLevel,
       currentSubLevel: newSubLevel,
-      targetLevel: Math.min(93, evaluation.recommendedLevel + 1),
+      // Capped at 59, not 93: worksheet generation still throws UnknownLevelError above 59.
+      targetLevel: Math.min(59, evaluation.recommendedLevel + 1),
       levelHistory
     });
 
@@ -1454,7 +1455,8 @@ export function registerEvaluationRoutes(app: express.Express) {
     // turning a score into a level.
     const classMatch = student.classGroup.match(/\d+/);
     const classNumber = classMatch ? parseInt(classMatch[0], 10) : 1;
-    const recommendedLevel = Math.max(1, Math.min(93, (classNumber - 1) * 10 + Math.ceil(percentage / 10)));
+    // Capped at 59, not 93: worksheet generation still throws UnknownLevelError above 59.
+    const recommendedLevel = Math.max(1, Math.min(59, (classNumber - 1) * 10 + Math.ceil(percentage / 10)));
     const recommendedSubLevel = percentage >= 80 ? 0 : percentage >= 50 ? 1 : 2;
 
     const updatedReport = await dbStore.updateEvaluationReport(report.id, {
@@ -1481,7 +1483,7 @@ export function registerEvaluationRoutes(app: express.Express) {
       await dbStore.updateStudent(student.id, {
         currentLevel: recommendedLevel,
         currentSubLevel: recommendedSubLevel,
-        targetLevel: Math.min(93, recommendedLevel + 1),
+        targetLevel: Math.min(59, recommendedLevel + 1),
         levelHistory,
       });
     }

--- a/backend/src/routes/students.ts
+++ b/backend/src/routes/students.ts
@@ -1086,8 +1086,9 @@ export function registerStudentRoutes(app: express.Express) {
       );
     } else {
       // Genuinely all correct: advance one past the hardest level assessed.
+      // Capped at 59, not 93: worksheet generation still throws UnknownLevelError above 59.
       const maxLevel = Math.max(0, ...assessedLevels);
-      recommendedLevel = Math.min(93, maxLevel + 1);
+      recommendedLevel = Math.min(59, maxLevel + 1);
     }
     pipelineDetail = readPipelineDetail({}, questions, answers);
     narrative = `Determined locally: student solved ${score}/${questions.length} questions correctly. Placed at Level ${recommendedLevel} using Weakest-Level Mapping.`;
@@ -1132,7 +1133,7 @@ export function registerStudentRoutes(app: express.Express) {
         '3. Continue routine class participation and worksheet drills.',
         '',
         'MEDIUM-TERM (Next month):',
-        `- Target next milestone: Level ${Math.min(93, recommendedLevel + 1)}.`,
+        `- Target next milestone: Level ${Math.min(59, recommendedLevel + 1)}.`,
         '',
         'The student demonstrated mastery in this attempt. No prerequisite remediation is required.',
         '',
@@ -1213,7 +1214,7 @@ export function registerStudentRoutes(app: express.Express) {
     await dbStore.updateStudent(student.id, {
       currentLevel: recommendedLevel,
       currentSubLevel: subLevel,
-      targetLevel: Math.min(93, recommendedLevel + 1),
+      targetLevel: Math.min(59, recommendedLevel + 1),
       levelHistory
     });
 
@@ -1305,7 +1306,7 @@ export function registerStudentRoutes(app: express.Express) {
         '3. Continue routine class participation and worksheet drills.',
         '',
         'MEDIUM-TERM (Next month):',
-        `- Target next milestone: Level ${Math.min(93, recommendedLevel + 1)}.`,
+        `- Target next milestone: Level ${Math.min(59, recommendedLevel + 1)}.`,
         '',
         'The student demonstrated mastery in this attempt. No prerequisite remediation is required.',
         '',
@@ -1441,7 +1442,7 @@ export function registerStudentRoutes(app: express.Express) {
         }
         if (failedFlnLevels.length > 0) {
           demonstratedLevel = Math.min(...failedFlnLevels);
-          nextDemonstratedLevel = Math.min(93, demonstratedLevel + 1);
+          nextDemonstratedLevel = Math.min(59, demonstratedLevel + 1);
         }
       }
       const currentCfg = CURRICULUM_MAPPING[demonstratedLevel];


### PR DESCRIPTION
Fastest fix for finding 5 flagged in the post-hoc #420 review (see #422's "Still open from the #420 review" section): placement/promotion recommends up to level 93, but worksheet generation (`levels_main.html`) still throws `UnknownLevelError` above 59 until the 59→93 migration finishes.

## Fix

Every path that assigns or recommends a student's level now caps at 59 instead of 93:

- `backend/src/gemini.ts` — Weakest-Level Mapping fallback, AI-narrative prompt hint, deterministic-evaluation fallback (4 sites)
- `backend/src/routes/evaluation.ts` — target-level persistence, ICR-correction recommendation, target-level persistence again (3 sites)
- `backend/src/routes/students.ts` — Weakest-Level Mapping, two narrative report strings, prerequisite-chain next-level (4 sites)

## Not fixed here, flagged for later

The Gemini-returned `recommendedLevel` (the JSON the LLM returns directly, `gemini.ts` around line 662) is used with no clamp at all — the prompt hint nudges the model toward 59 but nothing enforces it programmatically. A determined-adversarial or just unlucky LLM response could still return something above 59. Worth a follow-up hard clamp on that return value; out of scope for "cap the deterministic paths fast."

## Verification

- `grep -rn "Math.min(93" backend/src` — zero remaining hits.
- `npm run lint` (both workspaces) — clean, zero new errors. (Two pre-existing unrelated errors from `jose`/`otpauth` not being installed locally were a local-environment issue, not a code issue — resolved by `npm install`, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)