### PR TITLE
fix(school): register students panel for principal role (#446)

### DIFF
--- a/frontend/src/components/PanelViews.tsx
+++ b/frontend/src/components/PanelViews.tsx
@@ -96,6 +96,24 @@ export const PanelViews: React.FC<PanelViewsProps> = ({ activePanel, currentUser
   // ===================== PRINCIPAL / SCHOOL ADMIN PANELS =====================
   if (panel === 'teachers' && (currentUser.role === UserRole.SCHOOL || currentUser.role === UserRole.BLOCK_ADMIN)) return <TeachersPanel schools={schools} teachersList={teachersList} currentUser={currentUser} />;
 
+  // Fix #446: Principal Students navigation (view='students') had no matching
+  // panel handler, so PanelViews returned null and rendered nothing.
+  // Reuse StudentListPanel — the same component used by teachers for
+  // 'student_list'. StudentListPanel already gates the Register/CSV-import
+  // actions behind isTeacherOrVolunteer, so the principal gets a read-only
+  // roster view without any code duplication.
+  if (panel === 'students' && currentUser.role === UserRole.SCHOOL) {
+    return (
+      <StudentListPanel
+        students={students}
+        studentsLoading={studentsLoading}
+        currentUser={currentUser}
+        token={token}
+        refreshStudents={refreshStudents}
+      />
+    );
+  }
+
   // ===================== BLOCK/DISTRICT/STATE ADMIN + SUPERADMIN SHARED PANELS =====================
   if (panel === 'schools') return <SchoolsPanel schools={schools} />;
 


### PR DESCRIPTION
## Summary

Fixes #446 — Principal Students navigation pointed to a panel identifier (`students`) that had no matching handler in `PanelViews.tsx`, so clicking Students in the school/principal sidebar rendered nothing.

> **Note:** PR #471 is a larger batch PR that also touches `PanelViews.tsx` for the same issue (among many others). This PR is a focused, single-file fix for #446 only. Maintainers can close whichever lands second.

## Root cause

`Layout.tsx` correctly adds a Students nav item with `view: 'students'` for `UserRole.SCHOOL`. When clicked, `activePanel` becomes `'students'`, which falls through to the `<PanelViews>` catch-all in `App.tsx`. However, `PanelViews.tsx` had no `if (panel === 'students')` branch — only `'student_list'` (teacher role) was handled — so `PanelViews` returned `null` and the panel area went blank.

## Fix

Added a single `if`-block in `PanelViews.tsx`:

```tsx
if (panel === 'students' && currentUser.role === UserRole.SCHOOL) {
  return (
    <StudentListPanel
      students={students}
      studentsLoading={studentsLoading}
      currentUser={currentUser}
      token={token}
      refreshStudents={refreshStudents}
    />
  );
}
```

This reuses the existing `StudentListPanel` component. That component already gates the "Register New Student" and "Bulk Import CSV" actions behind an `isTeacherOrVolunteer` check, so the principal receives a read-only student roster — no code duplication, no new dependencies.

## Changed files

| File | Change |
|------|--------|
| `frontend/src/components/PanelViews.tsx` | +18 lines — one new panel handler |

## What was not changed

- No other roles (teacher, volunteer, admin, superadmin) are affected.
- No backend API changes.
- No navigation/sidebar changes.
- No new components or dependencies introduced.
- Issues #444, #445, #447, #449 are out of scope and not touched.

## Verification

`npm run build` in `frontend/` — 1885 modules transformed, exit 0, no new errors or warnings.
