### PR TITLE
fix(diagnostics): classify wrong-answer error types, retire dead legacy-pipeline code

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "test:panel-isolation": "tsx --test tests/panel-isolation.test.cjs",
     "audit:aadhaar": "tsx scripts/audit-aadhaar-at-rest.ts",
     "test:answer-matching": "tsx src/answerMatching.test.ts",
+    "test:error-classification": "tsx src/errorClassification.test.ts",
     "test:paper-lock": "tsx src/paperLock.test.ts"
   },
   "dependencies": {

--- a/backend/src/answerMatching.ts
+++ b/backend/src/answerMatching.ts
@@ -33,7 +33,7 @@ export function normalizeAnswer(value: unknown): string {
  */
 const PLAIN_NUMBER = /^[+-]?(\d{1,3}(,\d{3})+|\d+)(\.\d+)?$/;
 
-function asNumber(normalized: string): number | null {
+export function asNumber(normalized: string): number | null {
   if (!PLAIN_NUMBER.test(normalized)) return null;
   const n = Number(normalized.replace(/,/g, ''));
   return Number.isFinite(n) ? n : null;

--- a/backend/src/errorClassification.test.ts
+++ b/backend/src/errorClassification.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for deterministic error-type classification (FLN #459).
+ *
+ * Plain-script convention (node:assert, no runner), same as answerMatching.test.ts:
+ *   npm run test:error-classification --workspace @fln/backend
+ */
+import assert from 'node:assert';
+import { classifyErrorType } from './errorClassification';
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void): void {
+  try {
+    fn();
+    passed++;
+    console.log(`  PASS  ${name}`);
+  } catch (error: any) {
+    failed++;
+    console.error(`  FAIL  ${name}\n        ${error?.message || error}`);
+  }
+}
+
+const is = (submitted: unknown, expected: unknown, want: string) =>
+  assert.strictEqual(
+    classifyErrorType(submitted, expected),
+    want,
+    `expected classifyErrorType(${JSON.stringify(submitted)}, ${JSON.stringify(expected)}) to be ${want}`
+  );
+
+console.log('\nunanswered');
+test('blank submission', () => is('', '7', 'unanswered'));
+test('whitespace-only submission', () => is('   ', '7', 'unanswered'));
+
+console.log('\ndigit reversal');
+test('two-digit reversal', () => is('21', '12', 'digit_reversal'));
+test('two-digit reversal the other direction', () => is('13', '31', 'digit_reversal'));
+test('three-digit reversal', () => is('321', '123', 'digit_reversal'));
+test('different digit counts fall to decimal-shift, not reversal, when it is a clean 10x', () => is('1', '10', 'decimal_place_shift'));
+test('different digit counts with no power-of-ten relationship stay unclassified', () => is('12', '210', 'unclassified'));
+test('single digit cannot be a reversal of itself', () => is('7', '7', 'unclassified'));
+
+console.log('\ndecimal place shift');
+test('10x too large', () => is('70', '7', 'decimal_place_shift'));
+test('10x too small', () => is('7', '70', 'decimal_place_shift'));
+test('100x too large', () => is('700', '7', 'decimal_place_shift'));
+test('decimal point dropped', () => is('0.7', '7', 'decimal_place_shift'));
+test('decimal point dropped twice over', () => is('0.07', '7', 'decimal_place_shift'));
+
+console.log('\noff by one');
+test('one too high', () => is('8', '7', 'off_by_one'));
+test('one too low', () => is('6', '7', 'off_by_one'));
+test('off by one with a decimal value', () => is('12.5', '13.5', 'off_by_one'));
+
+console.log('\nunclassified — never guessed at');
+test('operand concatenation is not claimed by this classifier', () => is('56', '11', 'unclassified'));
+test('unrelated numbers', () => is('99', '3', 'unclassified'));
+test('non-numeric strings are never coerced into a numeric pattern', () => is('seven', 'seven apples', 'unclassified'));
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/backend/src/errorClassification.ts
+++ b/backend/src/errorClassification.ts
@@ -1,0 +1,77 @@
+/**
+ * Deterministic error-type classification for a wrong answer.
+ *
+ * FLN #459: `errorType` was always `'unclassified'` because nothing wired the
+ * (never-invoked) Python pipeline's `error_type` field into a real value. The
+ * platform's own roadmap already names the target patterns (see #413,
+ * "cluster recurring error patterns" — 5+6 -> 56 suggests operand
+ * concatenation) — this implements the handful of them that are verifiable
+ * from the submitted/expected pair alone, without needing pedagogy judgement
+ * or the 200-answer human-diagnosed corpus first.
+ *
+ * Every rule here is a FACT about the two strings (same digits reversed,
+ * off by a power of ten, blank) — never an inferred cause. A pair that
+ * matches no rule stays `'unclassified'` rather than being guessed at, same
+ * principle as `answerMatching.ts`: a fabricated cause is indistinguishable
+ * from a measured one once it's downstream.
+ */
+
+import { normalizeAnswer, asNumber } from './answerMatching';
+
+export type ErrorType =
+  | 'unanswered'
+  | 'digit_reversal'
+  | 'decimal_place_shift'
+  | 'off_by_one'
+  | 'unclassified';
+
+/** Same digits, different order — e.g. submitted "21" for expected "12". */
+function isDigitReversal(submittedDigits: string, expectedDigits: string): boolean {
+  if (submittedDigits.length < 2 || submittedDigits.length !== expectedDigits.length) return false;
+  if (submittedDigits === expectedDigits) return false;
+  return submittedDigits.split('').reverse().join('') === expectedDigits;
+}
+
+/** Digits-only representation for reversal comparison (drops sign/decimal point). */
+function digitsOnly(n: number): string {
+  return Math.abs(n).toString().replace('.', '');
+}
+
+/**
+ * Classify a single wrong answer. `submitted`/`expected` are the raw values
+ * exactly as `answersMatch` receives them elsewhere — this function does its
+ * own normalizing rather than assuming the caller already did.
+ */
+export function classifyErrorType(submitted: unknown, expected: unknown): ErrorType {
+  const s = normalizeAnswer(submitted);
+  const e = normalizeAnswer(expected);
+
+  if (s === '') return 'unanswered';
+
+  const sn = asNumber(s);
+  const en = asNumber(e);
+  if (sn === null || en === null) return 'unclassified';
+
+  // Off by exactly one — classic carry/borrow slip. Checked before the
+  // power-of-ten check since e.g. 9 vs 10 would otherwise also look close
+  // to a decimal shift on some ratios; off-by-one is the more specific,
+  // higher-confidence read when it applies.
+  if (Math.abs(sn - en) === 1) return 'off_by_one';
+
+  // Off by a power of ten (10x or 100x, either direction) — a decimal point
+  // or place value slip, not a reversal or a random miss. Floating-point
+  // division (e.g. 0.7 / 7) rarely lands on an exact power of ten, so this
+  // compares within a small relative tolerance rather than by equality.
+  if (sn !== 0 && en !== 0) {
+    const ratio = sn / en;
+    const closeTo = (target: number) => Math.abs(ratio - target) < target * 1e-9;
+    if (closeTo(10) || closeTo(0.1) || closeTo(100) || closeTo(0.01)) {
+      return 'decimal_place_shift';
+    }
+  }
+
+  // Same digits, reversed — "12" written for "21".
+  if (isDigitReversal(digitsOnly(sn), digitsOnly(en))) return 'digit_reversal';
+
+  return 'unclassified';
+}

--- a/backend/src/routes/students.ts
+++ b/backend/src/routes/students.ts
@@ -1,13 +1,11 @@
 import express from 'express';
-import path from 'path';
-import fs from 'fs';
 import { dbStore, UserRole, Student, Question, AnswerSubmission, EvaluationReport, EvaluationReasoning, CYCLE_NAMES } from '../db';
 import { answersMatch } from '../answerMatching';
+import { classifyErrorType } from '../errorClassification';
 import { getAuthUser, canAccessStudent } from '../auth';
 import { generateDiagnosticPaper } from '../paperGenerator';
 import { generateQuestionsForLevel } from '../levelGenerator';
 import { evaluateAIDiagnostic } from '../gemini';
-import { AI_SERVICES_DIR, PYTHON_BIN } from '../config';
 import { invalidateFingerprintCache } from './misconceptions';
 import { assignStudentToArchetype } from '../studentArchetypeService';
 import { resolvePrerequisites, describeConcept, directPrerequisites } from '../competencyPrerequisites';
@@ -28,49 +26,18 @@ function toPublicStudent(s: Student): PublicStudent {
 }
 
 /**
- * The pipeline's output file for a student, tried against both date spellings.
+ * Lift the per-error detail out of a wrong-answer set.
  *
- * `run_pipeline.py` names its output with the machine's LOCAL date; this
- * handler was building the path from `new Date().toISOString()`, which is UTC.
- * East of Greenwich the two disagree for the first hours of every local day —
- * in IST, midnight to 05:30 — and the lookup silently missed. Nothing threw:
- * `score` and `recommendedLevel` kept their initial 0 and 1, so every child
- * assessed in that window was placed at Level 1 with a score of zero and none
- * of the pipeline's analysis was recorded.
- *
- * Returns the first path that exists, or null when the pipeline produced
- * nothing under either name.
- */
-function findPipelineFile(dir: string, prefix: string, suffix: string): string | null {
-  const now = new Date();
-  const utcDate = now.toISOString().split('T')[0];
-  const localDate = new Date(now.getTime() - now.getTimezoneOffset() * 60000)
-    .toISOString()
-    .split('T')[0];
-  for (const date of [...new Set([localDate, utcDate])]) {
-    const candidate = path.join(dir, `${prefix}${date}${suffix}`);
-    if (fs.existsSync(candidate)) return candidate;
-  }
-  return null;
-}
-
-/**
- * Lift the per-error detail out of a `run_pipeline.py` evaluation JSON.
- *
- * The pipeline has always written `root_causes`, `levels_failed`,
- * `prerequisites_to_check` and `performance_by_difficulty`; the diagnostic
- * handler read `topics_to_focus` and dropped the rest on the floor. Everything
- * downstream that asks HOW a child failed — the misconception fingerprint, the
- * pipeline/measurement reconciliation — reads exactly these fields, so a
- * diagnostic-only child arrived there with nothing to read.
- *
- * Nothing here is inferred. When the pipeline's LLM step falls back it emits a
- * single overall verdict rather than one entry per question; in that case each
- * wrong answer is recorded with its OWN topic and level (from the question the
- * child actually sat) and the pipeline's overall `error_type` restated against
- * it. A shape the pipeline did not report is left unclassified rather than
- * guessed at — a fabricated cause is indistinguishable from a measured one
- * once it is downstream.
+ * `run_pipeline.py` used to write `root_causes` with a real `error_type` per
+ * question; that pipeline is never invoked from this backend (see FLN #458 —
+ * it runs on a legacy class/phrase data model with no connection to the
+ * current MongoDB-backed students), so `evalData` is always `{}` here now.
+ * Rather than leave every diagnostic `unclassified`, high-confidence patterns
+ * are detected directly from the submitted/expected answer pair — see
+ * `classifyErrorType` in `errorClassification.ts`. Nothing here is guessed:
+ * a shape that doesn't match a known pattern stays `unclassified` rather than
+ * having a fabricated cause attached — a fabricated cause is indistinguishable
+ * from a measured one once it is downstream (FLN #459).
  */
 function readPipelineDetail(
   evalData: any,
@@ -101,7 +68,10 @@ function readPipelineDetail(
   });
 
   if (rootCauses.length === 0) {
-    const overallType = evalData?.error_type ? String(evalData.error_type) : 'unclassified';
+    // A real pipeline verdict (when one exists) always wins over the local
+    // classifier — this is the fallback for the case that's true today,
+    // where evalData is always {} because nothing wires it in (FLN #458).
+    const overallType = evalData?.error_type ? String(evalData.error_type) : null;
     const overallAnalysis = evalData?.root_cause ? String(evalData.root_cause) : '';
     rootCauses = questions
       .filter(q => norm(answers?.[q.question_id]) !== norm(q.answer))
@@ -110,7 +80,7 @@ function readPipelineDetail(
         error: String(answers?.[q.question_id] ?? ''),
         topic: q.topic || 'Unclassified',
         flnLevel: Number(q.source_level ?? 0),
-        errorType: overallType,
+        errorType: overallType ?? classifyErrorType(answers?.[q.question_id], q.answer),
         analysis: overallAnalysis
       }));
   }
@@ -931,67 +901,6 @@ export function registerStudentRoutes(app: express.Express) {
       });
     }
 
