### PR TITLE
fix: display actual school name in principal dashboard

### DIFF
--- a/frontend/src/components/dashboards/SchoolDashboard.tsx
+++ b/frontend/src/components/dashboards/SchoolDashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { apiFetch } from '../../services/apiClient';
-import { ClassGroup, Student, DashboardProps } from '../../types';
+import { ClassGroup, Student, School, DashboardProps } from '../../types';
 import { WorksheetWorkflow } from '../WorksheetWorkflow';
 import { TicketSubmission } from '../TicketSubmission';
 
@@ -10,6 +10,7 @@ import { TicketSubmission } from '../TicketSubmission';
 export const SchoolDashboard: React.FC<DashboardProps> = ({ user, token }) => {
   const [classes, setClasses] = useState<ClassGroup[]>([]);
   const [students, setStudents] = useState<Student[]>([]);
+  const [school, setSchool] = useState<School | null>(null);
   const [activeClass, setActiveClass] = useState<ClassGroup | null>(null);
 
   const fetchSchoolData = async () => {
@@ -21,6 +22,12 @@ export const SchoolDashboard: React.FC<DashboardProps> = ({ user, token }) => {
       const stdRes = await apiFetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
       const stdData = await stdRes.json();
       if (Array.isArray(stdData)) setStudents(stdData);
+
+      // GET /api/schools is already scoped to user.schoolId for the 'school' role
+      // (see backend/src/routes/schools.ts), so the first result is this principal's school.
+      const schRes = await apiFetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
+      const schData = await schRes.json();
+      if (Array.isArray(schData) && schData.length > 0) setSchool(schData[0]);
     } catch (err) {
       console.error(err);
     }
@@ -50,7 +57,10 @@ export const SchoolDashboard: React.FC<DashboardProps> = ({ user, token }) => {
     <div className="space-y-6" id="school-dashboard">
       <div className="border-b border-zinc-200 dark:border-zinc-700 pb-4">
         <h1 className="text-3xl font-display font-semibold text-zinc-900 dark:text-white tracking-tight">School Administration</h1>
-        <p className="text-zinc-550 dark:text-zinc-400 text-sm mt-0.5">GPS Model Town Ludhiana (ID: {user.schoolId})</p>
+        <p className="text-zinc-550 dark:text-zinc-400 text-sm mt-0.5">
+          {school ? school.name : (user.schoolId ?? 'Loading…')}
+          {user.schoolId && <span className="ml-1 text-zinc-400 dark:text-zinc-500">(ID: {user.schoolId})</span>}
+        </p>
       </div>
 
       <TicketSubmission token={token} userRole={user.role} />

--- a/frontend/src/components/dashboards/TeacherDashboard.tsx
+++ b/frontend/src/components/dashboards/TeacherDashboard.tsx
@@ -4,7 +4,7 @@
 //this directory has been splitted from frontend/src/components/RoleDashboards.tsx for easy deployment
 import React, { useState, useEffect } from 'react';
 import { apiFetch, withBase } from '../../services/apiClient';
-import { User, Student, ClassGroup, DashboardProps } from '../../types';
+import { User, Student, ClassGroup, School, DashboardProps } from '../../types';
 import { DiagnosticWorkflow } from '../DiagnosticWorkflow';
 import { BaselineUpload } from '../BaselineUpload';
 import { SkillGraphPanel } from '../SkillGraphPanel';
@@ -30,6 +30,7 @@ export const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ user, token,
   // for every teacher for a moment before their real roster loads in.
   const [studentsLoading, setStudentsLoading] = useState(true);
   const [activeClass, setActiveClass] = useState<ClassGroup | null>(null);
+  const [school, setSchool] = useState<School | null>(null);
   const [showAllStudents, setShowAllStudents] = useState(true);
   const [diagnosticStudent, setDiagnosticStudent] = useState<Student | null>(null);
   const [baselineStudent, setBaselineStudent] = useState<Student | null>(null);
@@ -84,6 +85,12 @@ export const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ user, token,
       const stdRes = await apiFetch('/api/students', { headers: { 'Authorization': `Bearer ${token}` } });
       const stdData = await stdRes.json();
       if (Array.isArray(stdData)) setStudents(stdData);
+
+      // GET /api/schools is scoped to user.schoolId for the 'teacher' role
+      // (see backend/src/routes/schools.ts), so the first result is this teacher's school.
+      const schRes = await apiFetch('/api/schools', { headers: { 'Authorization': `Bearer ${token}` } });
+      const schData = await schRes.json();
+      if (Array.isArray(schData) && schData.length > 0) setSchool(schData[0]);
     } catch (err) {
       console.error(err);
     } finally {
@@ -201,7 +208,7 @@ export const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ user, token,
       <div className="border-b border-zinc-200 dark:border-zinc-700 pb-4 flex justify-between items-end">
         <div>
           <h1 className="text-3xl font-display font-semibold text-zinc-900 dark:text-white tracking-tight">Classroom Workspace</h1>
-          <p className="text-zinc-550 dark:text-zinc-400 text-sm mt-0.5 font-medium">Teacher: {user.name} · School Scope: gps-mt-001 Model Town</p>
+          <p className="text-zinc-550 dark:text-zinc-400 text-sm mt-0.5 font-medium">Teacher: {user.name} · School: {school ? school.name : (user.schoolId ?? 'Loading…')}</p>
         </div>
         <div className="flex gap-2">
           <button


### PR DESCRIPTION
## Summary

The School Principal dashboard was displaying a hardcoded demo school name — **GPS Model Town Ludhiana** — in its header subtitle, regardless of which school the authenticated principal actually belongs to. Any principal logging in from a different school would always see the wrong school identity.

This PR removes that hardcoded string and replaces it with the actual school name fetched from the backend, so every principal (and teacher) sees their own assigned school.

## Changes

### \rontend/src/components/dashboards/SchoolDashboard.tsx\
- Added \School\ to the type imports.
- Added a \school: School | null\ state variable.
- Extended the existing \etchSchoolData\ function to also call \GET /api/schools\. The backend already scopes this endpoint to \user.schoolId\ for the \school\ role (\ackend/src/routes/schools.ts\), so the first result is always the authenticated principal's school — no backend changes needed.
- Replaced \GPS Model Town Ludhiana (ID: {user.schoolId})\ with \{school.name}\, falling back to \user.schoolId\ while loading or if the fetch fails.

### \rontend/src/components/dashboards/TeacherDashboard.tsx\
- Same fix for the hardcoded \gps-mt-001 Model Town\ string in the teacher dashboard subtitle. The backend scopes \GET /api/schools\ to \user.schoolId\ for the \	eacher\ role as well.
- Falls back to \user.schoolId\ while loading.

No backend API changes were required.

## Testing

| Check | Result |
|---|---|
| \	sc --noEmit\ (frontend TypeScript) | ✅ 0 errors |
| \
pm run lint --workspace @fln/frontend\ | ✅ Passed |
| \git diff --check\ | ✅ Clean (no whitespace errors) |
| Manual diff review | ✅ Only 2 files changed, only targeted lines |

No frontend test suite is configured in this repository.

## Issue

Closes #443