-    // Connect to Python Evaluation Metrics Pipeline
-    const pipelineDir = AI_SERVICES_DIR;
-    const responseDir = path.join(pipelineDir, 'student_responses', `class_${classNumber}`, 'phrase_1');
-    fs.mkdirSync(responseDir, { recursive: true });
-
-    // Map answers for the Python pipeline. The pipeline's `1_compare_answers.py`
-    // looks each answer key up in `ai-services/questions/class_2/phrase_1/
-    // class_2_exam_phrase_1.json` (the static question bank). When the paper
-    // was generated dynamically by `generateClass2PaperFromAtlas` — because
-    // the live `questionBank` collection is empty (verified) — the paper's
-    // `question_id`s (e.g. `Q_L22_1`) are NOT in that static bank. So we
-    // (a) key the answers by the paper's *actual* `question_id` (not by an
-    // index-based Q1..Q10 that would alias the wrong static bank question),
-    // and (b) embed the paper's per-question metadata in `studentResponse.questions`
-    // so the comparator can fall back to it without a DB lookup.
-    const pipelineAnswers: { [qId: string]: { answer: string, confidence: number } } = {};
-    const paperQuestions: { [qId: string]: {
-      answer: string;
-      topic: string;
-      subtopic: string;
-      difficulty: string;
-      class_level: number;
-      source_level: number;
-      conceptId?: string;
-      conceptTitle?: string;
-    } } = {};
-    questions.forEach((q) => {
-      const submitted = (answers[q.question_id] || '').trim();
-      pipelineAnswers[q.question_id] = {
-        answer: String(submitted),
-        confidence: 0.95
-      };
-      paperQuestions[q.question_id] = {
-        answer: String(q.answer || '').trim(),
-        topic: q.topic || '',
-        subtopic: q.subtopic || '',
-        difficulty: q.difficulty || 'medium',
-        class_level: classNumber,
-        source_level: q.source_level || classNumber,
-        conceptId: q.conceptId,
-        conceptTitle: CURRICULUM_MAPPING[q.source_level || 0]?.levelTitle,
-      };
-    });
-
-    const studentResponse = {
-      student_id: student.id,
-      student_name: student.name,
-      enrolled_class: classNumber,
-      test_date: dateStr,
-      phrase: 'phrase_1',
-      exam_id: `C${classNumber}_WORKSHEET_PHRASE_1`,
-      // Embedded paper question metadata so the Python comparator can grade
-      // against the actual paper questions when the static question bank
-      // does not contain them.
-      questions: paperQuestions,
-      answers: pipelineAnswers
-    };
-
-    const responsePath = path.join(responseDir, `${student.id}.json`);
-    fs.writeFileSync(responsePath, JSON.stringify(studentResponse, null, 2));
-
     // Variables assigned by the scoring block below. Declared here (function
     // scope) so the rest of the handler can read them after the local block.
     let score = 0;
@@ -1217,31 +1126,16 @@ export function registerStudentRoutes(app: express.Express) {
       levelHistory
     });
 
-    // Create a special Evaluation Report with dynamic mock concept mastery
+    // Concept mastery by broad topic band. Coarse (four fixed bands keyed to
+    // recommendedLevel thresholds) rather than derived from which questions
+    // were actually missed — a real per-topic breakdown needs #413's error
+    // clustering, not something to fake here in the meantime.
     const conceptMastery: { [topic: string]: "Strong" | "Needs Practice" | "Satisfactory" } = {
       'Number Sense': recommendedLevel >= 15 ? 'Strong' : 'Needs Practice',
       'Shapes': recommendedLevel >= 25 ? 'Strong' : 'Needs Practice',
       'Fractions': recommendedLevel >= 35 ? 'Strong' : 'Needs Practice',
       'Operations': recommendedLevel >= 12 ? 'Strong' : 'Needs Practice'
     };
-
-    try {
-      const evalReportPath = findPipelineFile(
-        path.join(pipelineDir, 'evaluation_reports', `class_${classNumber}`, 'phrase_1', 'evaluation'),
-        `${student.id}_evaluation_`,
-        '.json'
-      );
-      if (evalReportPath) {
-        const evalData = JSON.parse(fs.readFileSync(evalReportPath, 'utf-8'));
-        if (evalData.topics_to_focus && Array.isArray(evalData.topics_to_focus)) {
-          evalData.topics_to_focus.forEach((t: string) => {
-            conceptMastery[t] = 'Needs Practice';
-          });
-        }
-      }
-    } catch (e) {
-      console.warn('Failed to parse dynamic concept mastery:', e);
-    }
 
     // Persist what the child actually wrote, alongside the verdict.
     //


### PR DESCRIPTION
Findings 3 and 4 from PR #420's review (fastest-path work, per Jinal's ruling 2026-09-07 — see #458, #459).

## Finding 4 — errorType always 'unclassified' (Critical)

Adds `classifyErrorType()` (`backend/src/errorClassification.ts`) — deterministic classification of a wrong answer into one of `unanswered` / `digit_reversal` / `decimal_place_shift` / `off_by_one`, or `unclassified` when no pattern matches. Every rule is a verifiable fact about the submitted/expected pair (same digits reversed, off by a power of ten, blank) — never an inferred pedagogy cause, same principle `answerMatching.ts` already follows. Reuses `asNumber` from `answerMatching.ts` (now exported) rather than re-implementing numeric parsing.

Wired into `readPipelineDetail()`'s fallback branch in `students.ts`: a real pipeline verdict (if `evalData.error_type` is ever populated again) still wins; the classifier only fills the gap that currently exists 100% of the time.

19 new unit tests (`npm run test:error-classification --workspace @fln/backend`), same plain-script convention as the existing `answerMatching.test.ts`.

## Finding 3 — personalized_evaluation_pipeline.py (investigated, not patched)

Investigation (written up in #458) found this isn't a small disconnect — it's ~150 lines across `students.ts` writing/reading files for Python scripts (`run_pipeline.py`, `personalized_evaluation_pipeline.py`, `scripts/1_compare_answers.py`) that are **never invoked from this backend** and operate on a legacy `class_N/phrase_N` flat-file data model with no relationship to the current MongoDB-backed students or the 93-level system.

Removed as confirmed-dead code:
- The `student_responses/{class}/{phrase}/{studentId}.json` write block — written on every diagnostic submission, never read back by anything live.
- The `evaluation_reports/{class}/phrase_1/evaluation/` read-back block that only ever populated a mock `conceptMastery` object, and always fails silently since nothing writes that directory for a real student.
- `findPipelineFile()`, now unused after the above.
- The unused `AI_SERVICES_DIR`/`PYTHON_BIN`/`fs`/`path` imports that only existed for this code.

Not attempting to rebuild `personalized_evaluation_pipeline.py` here — #458 recommends retiring it once the already-roadmapped "remediation plan service" ships, rather than rebuilding its legacy data model twice.

## Verification

- `npm run lint` (both workspaces) — clean.
- `npm run test:error-classification` — 19/19 passed.
- `npm run test:answer-matching` — 30/30 passed (unaffected, `asNumber` export is additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)